### PR TITLE
fixed runtime panic when there are missing trailing args

### DIFF
--- a/core/src/types/request.rs
+++ b/core/src/types/request.rs
@@ -44,7 +44,6 @@ pub enum Call {
 	Notification(Notification),
 	/// Invalid call
 	Invalid(Id),
-
 }
 
 impl From<MethodCall> for Call {

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,3 +16,4 @@ jsonrpc-pubsub = { version = "7.0", path = "../pubsub" }
 
 [dev-dependencies]
 jsonrpc-tcp-server = { version = "7.0", path = "../tcp" }
+serde_json = "1.0"

--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -426,6 +426,14 @@ fn params_len(params: &Params) -> Result<usize, Error> {
 	}
 }
 
+fn require_len(params: &Params, required: usize) -> Result<usize, Error> {
+	let len = params_len(params)?;
+	if len < required {
+		return Err(invalid_params("`params` should have at least {} arguments", required));
+	}
+	Ok(len)
+}
+
 fn parse_trailing_param<T: DeserializeOwned>(params: Params) -> Result<(Option<T>, ), Error> {
 	let len = try!(params_len(&params));
 	let id = match len {
@@ -501,7 +509,7 @@ macro_rules! wrap_with_trailing {
 			TRAILING: DeserializeOwned,
 		> Wrap<BASE> for fn(&BASE, $($x,)+ Trailing<TRAILING>) -> Result<OUT, Error> {
 			fn wrap_rpc(&self, base: &BASE, params: Params) -> Result<Value, Error> {
-				let len = try!(params_len(&params));
+				let len = require_len(&params, $num)?;
 
 				let params = match len - $num {
 					0 => params.parse::<($($x,)+)>()
@@ -524,7 +532,7 @@ macro_rules! wrap_with_trailing {
 			TRAILING: DeserializeOwned,
 		> WrapAsync<BASE> for fn(&BASE, $($x,)+ Trailing<TRAILING>) -> BoxFuture<OUT, Error> {
 			fn wrap_rpc(&self, base: &BASE, params: Params) -> BoxFuture<Value, Error> {
-				let len = match params_len(&params) {
+				let len = match require_len(&params, $num) {
 					Ok(len) => len,
 					Err(e) => return futures::failed(e).boxed(),
 				};
@@ -553,7 +561,7 @@ macro_rules! wrap_with_trailing {
 			TRAILING: DeserializeOwned,
 		> WrapMeta<BASE, META> for fn(&BASE, META, $($x,)+ Trailing<TRAILING>) -> BoxFuture<OUT, Error> {
 			fn wrap_rpc(&self, base: &BASE, params: Params, meta: META) -> BoxFuture<Value, Error> {
-				let len = match params_len(&params) {
+				let len = match require_len(&params, $num) {
 					Ok(len) => len,
 					Err(e) => return futures::failed(e).boxed(),
 				};
@@ -582,7 +590,7 @@ macro_rules! wrap_with_trailing {
 			TRAILING: DeserializeOwned,
 		> WrapSubscribe<BASE, META> for fn(&BASE, META, pubsub::Subscriber<OUT>, $($x,)+ Trailing<TRAILING>) {
 			fn wrap_rpc(&self, base: &BASE, params: Params, meta: META, subscriber: Subscriber) {
-				let len = match params_len(&params) {
+				let len = match require_len(&params, $num) {
 					Ok(len) => len,
 					Err(e) => {
 						let _ = subscriber.reject(e);

--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -429,7 +429,7 @@ fn params_len(params: &Params) -> Result<usize, Error> {
 fn require_len(params: &Params, required: usize) -> Result<usize, Error> {
 	let len = params_len(params)?;
 	if len < required {
-		return Err(invalid_params("`params` should have at least {} arguments", required));
+		return Err(invalid_params(&format!("`params` should have at least {} argument(s)", required), ""));
 	}
 	Ok(len)
 }

--- a/macros/tests/pubsub-macros.rs
+++ b/macros/tests/pubsub-macros.rs
@@ -1,0 +1,64 @@
+extern crate jsonrpc_core;
+extern crate jsonrpc_pubsub;
+#[macro_use]
+extern crate jsonrpc_macros;
+
+use std::sync::Arc;
+use jsonrpc_core::futures::{future, BoxFuture, Future};
+use jsonrpc_core::futures::sync::mpsc;
+use jsonrpc_core::Error;
+use jsonrpc_pubsub::{PubSubHandler, SubscriptionId, Session, PubSubMetadata};
+use jsonrpc_macros::{pubsub, Trailing};
+
+build_rpc_trait! {
+	pub trait Rpc {
+		type Metadata;
+
+		#[pubsub(name = "hello")] {
+			/// Hello subscription
+			#[rpc(name = "hello_subscribe")]
+			fn subscribe(&self, Self::Metadata, pubsub::Subscriber<String>, u32, Trailing<u64>);
+
+			/// Unsubscribe from hello subscription.
+			#[rpc(name = "hello_unsubscribe")]
+			fn unsubscribe(&self, SubscriptionId) -> BoxFuture<bool, Error>;
+		}
+	}
+}
+
+#[derive(Default)]
+struct RpcImpl;
+
+impl Rpc for RpcImpl {
+	type Metadata = Metadata;
+
+	fn subscribe(&self, _meta: Self::Metadata, subscriber: pubsub::Subscriber<String>, _pre: u32, _trailing: Trailing<u64>) {
+		let _sink = subscriber.assign_id(SubscriptionId::Number(5));
+	}
+
+	fn unsubscribe(&self, _id: SubscriptionId) -> BoxFuture<bool, Error> {
+		future::ok(true).boxed()
+	}
+}
+
+#[derive(Clone, Default)]
+struct Metadata;
+impl jsonrpc_core::Metadata for Metadata {}
+impl PubSubMetadata for Metadata {
+	fn session(&self) -> Option<Arc<Session>> {
+		let (tx, _rx) = mpsc::channel(1);
+		Some(Arc::new(Session::new(tx)))
+	}
+}
+
+#[test]
+fn test_invalid_trailing_pubsub_params() {
+	let mut io = PubSubHandler::default();
+	let rpc = RpcImpl::default();
+	io.extend_with(rpc.to_delegate());
+
+	// when
+	let meta = Metadata;
+	let req = r#"{"jsonrpc":"2.0","id":1,"method":"hello_subscribe","params":[]}"#;
+	let _res = io.handle_request_sync(req, meta);
+}

--- a/macros/tests/pubsub-macros.rs
+++ b/macros/tests/pubsub-macros.rs
@@ -1,3 +1,4 @@
+extern crate serde_json;
 extern crate jsonrpc_core;
 extern crate jsonrpc_pubsub;
 #[macro_use]
@@ -60,5 +61,18 @@ fn test_invalid_trailing_pubsub_params() {
 	// when
 	let meta = Metadata;
 	let req = r#"{"jsonrpc":"2.0","id":1,"method":"hello_subscribe","params":[]}"#;
-	let _res = io.handle_request_sync(req, meta);
+	let res = io.handle_request_sync(req, meta);
+	let expected = r#"{
+		"jsonrpc": "2.0",
+		"error": {
+			"code": -32602,
+			"message": "Couldn't parse parameters: `params` should have at least 1 argument(s)",
+			"data": "\"\""
+		},
+		"id": 1
+	}"#;
+
+	let expected: jsonrpc_core::Response = serde_json::from_str(expected).unwrap();
+	let result: jsonrpc_core::Response = serde_json::from_str(&res.unwrap()).unwrap();
+	assert_eq!(expected, result);
 }


### PR DESCRIPTION
fixed runtime panic when there are missing trailing args for pubsub macros genereted functions

fixes #182 and https://github.com/paritytech/parity/issues/6262