### PR TITLE
Query ws for actual address bound to when listening

### DIFF
--- a/ws/src/server.rs
+++ b/ws/src/server.rs
@@ -63,6 +63,7 @@ impl Server {
 		// Start listening...
 		let ws = ws.bind(addr)?;
 		let local_addr = ws.local_addr()?;
+		debug!("Bound to local address: {}", local_addr);
 
 		// Spawn a thread with event loop
 		let handle = thread::spawn(move || {

--- a/ws/src/server.rs
+++ b/ws/src/server.rs
@@ -62,6 +62,8 @@ impl Server {
 
 		// Start listening...
 		let ws = ws.bind(addr)?;
+		let local_addr = ws.local_addr()?;
+
 		// Spawn a thread with event loop
 		let handle = thread::spawn(move || {
 			match ws.run().map_err(Error::from) {
@@ -75,7 +77,7 @@ impl Server {
 
 		// Return a handle
 		Ok(Server {
-			addr: addr.to_owned(),
+			addr: local_addr,
 			handle: Some(handle),
 			remote: Some(eloop),
 			broadcaster: broadcaster,


### PR DESCRIPTION
This PR uses a newer version of `ws` in my fork of that repo. I suggest first updating https://github.com/tomusdrw/ws-rs to the code at https://github.com/faern/ws-rs/tree/arbitrary-handshake-responses. Then this PR does not have to change the dependency any longer and I can remove that commit. So that this repo never have to depend on my fork.

Other than than this PR uses the new `WebSocket::local_addr` method to query which `SocketAddr` we were actually bound to. Thus making it possible to find out which port was chosen if one bind to port `0` to get a random one.