### PR TITLE
WS pubsub example.

### DIFF
--- a/http/examples/http_async.rs
+++ b/http/examples/http_async.rs
@@ -4,7 +4,7 @@ extern crate jsonrpc_http_server;
 
 use jsonrpc_core::*;
 use jsonrpc_core::futures::Future;
-use jsonrpc_http_server::*;
+use jsonrpc_http_server::{ServerBuilder, DomainsValidation, AccessControlAllowOrigin};
 
 fn main() {
 	let mut io = IoHandler::default();

--- a/http/examples/http_middleware.rs
+++ b/http/examples/http_middleware.rs
@@ -4,7 +4,7 @@ extern crate jsonrpc_http_server;
 
 use jsonrpc_core::{IoHandler, Value};
 use jsonrpc_core::futures::{self, Future};
-use jsonrpc_http_server::*;
+use jsonrpc_http_server::{hyper, ServerBuilder, DomainsValidation, AccessControlAllowOrigin, Response};
 
 fn main() {
 	let mut io = IoHandler::default();

--- a/http/examples/server.rs
+++ b/http/examples/server.rs
@@ -2,7 +2,7 @@ extern crate jsonrpc_core;
 extern crate jsonrpc_http_server;
 
 use jsonrpc_core::*;
-use jsonrpc_http_server::*;
+use jsonrpc_http_server::{ServerBuilder, DomainsValidation, AccessControlAllowOrigin};
 
 fn main() {
 	let mut io = IoHandler::default();

--- a/minihttp/examples/http_async.rs
+++ b/minihttp/examples/http_async.rs
@@ -4,7 +4,7 @@ extern crate jsonrpc_minihttp_server;
 
 use jsonrpc_core::*;
 use jsonrpc_core::futures::Future;
-use jsonrpc_minihttp_server::*;
+use jsonrpc_minihttp_server::{cors, ServerBuilder, DomainsValidation};
 
 fn main() {
 	let mut io = IoHandler::default();

--- a/minihttp/examples/http_meta.rs
+++ b/minihttp/examples/http_meta.rs
@@ -3,7 +3,7 @@ extern crate jsonrpc_minihttp_server;
 
 use jsonrpc_core::*;
 use jsonrpc_core::futures::Future;
-use jsonrpc_minihttp_server::*;
+use jsonrpc_minihttp_server::{cors, ServerBuilder, DomainsValidation, Req};
 
 #[derive(Clone, Default)]
 struct Meta(usize);

--- a/minihttp/examples/server.rs
+++ b/minihttp/examples/server.rs
@@ -2,7 +2,7 @@ extern crate jsonrpc_core;
 extern crate jsonrpc_minihttp_server;
 
 use jsonrpc_core::*;
-use jsonrpc_minihttp_server::*;
+use jsonrpc_minihttp_server::{cors, ServerBuilder, DomainsValidation};
 
 fn main() {
 	let mut io = IoHandler::default();

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -16,3 +16,4 @@ jsonrpc-core = { version = "7.0", path = "../core" }
 
 [dev-dependencies]
 jsonrpc-tcp-server = { version = "7.0", path = "../tcp" }
+jsonrpc-ws-server = { version = "7.0", path = "../ws" }

--- a/pubsub/examples/pubsub.rs
+++ b/pubsub/examples/pubsub.rs
@@ -6,8 +6,8 @@ use std::{time, thread};
 use std::sync::Arc;
 
 use jsonrpc_core::*;
-use jsonrpc_pubsub::*;
-use jsonrpc_tcp_server::*;
+use jsonrpc_pubsub::{PubSubHandler, PubSubMetadata, Session, Subscriber, SubscriptionId};
+use jsonrpc_tcp_server::{ServerBuilder, RequestContext};
 
 use jsonrpc_core::futures::Future;
 

--- a/pubsub/examples/pubsub_ws.rs
+++ b/pubsub/examples/pubsub_ws.rs
@@ -6,7 +6,7 @@ use std::{time, thread};
 use std::sync::Arc;
 
 use jsonrpc_core::*;
-use jsonrpc_pubsub::*;
+use jsonrpc_pubsub::{PubSubHandler, PubSubMetadata, Session, Subscriber, SubscriptionId};
 use jsonrpc_ws_server::{ServerBuilder, RequestContext};
 
 use jsonrpc_core::futures::Future;

--- a/pubsub/examples/pubsub_ws.rs
+++ b/pubsub/examples/pubsub_ws.rs
@@ -1,13 +1,13 @@
 extern crate jsonrpc_core;
 extern crate jsonrpc_pubsub;
-extern crate jsonrpc_tcp_server;
+extern crate jsonrpc_ws_server;
 
 use std::{time, thread};
 use std::sync::Arc;
 
 use jsonrpc_core::*;
 use jsonrpc_pubsub::*;
-use jsonrpc_tcp_server::*;
+use jsonrpc_ws_server::{ServerBuilder, RequestContext};
 
 use jsonrpc_core::futures::Future;
 
@@ -31,12 +31,28 @@ impl PubSubMetadata for Meta {
 	}
 }
 
-/// To test the server:
+/// Use following node.js code to test:
 ///
-/// ```bash
-/// $ netcat localhost 3030 -
-/// {"id":1,"jsonrpc":"2.0","method":"hello_subscribe","params":[10]}
+/// ```js
+/// const WebSocket = require('websocket').w3cwebsocket;
 ///
+/// const ws = new WebSocket('ws://localhost:3030');
+/// ws.addEventListener('open', () => {
+///   console.log('Sending request');
+///
+///   ws.send(JSON.stringify({
+///     jsonrpc: "2.0",
+///     id: 1,
+///     method: "subscribe_hello",
+///     params: [],
+///   }));
+/// });
+///
+/// ws.addEventListener('message', (message) => {
+///   console.log('Received: ', message.data);
+/// });
+///
+/// console.log('Starting');
 /// ```
 fn main() {
 	let mut io = PubSubHandler::new(MetaIoHandler::default());
@@ -61,7 +77,7 @@ fn main() {
 			// or drop(subscriber)
 			thread::spawn(move || {
 				loop {
-					thread::sleep(time::Duration::from_millis(100));
+					thread::sleep(time::Duration::from_millis(1000));
 					match sink.notify(Params::Array(vec![Value::Number(10.into())])).wait() {
 						Ok(_) => {},
 						Err(_) => {
@@ -81,12 +97,11 @@ fn main() {
 	let server = ServerBuilder::new(io)
 		.session_meta_extractor(|context: &RequestContext| {
 			Meta {
-				session: Some(Arc::new(Session::new(context.sender.clone()))),
+				session: Some(Arc::new(Session::new(context.sender()))),
 			}
 		})
 		.start(&"127.0.0.1:3030".parse().unwrap())
 		.expect("Unable to start RPC server");
 
-	server.wait();
+	let _ = server.wait();
 }
-

--- a/pubsub/src/lib.rs
+++ b/pubsub/src/lib.rs
@@ -12,7 +12,6 @@ mod handler;
 mod subscription;
 mod types;
 
-
 pub use self::handler::{PubSubHandler, SubscribeRpcMethod, UnsubscribeRpcMethod};
 pub use self::subscription::{Session, Sink, Subscriber, new_subscription};
 pub use self::types::{PubSubMetadata, SubscriptionId, TransportError, SinkResult};

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -83,7 +83,7 @@ impl Drop for Session {
 #[derive(Debug, Clone)]
 pub struct Sink {
 	notification: String,
-	transport: TransportSender
+	transport: TransportSender,
 }
 
 impl Sink {

--- a/tcp/examples/tcp.rs
+++ b/tcp/examples/tcp.rs
@@ -2,7 +2,7 @@ extern crate jsonrpc_core;
 extern crate jsonrpc_tcp_server;
 
 use jsonrpc_core::*;
-use jsonrpc_tcp_server::*;
+use jsonrpc_tcp_server::ServerBuilder;
 
 fn main() {
 	let mut io = IoHandler::default();

--- a/ws/examples/ws.rs
+++ b/ws/examples/ws.rs
@@ -2,7 +2,7 @@ extern crate jsonrpc_core;
 extern crate jsonrpc_ws_server;
 
 use jsonrpc_core::*;
-use jsonrpc_ws_server::*;
+use jsonrpc_ws_server::ServerBuilder;
 
 fn main() {
 	let mut io = IoHandler::default();

--- a/ws/src/lib.rs
+++ b/ws/src/lib.rs
@@ -22,4 +22,3 @@ pub use self::server_builder::{ServerBuilder, Error};
 pub use self::server_utils::cors::Origin;
 pub use self::server_utils::hosts::{Host, DomainsValidation};
 pub use self::server_utils::tokio_core;
-

--- a/ws/src/metadata.rs
+++ b/ws/src/metadata.rs
@@ -1,10 +1,63 @@
 use std::fmt;
+use std::sync::{atomic, Arc};
 
-use core;
+use core::{self, futures};
+use core::futures::sync::mpsc;
+use server_utils::tokio_core::reactor::Remote;
 use ws;
 
 use session;
 use Origin;
+
+/// Output of WebSocket connection. Use this to send messages to the other endpoint.
+#[derive(Clone)]
+pub struct Sender {
+	out: ws::Sender,
+	active: Arc<atomic::AtomicBool>,
+}
+
+impl Sender {
+	/// Creates a new `Sender`.
+	pub fn new(out: ws::Sender, active: Arc<atomic::AtomicBool>) -> Self {
+		Sender {
+			out: out,
+			active: active,
+		}
+	}
+
+	fn check_active(&self) -> ws::Result<()> {
+		if self.active.load(atomic::Ordering::SeqCst) {
+			Ok(())
+		} else {
+			Err(ws::Error::new(ws::ErrorKind::Internal, "Attempting to send a message to closed connection."))
+		}
+	}
+
+	/// Sends a message over the connection.
+	/// Will return error if the connection is not active any more.
+	pub fn send<M>(&self, msg: M) -> ws::Result<()> where
+		M: Into<ws::Message>
+	{
+		self.check_active()?;
+		self.out.send(msg)
+	}
+
+	/// Sends a message over the endpoints of all connections.
+	/// Will return error if the connection is not active any more.
+	pub fn broadcast<M>(&self, msg: M) -> ws::Result<()> where
+		M: Into<ws::Message>
+	{
+		self.check_active()?;
+		self.out.broadcast(msg)
+	}
+
+	/// Sends a close code to the other endpoint.
+	/// Will return error if the connection is not active any more.
+	pub fn close(&self, code: ws::CloseCode) -> ws::Result<()> {
+		self.check_active()?;
+		self.out.close(code)
+	}
+}
 
 /// Request context
 pub struct RequestContext {
@@ -15,7 +68,20 @@ pub struct RequestContext {
 	/// Requested protocols
 	pub protocols: Vec<String>,
 	/// Direct channel to send messages to a client.
-	pub out: ws::Sender,
+	pub out: Sender,
+	/// Remote to underlying event loop.
+	pub remote: Remote,
+}
+
+impl RequestContext {
+	/// Get this session as a `Sink` spawning a new future
+	/// in the underlying event loop.
+	pub fn sender(&self) -> mpsc::Sender<String> {
+		let out = self.out.clone();
+		let (sender, receiver) = mpsc::channel(1);
+		self.remote.spawn(move |_| SenderFuture(out, receiver));
+		sender
+	}
 }
 
 impl fmt::Debug for RequestContext {
@@ -36,7 +102,44 @@ pub trait MetaExtractor<M: core::Metadata>: Send + Sync + 'static {
 	}
 }
 
+impl<M, F> MetaExtractor<M> for F where
+	M: core::Metadata,
+	F: Fn(&RequestContext) -> M + Send + Sync + 'static,
+{
+	fn extract(&self, context: &RequestContext) -> M {
+		(*self)(context)
+	}
+}
+
 /// Dummy metadata extractor
 #[derive(Clone)]
 pub struct NoopExtractor;
 impl<M: core::Metadata> MetaExtractor<M> for NoopExtractor {}
+
+struct SenderFuture(Sender, mpsc::Receiver<String>);
+impl futures::Future for SenderFuture {
+	type Item = ();
+	type Error = ();
+
+	fn poll(&mut self) -> futures::Poll<Self::Item, Self::Error> {
+		use self::futures::Stream;
+
+		loop {
+			let item = self.1.poll()?;
+			match item {
+				futures::Async::NotReady => {
+					return Ok(futures::Async::NotReady);
+				},
+				futures::Async::Ready(None) => {
+					return Ok(futures::Async::Ready(()));
+				},
+				futures::Async::Ready(Some(val)) => {
+					if let Err(e) = self.0.send(val) {
+						warn!("Error sending a subscription update: {:?}", e);
+						return Ok(futures::Async::Ready(()));
+					}
+				},
+			}
+		}
+	}
+}

--- a/ws/src/session.rs
+++ b/ws/src/session.rs
@@ -109,11 +109,11 @@ impl<M: core::Metadata, S: core::Middleware<M>> Session<M, S> {
 
 	fn verify_origin(&self, origin: Option<&[u8]>) -> Option<ws::Response> {
 		if !header_is_allowed(&self.allowed_origins, origin) {
-			warn!(target: "signer", "Blocked connection to Signer API from untrusted origin: {:?}", origin);
-			Some(forbidden(
-				"URL Blocked",
-				"Connection Origin has been rejected.",
-			))
+			warn!(
+				"Blocked connection to WebSockets server from untrusted origin: {:?}",
+				origin.and_then(|s| std::str::from_utf8(s).ok()),
+			);
+			Some(forbidden("URL Blocked", "Connection Origin has been rejected."))
 		} else {
 			None
 		}
@@ -122,11 +122,11 @@ impl<M: core::Metadata, S: core::Middleware<M>> Session<M, S> {
 	fn verify_host(&self, req: &ws::Request) -> Option<ws::Response> {
 		let host = req.header("host").map(|x| &x[..]);
 		if !header_is_allowed(&self.allowed_hosts, host) {
-			warn!(target: "signer", "Blocked connection to Signer API with untrusted host: {:?}", host);
-			Some(forbidden(
-				"URL Blocked",
-				"Connection Host has been rejected.",
-			))
+			warn!(
+				"Blocked connection to WebSockets server with untrusted host: {:?}",
+				host.and_then(|s| std::str::from_utf8(s).ok()),
+			);
+			Some(forbidden("URL Blocked", "Connection Host has been rejected."))
 		} else {
 			None
 		}
@@ -184,7 +184,7 @@ impl<M: core::Metadata, S: core::Middleware<M>> ws::Handler for Session<M, S> {
 				if let Some(result) = response {
 					let res = out.send(result);
 					if let Err(e) = res {
-						warn!(target: "signer", "Error while sending response: {:?}", e);
+						warn!("Error while sending response: {:?}", e);
 					}
 				}
 			});


### PR DESCRIPTION
- Exposing `futures::sync::mpsc::Sender` in `RequestContext`
- Apparently `ws::Sender` doesn't track if the connection is still active so I've added manual tracking and exposed it in `RequestContext`.
- Updates all examples to avoid glob imports (only `jsonrpc_core` is imported with a wildcard)

Closes: #120 