### PR TITLE
Implement Debug

### DIFF
--- a/server-utils/src/reactor.rs
+++ b/server-utils/src/reactor.rs
@@ -8,6 +8,7 @@ use tokio_core;
 use core::futures::{self, Future};
 
 /// Possibly uninitialized event loop remote.
+#[derive(Debug)]
 pub enum UninitializedRemote {
 	/// Shared instance of remote.
 	Shared(tokio_core::reactor::Remote),
@@ -35,6 +36,7 @@ impl UninitializedRemote {
 }
 
 /// Initialized Remote
+#[derive(Debug)]
 pub enum Remote {
 	/// Shared instance
 	Shared(tokio_core::reactor::Remote),
@@ -67,6 +69,7 @@ impl Remote {
 }
 
 /// A handle to running event loop. Dropping the handle will cause event loop to finish.
+#[derive(Debug)]
 pub struct RpcEventLoop {
 	remote: tokio_core::reactor::Remote,
 	close: Option<futures::Complete<()>>,

--- a/server-utils/src/stream_codec.rs
+++ b/server-utils/src/stream_codec.rs
@@ -3,7 +3,7 @@ use tokio_io::codec::{Decoder, Encoder};
 use bytes::BytesMut;
 
 /// Separator for enveloping messages in streaming codecs
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum Separator {
 	/// No envelope is expected between messages. Decoder will try to figure out
 	/// message boundaries by accumulating incoming bytes until valid JSON is formed.
@@ -20,7 +20,7 @@ impl Default for Separator {
 }
 
 /// Stream codec for streaming protocols (ipc, tcp)
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct StreamCodec {
 	incoming_separator: Separator,
 	outgoing_separator: Separator,

--- a/tcp/src/dispatch.rs
+++ b/tcp/src/dispatch.rs
@@ -63,7 +63,7 @@ impl Dispatcher {
 		let mut channels = self.channels.lock();
 
 		match channels.get_mut(peer_addr) {
-			Some(mut channel) => {
+			Some(channel) => {
 				// todo: maybe async here later?
 				try!(channel.send(msg).wait().map_err(|e| PushMessageError::from(e)));
 				Ok(())

--- a/tcp/src/tests.rs
+++ b/tcp/src/tests.rs
@@ -227,7 +227,7 @@ impl MetaExtractor<SocketMetadata> for PeerListMetaExtractor {
 #[test]
 fn message() {
 
-	/// MASSIVE SETUP
+	// MASSIVE SETUP
 	::logger::init_log();
 	let addr: SocketAddr = "127.0.0.1:17790".parse().unwrap();
 	let mut io = MetaIoHandler::<SocketMetadata>::default();
@@ -250,7 +250,7 @@ fn message() {
 	let executed_dispatch = RefCell::new(false);
 	let executed_request = RefCell::new(false);
 
-	/// CLIENT RUN
+	// CLIENT RUN
 	let stream = TcpStream::connect(&addr, &core.handle())
 		.and_then(|stream| {
 			future::ok(stream).join(timeout)

--- a/ws/src/metadata.rs
+++ b/ws/src/metadata.rs
@@ -115,7 +115,7 @@ impl<M, F> MetaExtractor<M> for F where
 }
 
 /// Dummy metadata extractor
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct NoopExtractor;
 impl<M: core::Metadata> MetaExtractor<M> for NoopExtractor {}
 

--- a/ws/src/server.rs
+++ b/ws/src/server.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -19,6 +20,16 @@ pub struct Server {
 	handle: Option<thread::JoinHandle<Result<(), Error>>>,
 	remote: Arc<Mutex<Option<Remote>>>,
 	broadcaster: ws::Sender,
+}
+
+impl fmt::Debug for Server {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		f.debug_struct("Server")
+			.field("addr", &self.addr)
+			.field("handle", &self.handle)
+			.field("remote", &self.remote)
+			.finish()
+    }
 }
 
 impl Server {

--- a/ws/src/session.rs
+++ b/ws/src/session.rs
@@ -366,7 +366,7 @@ fn forbidden(title: &str, message: &str) -> ws::Response {
 		format!("{}\n{}\n", title, message).as_bytes()
 	);
 	{
-		let mut headers = forbidden.headers_mut();
+		let headers = forbidden.headers_mut();
 		headers.push(("Connection".to_owned(), "close".as_bytes().to_vec()));
 	}
 	forbidden

--- a/ws/src/session.rs
+++ b/ws/src/session.rs
@@ -34,6 +34,7 @@ impl<F> RequestMiddleware for F where
 }
 
 /// Request middleware action
+#[derive(Debug)]
 pub enum MiddlewareAction {
 	/// Proceed with standard JSON-RPC behaviour.
 	Proceed,
@@ -82,6 +83,7 @@ type TaskSlab = Mutex<Slab<Option<oneshot::Sender<()>>>>;
 
 // future for checking session liveness.
 // this returns `NotReady` until the session it corresponds to is dropped.
+#[derive(Debug)]
 struct LivenessPoll {
 	task_slab: Arc<TaskSlab>,
 	slab_handle: usize,


### PR DESCRIPTION
I tried to use `unwrap_err` on a local object containing a `jsonrpc-ws-server::Server`, but failed because it did not implement Debug. So I thought it would be helpful to add a `Debug` impl for that type and many other types I found in these crates.

Also fixed a few compiler warnings completely unrelated to `Debug`.