### PR TITLE
Allow any error that implements Into<jsonrpc::Error> for rpc traits

### DIFF
--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -322,7 +322,7 @@ impl<B, OUT> WrapAsync<B> for fn(&B) -> BoxFuture<OUT, Error>
 {
 	fn wrap_rpc(&self, base: &B, params: Params) -> BoxFuture<Value, Error> {
 		match expect_no_params(params) {
-			Ok(()) => (self)(base).map(to_value).map_err(|e| e.into()).boxed(),
+			Ok(()) => (self)(base).map(to_value).map_err(Into::into).boxed(),
 			Err(e) => futures::failed(e).boxed(),
 		}
 	}
@@ -333,7 +333,7 @@ impl<B, M, OUT> WrapMeta<B, M> for fn(&B, M) -> BoxFuture<OUT, Error>
 {
 	fn wrap_rpc(&self, base: &B, params: Params, meta: M) -> BoxFuture<Value, Error> {
 		match expect_no_params(params) {
-			Ok(()) => (self)(base, meta).map(to_value).map_err(|e| e.into()).boxed(),
+			Ok(()) => (self)(base, meta).map(to_value).map_err(Into::into).boxed(),
 			Err(e) => futures::failed(e.into()).boxed(),
 		}
 	}
@@ -366,7 +366,7 @@ macro_rules! wrap {
 			fn wrap_rpc(&self, base: &BASE, params: Params) -> Result<Value, Error> {
 				params.parse::<($($x,)+)>().and_then(|($($x,)+)| {
 					(self)(base, $($x,)+)
-				}).map(to_value).map_err(|e| e.into())
+				}).map(to_value).map_err(Into::into)
 			}
 		}
 

--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -362,8 +362,8 @@ macro_rules! wrap {
 		impl <
 			BASE: Send + Sync + 'static,
 			OUT: Serialize + 'static,
-		    $($x: DeserializeOwned,)+
-            ERR: Into<Error> + 'static,
+			$($x: DeserializeOwned,)+
+			ERR: Into<Error> + 'static,
 		> Wrap<BASE> for fn(&BASE, $($x,)+) -> Result<OUT, ERR> {
 			fn wrap_rpc(&self, base: &BASE, params: Params) -> Result<Value, Error> {
                 match params.parse::<($($x,)+)>() {
@@ -377,8 +377,8 @@ macro_rules! wrap {
 		impl <
 			BASE: Send + Sync + 'static,
 			OUT: Serialize + 'static,
-		    $($x: DeserializeOwned,)+
-            ERR: Into<Error> + 'static
+			$($x: DeserializeOwned,)+
+			ERR: Into<Error> + 'static
 		> WrapAsync<BASE> for fn(&BASE, $($x,)+ ) -> BoxFuture<OUT, ERR> {
 			fn wrap_rpc(&self, base: &BASE, params: Params) -> BoxFuture<Value, Error> {
 				match params.parse::<($($x,)+)>() {
@@ -393,8 +393,8 @@ macro_rules! wrap {
 			BASE: Send + Sync + 'static,
 			META: Metadata,
 			OUT: Serialize + 'static,
-		    $($x: DeserializeOwned,)+
-            ERR: Into<Error> + 'static
+			$($x: DeserializeOwned,)+
+			ERR: Into<Error> + 'static
 		> WrapMeta<BASE, META> for fn(&BASE, META, $($x,)+) -> BoxFuture<OUT, ERR> {
 			fn wrap_rpc(&self, base: &BASE, params: Params, meta: META) -> BoxFuture<Value, Error> {
 				match params.parse::<($($x,)+)>() {

--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -366,10 +366,10 @@ macro_rules! wrap {
 			ERR: Into<Error> + 'static,
 		> Wrap<BASE> for fn(&BASE, $($x,)+) -> Result<OUT, ERR> {
 			fn wrap_rpc(&self, base: &BASE, params: Params) -> Result<Value, Error> {
-                match params.parse::<($($x,)+)>() {
-                    Ok(($($x,)+)) => (self)(base, $($x,)+).map(to_value).map_err(Into::into),
-                    Err(e) => Err(e)
-                }
+				match params.parse::<($($x,)+)>() {
+					Ok(($($x,)+)) => (self)(base, $($x,)+).map(to_value).map_err(Into::into),
+					Err(e) => Err(e)
+				}
 			}
 		}
 
@@ -512,7 +512,7 @@ macro_rules! wrap_with_trailing {
 			OUT: Serialize + 'static,
 			$($x: DeserializeOwned,)+
 			TRAILING: DeserializeOwned,
-            ERR: Into<Error> + 'static
+			ERR: Into<Error> + 'static
 		> Wrap<BASE> for fn(&BASE, $($x,)+ Trailing<TRAILING>) -> Result<OUT, ERR> {
 			fn wrap_rpc(&self, base: &BASE, params: Params) -> Result<Value, Error> {
 				let len = require_len(&params, $num)?;
@@ -536,7 +536,7 @@ macro_rules! wrap_with_trailing {
 			OUT: Serialize + 'static,
 			$($x: DeserializeOwned,)+
 			TRAILING: DeserializeOwned,
-            ERR: Into<Error> + 'static
+			ERR: Into<Error> + 'static
 		> WrapAsync<BASE> for fn(&BASE, $($x,)+ Trailing<TRAILING>) -> BoxFuture<OUT, ERR> {
 			fn wrap_rpc(&self, base: &BASE, params: Params) -> BoxFuture<Value, Error> {
 				let len = match require_len(&params, $num) {
@@ -566,7 +566,7 @@ macro_rules! wrap_with_trailing {
 			OUT: Serialize + 'static,
 			$($x: DeserializeOwned,)+
 			TRAILING: DeserializeOwned,
-            ERR: Into<Error> + 'static
+			ERR: Into<Error> + 'static
 		> WrapMeta<BASE, META> for fn(&BASE, META, $($x,)+ Trailing<TRAILING>) -> BoxFuture<OUT, ERR> {
 			fn wrap_rpc(&self, base: &BASE, params: Params, meta: META) -> BoxFuture<Value, Error> {
 				let len = match require_len(&params, $num) {


### PR DESCRIPTION
This makes it so that when using `jsonrpc_macros`, for methods in an rpc trait, the error can be anything that implements `Into<jsonrpc::Error>` instead of just `jsonrpc::Error` itself.