### PR TITLE
Proper check for Origins in WS server.

### DIFF
--- a/server-utils/src/cors.rs
+++ b/server-utils/src/cors.rs
@@ -2,7 +2,7 @@
 
 use std::{fmt, ops};
 use hosts::{Host, Port};
-use matcher::Matcher;
+use matcher::{Matcher, Pattern};
 
 /// Origin Protocol
 #[derive(Clone, Hash, Debug, PartialEq, Eq)]
@@ -74,11 +74,6 @@ impl Origin {
 		Origin::with_host(protocol, hostname)
 	}
 
-	/// Checks if given string matches the pattern.
-	pub fn matches<T: AsRef<str>>(&self, other: T) -> bool {
-		self.matcher.matches(other)
-	}
-
 	fn to_string(protocol: &OriginProtocol, host: &Host) -> String {
 		format!(
 			"{}://{}",
@@ -89,6 +84,12 @@ impl Origin {
 			},
 			&**host,
 		)
+	}
+}
+
+impl Pattern for Origin {
+	fn matches<T: AsRef<str>>(&self, other: T) -> bool {
+		self.matcher.matches(other)
 	}
 }
 

--- a/server-utils/src/hosts.rs
+++ b/server-utils/src/hosts.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
-use matcher::Matcher;
+use matcher::{Matcher, Pattern};
 
 const SPLIT_PROOF: &'static str = "split always returns non-empty iterator.";
 
@@ -80,11 +80,6 @@ impl Host {
 		Host::new(host, port)
 	}
 
-	/// Checks if given string matches the pattern.
-	pub fn matches<T: AsRef<str>>(&self, other: T) -> bool {
-		self.matcher.matches(other)
-	}
-
 	fn pre_process(host: &str) -> String {
 		// Remove possible protocol definition
 		let mut it = host.split("://");
@@ -108,6 +103,12 @@ impl Host {
 				Port::None => "".into(),
 			},
 		)
+	}
+}
+
+impl Pattern for Host {
+	fn matches<T: AsRef<str>>(&self, other: T) -> bool {
+		self.matcher.matches(other)
 	}
 }
 

--- a/server-utils/src/lib.rs
+++ b/server-utils/src/lib.rs
@@ -14,3 +14,5 @@ pub mod cors;
 pub mod hosts;
 pub mod reactor;
 mod matcher;
+
+pub use matcher::Pattern;

--- a/server-utils/src/matcher.rs
+++ b/server-utils/src/matcher.rs
@@ -2,6 +2,12 @@ use globset::{GlobMatcher, GlobBuilder};
 use std::ascii::AsciiExt;
 use std::{fmt, hash};
 
+/// Pattern that can be matched to string.
+pub trait Pattern {
+	/// Returns true if given string matches the pattern.
+	fn matches<T: AsRef<str>>(&self, other: T) -> bool;
+}
+
 #[derive(Clone)]
 pub struct Matcher(Option<GlobMatcher>, String);
 impl Matcher {
@@ -16,8 +22,10 @@ impl Matcher {
 			string.into()
 		)
 	}
+}
 
-	pub fn matches<T: AsRef<str>>(&self, other: T) -> bool {
+impl Pattern for Matcher {
+	fn matches<T: AsRef<str>>(&self, other: T) -> bool {
 		let s = other.as_ref();
 		match self.0 {
 			Some(ref matcher) => matcher.is_match(s),

--- a/ws/src/session.rs
+++ b/ws/src/session.rs
@@ -1,9 +1,9 @@
 use std;
-use std::ascii::AsciiExt;
 use std::sync::{atomic, Arc};
 
 use core;
 use core::futures::Future;
+use server_utils::Pattern;
 use server_utils::cors::Origin;
 use server_utils::hosts::Host;
 use server_utils::tokio_core::reactor::Remote;
@@ -258,7 +258,7 @@ impl<M: core::Metadata, S: core::Middleware<M>> ws::Factory for Factory<M, S> {
 }
 
 fn header_is_allowed<T>(allowed: &Option<Vec<T>>, header: Option<&[u8]>) -> bool where
-	T: ::std::ops::Deref<Target=str>,
+	T: Pattern,
 {
 	let header = header.map(std::str::from_utf8);
 
@@ -270,7 +270,7 @@ fn header_is_allowed<T>(allowed: &Option<Vec<T>>, header: Option<&[u8]>) -> bool
 		// Validate Origin
 		(Some(Ok(val)), Some(values)) => {
 			for v in values {
-				if val.eq_ignore_ascii_case(&v) {
+				if v.matches(val) {
 					return true
 				}
 			}


### PR DESCRIPTION
Actually WS server was still using string comparison.