### PR TITLE
Windows IPC implementation fails in case of multimple concurrent requests

### DIFF
--- a/ipc/tests/multithreaded_test.rs
+++ b/ipc/tests/multithreaded_test.rs
@@ -1,0 +1,59 @@
+extern crate jsonrpc_core;
+extern crate jsonrpc_ipc_server;
+
+extern crate miow;
+
+#[cfg(test)]
+mod multithreaded_test {
+	use jsonrpc_core::*;
+	use jsonrpc_ipc_server::Server;
+
+	use miow::pipe::connect;
+
+	use std::thread;
+	use std::time::Duration;
+	use std::io::{Read, Write};
+
+	#[cfg(windows)]
+	fn pipe_name() -> &'static str {
+		"\\\\.\\pipe\\Foo\\Bar\\Baz"
+	}
+
+	#[cfg(windows)]
+	fn say_to_pipe(pipe_name: &str, message: String) -> String {
+		let mut connection = connect(pipe_name).expect("Failed to get a client connection to the pipe");
+		connection.write_all(message.as_bytes()).expect("Failed to write to the pipe");
+
+    	let mut buf = [0u8; 1024];
+		connection.read(&mut buf).expect("Failed to read from the pipe");
+		String::from_utf8_lossy(&buf).into_owned().trim_right_matches('\u{0}').to_string()
+	}
+
+	fn message(n: i32) -> String {
+		format!(r#"{{ "jsonrpc":"2.0", "method":"hello", "params": {{"message": "Hello from {n}!"}}, "id": {n} }}"#, n=n)
+	}
+
+	fn expected_response(n: i32) -> String {
+		format!(r#"{{"jsonrpc":"2.0","result":"hello accepted","id":{n}}}"#, n=n)
+	}
+
+	#[test]
+	fn processes_several_requests_at_once() {
+		let mut io = IoHandler::new();
+		io.add_method("hello", |_params| {
+			thread::sleep(Duration::from_millis(100)); // Some ard work to block socket
+			Ok(Value::String("hello accepted".into()))
+		});
+
+		let server = Server::new(pipe_name(), io).unwrap();
+		thread::spawn(move || server.run().unwrap());
+
+		thread::sleep(Duration::from_millis(100)); // Let's make sure the pipe server has been initialized
+
+		let thread1 = thread::spawn(|| assert_eq!(say_to_pipe(pipe_name(), message(1)), expected_response(1)));
+		let thread2 = thread::spawn(|| assert_eq!(say_to_pipe(pipe_name(), message(2)), expected_response(2)));
+
+		thread1.join().unwrap();
+		thread2.join().unwrap();
+	}
+}

--- a/ipc/tests/multithreaded_test.rs
+++ b/ipc/tests/multithreaded_test.rs
@@ -5,72 +5,102 @@ extern crate miow;
 
 #[cfg(test)]
 mod multithreaded_test {
-	use jsonrpc_core::*;
-	use jsonrpc_ipc_server::Server;
+    use jsonrpc_core::*;
+    use jsonrpc_core::futures::Future;
+    use jsonrpc_core::futures::future::ok;
+    use jsonrpc_ipc_server::Server;
 
-	#[cfg(windows)]
-	use miow::pipe::connect;
-	#[cfg(not(windows))]
-	use std::os::unix::net::UnixStream;
+    #[cfg(windows)]
+    use miow::pipe::connect;
+    #[cfg(not(windows))]
+    use std::os::unix::net::UnixStream;
 
-	use std::thread;
-	use std::time::Duration;
-	use std::io::{Read, Write};
+    use std::thread;
+    use std::time::Duration;
+    use std::io::{Read, Write};
 
-	#[cfg(windows)]
-	fn pipe_name() -> &'static str {
-		"\\\\.\\pipe\\Foo\\Bar\\Baz"
-	}
-	#[cfg(not(windows))]
-	fn pipe_name() -> &'static str {
-		"/tmp/foobar.sock"
-	}
+    #[cfg(windows)]
+    fn pipe_name() -> &'static str {
+        "\\\\.\\pipe\\Foo\\Bar\\Baz"
+    }
+    #[cfg(not(windows))]
+    fn pipe_name() -> &'static str {
+        "/tmp/foobar.sock"
+    }
 
