### PR TITLE
Impl Error trait on http server Error types

### DIFF
--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -33,6 +33,7 @@ mod utils;
 #[cfg(test)]
 mod tests;
 
+use std::fmt;
 use std::sync::Arc;
 use std::net::SocketAddr;
 use std::thread;
@@ -73,6 +74,28 @@ impl From<hyper::error::Error> for Error {
 			e => Error::Other(e)
 		}
 	}
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Io(ref e) => e.fmt(f),
+            Error::Other(ref e) => e.fmt(f),
+        }
+    }
+}
+
+impl ::std::error::Error for Error {
+    fn description(&self) -> &str {
+        "Starting the JSON-RPC HTTP server failed"
+    }
+
+    fn cause(&self) -> Option<&::std::error::Error> {
+        Some(match *self {
+            Error::Io(ref e) => e,
+            Error::Other(ref e) => e,
+        })
+    }
 }
 
 /// Action undertaken by a middleware.

--- a/minihttp/src/lib.rs
+++ b/minihttp/src/lib.rs
@@ -32,6 +32,7 @@ mod res;
 #[cfg(test)]
 mod tests;
 
+use std::fmt;
 use std::io;
 use std::ascii::AsciiExt;
 use std::sync::{Arc, mpsc};
@@ -61,6 +62,26 @@ impl From<io::Error> for Error {
 	fn from(err: io::Error) -> Self {
 		Error::Io(err)
 	}
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Io(ref e) => e.fmt(f),
+        }
+    }
+}
+
+impl ::std::error::Error for Error {
+    fn description(&self) -> &str {
+        "Starting the JSON-RPC HTTP server failed"
+    }
+
+    fn cause(&self) -> Option<&::std::error::Error> {
+        Some(match *self {
+            Error::Io(ref e) => e,
+        })
+    }
 }
 
 /// Extracts metadata from the HTTP request.


### PR DESCRIPTION
Implementing the standard `Error` trait for the error returned by `ServerBuilder::start_http` making it more ergonomic to handle. For example makes it easy to just `.chain_err(...)` when using the `error_chain` crate