### PR TITLE
Allow requests when Origin and Host match.

### DIFF
--- a/http/src/utils.rs
+++ b/http/src/utils.rs
@@ -26,7 +26,7 @@ pub fn cors_header(
 	request: &hyper::server::Request<hyper::net::HttpStream>,
 	cors_domains: &Option<Vec<cors::AccessControlAllowOrigin>>
 ) -> CorsHeader<header::AccessControlAllowOrigin> {
-	cors::get_cors_header(read_header(request, "origin"), cors_domains).map(|origin| {
+	cors::get_cors_header(read_header(request, "origin"), read_header(request, "host"), cors_domains).map(|origin| {
 		use self::cors::AccessControlAllowOrigin::*;
 		match origin {
 			Value(val) => header::AccessControlAllowOrigin::Value((*val).to_owned()),

--- a/minihttp/src/lib.rs
+++ b/minihttp/src/lib.rs
@@ -245,7 +245,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> tokio_service::Service for
 
 		// Validate allowed hosts
 		let host = request.header("Host");
-		if !hosts::is_host_valid(host, &self.hosts) {
+		if !hosts::is_host_valid(host.clone(), &self.hosts) {
 			return future::ok(
 				res::invalid_host()
 			).boxed();
@@ -253,7 +253,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> tokio_service::Service for
 
 		// Extract CORS headers
 		let origin = request.header("Origin");
-		let cors = cors::get_cors_header(origin, &self.cors_domains);
+		let cors = cors::get_cors_header(origin, host, &self.cors_domains);
 
 		// Validate cors header
 		if let cors::CorsHeader::Invalid = cors {


### PR DESCRIPTION
`Origin` header is included in POST request even if `<Origin> = http://<Host>`, so the response can be read without CORS headers (cause it's not CORS request).
This PR allows such requests to be processed.