-	#[cfg(windows)]
-	fn say_to_pipe(pipe_name: &str, message: String) -> String {
-		let mut connection = connect(pipe_name).expect("Failed to get a client connection to the pipe");
-		connection.write_all(message.as_bytes()).expect("Failed to write to the pipe");
+    #[cfg(windows)]
+    fn say_to_pipe(pipe_name: &str, message: String) -> String {
+        let mut connection =
+            connect(pipe_name).expect("Failed to get a client connection to the pipe");
+        connection
+            .write_all(message.as_bytes())
+            .expect("Failed to write to the pipe");
 
-		let mut buf = [0u8; 1024];
-		connection.read(&mut buf).expect("Failed to read from the pipe");
-		String::from_utf8_lossy(&buf).into_owned().trim_right_matches('\u{0}').to_string()
-	}
-	#[cfg(not(windows))]
-	fn say_to_pipe(pipe_name: &str, message: String) -> String {
-		let mut connection = UnixStream::connect(pipe_name).expect("Failed to connect to unix socket");
-		connection.write_all(message.as_bytes()).expect("Failed to write to the pipe");
+        let mut buf = [0u8; 1024];
+        connection
+            .read(&mut buf)
+            .expect("Failed to read from the pipe");
+        String::from_utf8_lossy(&buf)
+            .into_owned()
+            .trim_right_matches('\u{0}')
+            .to_string()
+    }
+    #[cfg(not(windows))]
+    fn say_to_pipe(pipe_name: &str, message: String) -> String {
+        let mut connection =
+            UnixStream::connect(pipe_name).expect("Failed to connect to unix socket");
+        connection
+            .write_all(message.as_bytes())
+            .expect("Failed to write to the pipe");
 
-		let mut buf = [0u8; 1024];
-		connection.read(&mut buf).expect("Failed to read from the pipe");
-		String::from_utf8_lossy(&buf).into_owned().trim_right_matches('\u{0}').to_string()
-	}
+        let mut buf = [0u8; 1024];
+        connection
+            .read(&mut buf)
+            .expect("Failed to read from the pipe");
+        String::from_utf8_lossy(&buf)
+            .into_owned()
+            .trim_right_matches('\u{0}')
+            .to_string()
+    }
 
 
-	fn message(n: i32) -> String {
-		format!(r#"{{ "jsonrpc":"2.0", "method":"hello", "params": {{"message": "Hello from {n}!"}}, "id": {n} }}"#, n=n)
-	}
+    fn message(n: i32) -> String {
+        format!(r#"{{ "jsonrpc":"2.0", "method":"hello", "params": {{"message": "Hello from {n}!"}}, "id": {n} }}"#, n=n)
+    }
 
-	fn expected_response(n: i32) -> String {
-		format!(r#"{{"jsonrpc":"2.0","result":"hello accepted","id":{n}}}"#, n=n)
-	}
+    fn expected_response(n: i32) -> String {
+        format!(r#"{{"jsonrpc":"2.0","result":"hello accepted","id":{n}}}"#,
+                n = n)
+    }
 
-	#[test]
-	fn processes_several_requests_at_once() {
-		let mut io = IoHandler::new();
-		io.add_method("hello", |_params| {
-			thread::sleep(Duration::from_millis(1000)); // Some hard work to block socket
-			Ok(Value::String("hello accepted".into()))
-		});
+    #[test]
+    fn processes_several_requests_at_once() {
+        let mut io = IoHandler::new();
+        io.add_async_method("hello", |_params| {
+            ok(String::new())
+                .and_then(|x| {
+                              thread::sleep(Duration::from_millis(100));
+                              ok(x)
+                          })
+                .and_then(|_| ok(Value::String("hello accepted".into())))
+                .boxed()
+        });
 
-		let server = Server::new(pipe_name(), io).unwrap();
-		thread::spawn(move || server.run());
+        let server = Server::new(pipe_name(), io).unwrap();
+        thread::spawn(move || server.run());
 
-		thread::sleep(Duration::from_millis(100)); // Let's make sure the pipe server has been initialized
+        thread::sleep(Duration::from_millis(100)); // Let's make sure the pipe server has been initialized
 
-		let thread1 = thread::spawn(|| assert_eq!(say_to_pipe(pipe_name(), message(1)), expected_response(1)));
-		let thread2 = thread::spawn(|| assert_eq!(say_to_pipe(pipe_name(), message(2)), expected_response(2)));
+        let thread1 = thread::spawn(|| {
+                                        assert_eq!(say_to_pipe(pipe_name(), message(1)),
+                                                   expected_response(1))
+                                    });
+        let thread2 = thread::spawn(|| {
+                                        assert_eq!(say_to_pipe(pipe_name(), message(2)),
+                                                   expected_response(2))
+                                    });
 
-		thread1.join().unwrap();
-		thread2.join().unwrap();
-	}
+        thread1.join().unwrap();
+        thread2.join().unwrap();
+    }
 }

--- a/ipc/tests/multithreaded_test.rs
+++ b/ipc/tests/multithreaded_test.rs
@@ -8,7 +8,10 @@ mod multithreaded_test {
 	use jsonrpc_core::*;
 	use jsonrpc_ipc_server::Server;
 
+	#[cfg(windows)]
 	use miow::pipe::connect;
+	#[cfg(not(windows))]
+	use std::os::unix::net::UnixStream;
 
 	use std::thread;
 	use std::time::Duration;
@@ -18,16 +21,30 @@ mod multithreaded_test {
 	fn pipe_name() -> &'static str {
 		"\\\\.\\pipe\\Foo\\Bar\\Baz"
 	}
+	#[cfg(not(windows))]
+	fn pipe_name() -> &'static str {
+		"/tmp/foobar.sock"
+	}
 
 	#[cfg(windows)]
 	fn say_to_pipe(pipe_name: &str, message: String) -> String {
 		let mut connection = connect(pipe_name).expect("Failed to get a client connection to the pipe");
 		connection.write_all(message.as_bytes()).expect("Failed to write to the pipe");
 
-    	let mut buf = [0u8; 1024];
+		let mut buf = [0u8; 1024];
 		connection.read(&mut buf).expect("Failed to read from the pipe");
 		String::from_utf8_lossy(&buf).into_owned().trim_right_matches('\u{0}').to_string()
 	}
+	#[cfg(not(windows))]
+	fn say_to_pipe(pipe_name: &str, message: String) -> String {
+		let mut connection = UnixStream::connect(pipe_name).expect("Failed to connect to unix socket");
+		connection.write_all(message.as_bytes()).expect("Failed to write to the pipe");
+
+		let mut buf = [0u8; 1024];
+		connection.read(&mut buf).expect("Failed to read from the pipe");
+		String::from_utf8_lossy(&buf).into_owned().trim_right_matches('\u{0}').to_string()
+	}
+
 
 	fn message(n: i32) -> String {
 		format!(r#"{{ "jsonrpc":"2.0", "method":"hello", "params": {{"message": "Hello from {n}!"}}, "id": {n} }}"#, n=n)
@@ -41,12 +58,12 @@ mod multithreaded_test {
 	fn processes_several_requests_at_once() {
 		let mut io = IoHandler::new();
 		io.add_method("hello", |_params| {
-			thread::sleep(Duration::from_millis(100)); // Some ard work to block socket
+			thread::sleep(Duration::from_millis(1000)); // Some hard work to block socket
 			Ok(Value::String("hello accepted".into()))
 		});
 
 		let server = Server::new(pipe_name(), io).unwrap();
-		thread::spawn(move || server.run().unwrap());
+		thread::spawn(move || server.run());
 
 		thread::sleep(Duration::from_millis(100)); // Let's make sure the pipe server has been initialized
 


### PR DESCRIPTION
This is just a PR to start a discussion.

I'd really like to improve windows support for the IPC implementation.
The usecase I'm facing is the following: multiple clients are asking server for a long and heavy computation simultaneously.

Currently the linux sockets implementation sorta-works (parallel processing aside), while windows pipes-based one deadlocks somehow (if I'm using synchronous API for handlers, `add_method`), or fails with `Error { repr: Os { code: 5, message: "Access is denied." } }` (in case of future-based `add_async_method` implementation).

Either I am doing something really wrong here (it's quite possible, I'm not a Windows guy; will be grateful for any tips), or Windows implementation needs some love (and then I'd like to contribute, but might need some directions on from where to start; still not a Windows guy).


Please feel free to close this PR if needed -- after all my tests currently won't work on `master`, only on `stable`.