### PR TITLE
Update/refactor to latest tokio_io (#122), backport

### DIFF
--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -14,6 +14,7 @@ tokio-service = "0.1"
 jsonrpc-core = { version = "7.0", path = "../core" }
 jsonrpc-server-utils = { version = "7.0", path = "../server-utils" }
 parity-tokio-ipc = { git = "https://github.com/nikvolf/parity-tokio-ipc" }
+bytes = "0.4"
 
 [dev-dependencies]
 env_logger = "0.4"

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -6,6 +6,7 @@ extern crate jsonrpc_core as jsonrpc;
 extern crate jsonrpc_server_utils as server_utils;
 extern crate parity_tokio_ipc;
 extern crate tokio_service;
+extern crate bytes;
 
 #[macro_use] extern crate log;
 

--- a/ipc/src/logger.rs
+++ b/ipc/src/logger.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::env;
 use log::LogLevelFilter;
 use env_logger::LogBuilder;

--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -13,9 +13,9 @@ log = "0.3"
 parking_lot = "0.4"
 serde_json = "0.9"
 tokio-service = "0.1"
-
 jsonrpc-core = { version = "7.0", path = "../core" }
 jsonrpc-server-utils = { version = "7.0", path = "../server-utils" }
+bytes = "0.4"
 
 [dev-dependencies]
 lazy_static = "0.2"

--- a/tcp/src/lib.rs
+++ b/tcp/src/lib.rs
@@ -27,6 +27,7 @@ extern crate jsonrpc_server_utils as server_utils;
 extern crate parking_lot;
 extern crate serde_json;
 extern crate tokio_service;
+extern crate bytes;
 
 #[macro_use] extern crate log;
 

--- a/tcp/src/tests.rs
+++ b/tcp/src/tests.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use jsonrpc::{MetaIoHandler, Value, Metadata};
 use jsonrpc::futures::{Future, future};
 
-use server_utils::tokio_core::io;
+use server_utils::tokio_io::io;
 use server_utils::tokio_core::net::TcpStream;
 use server_utils::tokio_core::reactor::{Core, Timeout};
 
@@ -114,6 +114,41 @@ fn doc_test_handle() {
 		"{\"jsonrpc\":\"2.0\",\"result\":\"hello\",\"id\":1}\n",
 		"Response does not exactly much the expected response",
 		);
+}
+
+#[test]
+fn req_parallel() {
+	use std::thread;
+
+	::logger::init_log();
+	let addr: SocketAddr = "127.0.0.1:17782".parse().unwrap();
+	let server = casual_server();
+	let _server = server.start(&addr).expect("Server must run with no issues");
+
+	let mut handles = Vec::new();
+	for _ in 0..6 {
+		let addr = addr.clone();
+		handles.push(
+			thread::spawn(move || {
+				for _ in 0..100 {
+					let result = dummy_request_str(
+						&addr,
+						b"{\"jsonrpc\": \"2.0\", \"method\": \"say_hello\", \"params\": [42, 23], \"id\": 1}\n",
+						);
+
+					assert_eq!(
+						result,
+						"{\"jsonrpc\":\"2.0\",\"result\":\"hello\",\"id\":1}\n",
+						"Response does not exactly much the expected response",
+						);					
+				}					
+			})
+		);
+	}	
+
+	for handle in handles.drain(..) {
+		handle.join().unwrap();
+	}
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
* failing tests for tcp and ipc

* encoder/decoder

* fix remaining

* also tcp

* fix warnings

* review fixes

* fix warnings