### PR TITLE
Adapt to Futures 0.1.15 by not using boxed()

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -49,7 +49,7 @@ use jsonrpc_core::futures::Future;
 fn main() {
 	let io = IoHandler::new();
 	io.add_async_method("say_hello", |_params: Params| {
-		futures::finished(Value::String("hello".into())).boxed()
+		Box::new(futures::finished(Value::String("hello".into())))
 	});
 
 	let request = r#"{"jsonrpc": "2.0", "method": "say_hello", "params": [42, 23], "id": 1}"#;

--- a/core/examples/middlewares.rs
+++ b/core/examples/middlewares.rs
@@ -22,10 +22,10 @@ impl Middleware<Meta> for MyMiddleware {
 		let request_number = self.0.fetch_add(1, atomic::Ordering::SeqCst);
 		println!("Processing request {}: {:?}, {:?}", request_number, request, meta);
 
-		next(request, meta).map(move |res| {
+		Box::new(next(request, meta).map(move |res| {
 			println!("Processing took: {:?}", start.elapsed());
 			res
-		}).boxed()
+		}))
 	}
 }
 

--- a/core/src/calls.rs
+++ b/core/src/calls.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use types::{Params, Value, Error};
-use futures::{BoxFuture, Future};
+use futures::Future;
+use BoxFuture;
 
 /// Metadata trait
 pub trait Metadata: Default + Clone + Send + 'static {}

--- a/core/src/calls.rs
+++ b/core/src/calls.rs
@@ -61,7 +61,7 @@ impl<F: Send + Sync + 'static, X: Send + 'static> RpcMethodSimple for F where
 	X: Future<Item=Value, Error=Error>,
 {
 	fn call(&self, params: Params) -> BoxFuture<Value, Error> {
-		self(params).boxed()
+		Box::new(self(params))
 	}
 }
 
@@ -79,7 +79,7 @@ impl<F: Send + Sync + 'static, X: Send + 'static, T> RpcMethod<T> for F where
 	X: Future<Item=Value, Error=Error>,
 {
 	fn call(&self, params: Params, meta: T) -> BoxFuture<Value, Error> {
-		self(params, meta).boxed()
+		Box::new(self(params, meta))
 	}
 }
 

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -3,12 +3,13 @@ use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 
 use serde_json;
-use futures::{self, future, Future, BoxFuture};
+use futures::{self, future, Future};
 
 use calls::{RemoteProcedure, Metadata, RpcMethodSync, RpcMethodSimple, RpcMethod, RpcNotificationSimple, RpcNotification};
 use middleware::{self, Middleware};
 use types::{Params, Error, ErrorCode, Version};
 use types::{Request, Response, Call, Output};
+use BoxFuture;
 
 /// A type representing middleware or RPC response before serialization.
 pub type FutureResponse = BoxFuture<Option<Response>, ()>;

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -179,11 +179,11 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 			Ok(request) => B(self.handle_rpc_request(request, meta)),
 		};
 
-		result.map(|response| {
+		Box::new(result.map(|response| {
 			let res = response.map(write_response);
 			debug!(target: "rpc", "Response: {:?}.", res);
 			res
-		}).boxed()
+		}))
 	}
 
 	/// Handle deserialized RPC request.
@@ -235,9 +235,9 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 				};
 
 				match result {
-					Ok(result) => A(result
+					Ok(result) => A(Box::new(result
 						.then(move |result| futures::finished(Some(Output::from(result, id, jsonrpc))))
-						.boxed()),
+						)),
 					Err(err) => B(futures::finished(Some(Output::from(Err(err), id, jsonrpc)))),
 				}
 			},

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -36,6 +36,9 @@ mod io;
 mod middleware;
 pub mod types;
 
+/// A `Future` trait object.
+pub type BoxFuture<T, E> = Box<futures::Future<Item = T, Error = E> + Send>;
+
 pub use calls::{RemoteProcedure, Metadata, RpcMethodSync, RpcMethodSimple, RpcMethod, RpcNotificationSimple, RpcNotification};
 pub use io::{Compatibility, IoHandler, MetaIoHandler, FutureResponse};
 pub use middleware::{Middleware, Noop as NoopMiddleware};

--- a/core/src/middleware.rs
+++ b/core/src/middleware.rs
@@ -2,7 +2,8 @@
 
 use calls::Metadata;
 use types::{Request, Response};
-use futures::{Future, BoxFuture};
+use futures::Future;
+use BoxFuture;
 
 /// RPC middleware
 pub trait Middleware<M: Metadata>: Send + Sync + 'static {

--- a/core/src/middleware.rs
+++ b/core/src/middleware.rs
@@ -28,7 +28,7 @@ impl<M: Metadata> Middleware<M> for Noop {
 		F: FnOnce(Request, M) -> X + Send,
 		X: Future<Item=Option<Response>, Error=()> + Send + 'static,
 	{
-		process(request, meta).boxed()
+		Box::new(process(request, meta))
 	}
 }
 

--- a/http/src/handler.rs
+++ b/http/src/handler.rs
@@ -7,8 +7,8 @@ use hyper::{self, mime, server, Method};
 use hyper::header::{self, Headers};
 use unicase::Ascii;
 
-use jsonrpc::{Metadata, Middleware, NoopMiddleware};
-use jsonrpc::futures::{Future, Poll, Async, BoxFuture, Stream};
+use jsonrpc::{BoxFuture, Metadata, Middleware, NoopMiddleware};
+use jsonrpc::futures::{Future, Poll, Async, Stream};
 use response::Response;
 use server_utils::cors;
 

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -132,7 +132,7 @@ impl<T> From<Option<T>> for RequestMiddlewareAction where
 			},
 			Some(handler) => RequestMiddlewareAction::Respond {
 				should_validate_hosts: true,
-				handler: handler.into_future().boxed(),
+				handler: Box::new(handler.into_future()),
 			},
 		}
 	}

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -38,8 +38,8 @@ use std::sync::{mpsc, Arc};
 use std::net::SocketAddr;
 
 use hyper::server;
-use jsonrpc::MetaIoHandler;
-use jsonrpc::futures::{self, Future, IntoFuture, BoxFuture, Stream};
+use jsonrpc::{BoxFuture, MetaIoHandler};
+use jsonrpc::futures::{self, Future, IntoFuture, Stream};
 use jsonrpc::futures::sync::oneshot;
 use server_utils::reactor::{Remote, UninitializedRemote};
 

--- a/http/src/tests.rs
+++ b/http/src/tests.rs
@@ -21,7 +21,7 @@ fn serve() -> Server {
 	let mut io = IoHandler::default();
 	io.add_method("hello", |_params: Params| Ok(Value::String("world".into())));
 	io.add_async_method("hello_async", |_params: Params| {
-		futures::finished(Value::String("world".into())).boxed()
+		Box::new(futures::finished(Value::String("world".into())))
 	});
 	io.add_async_method("hello_async2", |_params: Params| {
 		let (c, p) = futures::oneshot();
@@ -29,7 +29,7 @@ fn serve() -> Server {
 			thread::sleep(::std::time::Duration::from_millis(10));
 			c.send(Value::String("world".into())).unwrap();
 		});
-		p.map_err(|_| Error::invalid_request()).boxed()
+		Box::new(p.map_err(|_| Error::invalid_request()))
 	});
 
 	ServerBuilder::new(io)

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -14,7 +14,6 @@ tokio-service = "0.1"
 jsonrpc-core = { version = "7.1", path = "../core" }
 jsonrpc-server-utils = { version = "7.1", path = "../server-utils" }
 parity-tokio-ipc = { git = "https://github.com/nikvolf/parity-tokio-ipc" }
-bytes = "0.4"
 
 [dev-dependencies]
 env_logger = "0.4"

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -6,7 +6,6 @@ extern crate jsonrpc_core as jsonrpc;
 extern crate jsonrpc_server_utils as server_utils;
 extern crate parity_tokio_ipc;
 extern crate tokio_service;
-extern crate bytes;
 
 #[macro_use] extern crate log;
 

--- a/ipc/src/server.rs
+++ b/ipc/src/server.rs
@@ -4,8 +4,7 @@ use std::sync::Arc;
 use tokio_service::{self, Service as TokioService};
 use jsonrpc::futures::{future, Future, Stream, Sink};
 use jsonrpc::futures::sync::{mpsc, oneshot};
-use jsonrpc::{Metadata, MetaIoHandler, Middleware, NoopMiddleware};
-use jsonrpc::futures::BoxFuture;
+use jsonrpc::{BoxFuture, Metadata, MetaIoHandler, Middleware, NoopMiddleware};
 
 use server_utils::tokio_core::reactor::Remote;
 use server_utils::tokio_io::AsyncRead;

--- a/ipc/src/server.rs
+++ b/ipc/src/server.rs
@@ -117,7 +117,7 @@ impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
 				Ok(l) => l,
 				Err(e) => {
 					start_signal.send(Err(e)).expect("Cannot fail since receiver never dropped before receiving");
-					return future::ok(()).boxed();
+					return Box::new(future::ok(())) as BoxFuture<_, _>;
 				}
 			};
 
@@ -179,10 +179,11 @@ impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
 			});
 
 			let stop = stop_receiver.map_err(|_| std::io::ErrorKind::Interrupted.into());
-			server.select(stop)
-				.map(|_| ())
-				.map_err(|_| ())
-				.boxed()
+			Box::new(
+				server.select(stop)
+					.map(|_| ())
+					.map_err(|_| ())
+			)
 		});
 
 		match start_receiver.wait().expect("Message should always be sent") {

--- a/macros/examples/meta-macros.rs
+++ b/macros/examples/meta-macros.rs
@@ -47,11 +47,11 @@ impl Rpc for RpcImpl {
 	}
 
 	fn call(&self, x: u64) -> BoxFuture<String, Error> {
-		futures::finished(format!("OK: {}", x)).boxed()
+		Box::new(futures::finished(format!("OK: {}", x)))
 	}
 
 	fn call_meta(&self, meta: Self::Metadata, map: BTreeMap<String, Value>) -> BoxFuture<String, Error> {
-		futures::finished(format!("From: {}, got: {:?}", meta.0, map)).boxed()
+		Box::new(futures::finished(format!("From: {}, got: {:?}", meta.0, map)))
 	}
 }
 

--- a/macros/examples/meta-macros.rs
+++ b/macros/examples/meta-macros.rs
@@ -5,8 +5,7 @@ extern crate jsonrpc_tcp_server;
 
 use std::collections::BTreeMap;
 
-use jsonrpc_core::{BoxFuture, MetaIoHandler, Metadata, Error, Value};
-use jsonrpc_core::futures::{self, Future};
+use jsonrpc_core::{futures, BoxFuture, MetaIoHandler, Metadata, Error, Value};
 
 #[derive(Clone, Default)]
 struct Meta(String);

--- a/macros/examples/meta-macros.rs
+++ b/macros/examples/meta-macros.rs
@@ -5,8 +5,8 @@ extern crate jsonrpc_tcp_server;
 
 use std::collections::BTreeMap;
 
-use jsonrpc_core::{MetaIoHandler, Metadata, Error, Value};
-use jsonrpc_core::futures::{self, BoxFuture, Future};
+use jsonrpc_core::{BoxFuture, MetaIoHandler, Metadata, Error, Value};
+use jsonrpc_core::futures::{self, Future};
 
 #[derive(Clone, Default)]
 struct Meta(String);

--- a/macros/examples/pubsub-macros.rs
+++ b/macros/examples/pubsub-macros.rs
@@ -76,15 +76,15 @@ impl Rpc for RpcImpl {
 
 	fn unsubscribe(&self, id: SubscriptionId) -> BoxFuture<bool, Error> {
 		let removed = self.active.write().unwrap().remove(&id);
-		if removed.is_some() {
-			future::ok(true).boxed()
+		Box::new(if removed.is_some() {
+			future::ok(true)
 		} else {
 			future::err(Error {
 				code: ErrorCode::InvalidParams,
 				message: "Invalid subscription.".into(),
 				data: None,
-			}).boxed()
-		}
+			})
+		})
 	}
 }
 

--- a/macros/examples/pubsub-macros.rs
+++ b/macros/examples/pubsub-macros.rs
@@ -9,7 +9,7 @@ use std::sync::{atomic, Arc, RwLock};
 use std::collections::HashMap;
 
 use jsonrpc_core::{BoxFuture, Metadata, Error, ErrorCode};
-use jsonrpc_core::futures::{Future, future};
+use jsonrpc_core::futures::{future, Future};
 use jsonrpc_pubsub::{Session, PubSubMetadata, PubSubHandler, SubscriptionId};
 
 use jsonrpc_macros::pubsub;

--- a/macros/examples/pubsub-macros.rs
+++ b/macros/examples/pubsub-macros.rs
@@ -8,8 +8,8 @@ use std::thread;
 use std::sync::{atomic, Arc, RwLock};
 use std::collections::HashMap;
 
-use jsonrpc_core::{Metadata, Error, ErrorCode};
-use jsonrpc_core::futures::{BoxFuture, Future, future};
+use jsonrpc_core::{BoxFuture, Metadata, Error, ErrorCode};
+use jsonrpc_core::futures::{Future, future};
 use jsonrpc_pubsub::{Session, PubSubMetadata, PubSubHandler, SubscriptionId};
 
 use jsonrpc_macros::pubsub;

--- a/macros/examples/std.rs
+++ b/macros/examples/std.rs
@@ -2,8 +2,8 @@ extern crate jsonrpc_core;
 #[macro_use]
 extern crate jsonrpc_macros;
 
-use jsonrpc_core::{IoHandler, Error};
-use jsonrpc_core::futures::{self, BoxFuture, Future};
+use jsonrpc_core::{BoxFuture, IoHandler, Error};
+use jsonrpc_core::futures::{self, Future};
 
 build_rpc_trait! {
 	pub trait Rpc {

--- a/macros/examples/std.rs
+++ b/macros/examples/std.rs
@@ -2,8 +2,7 @@ extern crate jsonrpc_core;
 #[macro_use]
 extern crate jsonrpc_macros;
 
-use jsonrpc_core::{BoxFuture, IoHandler, Error};
-use jsonrpc_core::futures::{self, Future};
+use jsonrpc_core::{futures, BoxFuture, IoHandler, Error};
 
 build_rpc_trait! {
 	pub trait Rpc {

--- a/macros/examples/std.rs
+++ b/macros/examples/std.rs
@@ -33,7 +33,7 @@ impl Rpc for RpcImpl {
 	}
 
 	fn call(&self, _: u64) -> BoxFuture<String, Error> {
-		futures::finished("OK".to_owned()).boxed()
+		Box::new(futures::finished("OK".to_owned()))
 	}
 }
 

--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -4,8 +4,8 @@
 
 ///! Automatically serialize and deserialize parameters around a strongly-typed function.
 
-use jsonrpc_core::{Error, Params, Value, Metadata};
-use jsonrpc_core::futures::{self, BoxFuture, Future};
+use jsonrpc_core::{BoxFuture, Error, Params, Value, Metadata};
+use jsonrpc_core::futures::{self, Future};
 use jsonrpc_pubsub::{PubSubMetadata, Subscriber};
 use pubsub;
 use serde::Serialize;

--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -235,7 +235,7 @@ macro_rules! build_rpc_trait {
 			}),
 			($unsubscribe, move |base, id| {
 				use $crate::jsonrpc_core::futures::Future;
-				Self::$unsub_method(base, id).map($crate::to_value).boxed()
+				Box::new(Self::$unsub_method(base, id).map($crate::to_value))
 			}),
 		);
 
@@ -323,8 +323,8 @@ impl<B, OUT, E> WrapAsync<B> for fn(&B) -> BoxFuture<OUT, E>
 {
 	fn wrap_rpc(&self, base: &B, params: Params) -> BoxFuture<Value, Error> {
 		match expect_no_params(params) {
-			Ok(()) => (self)(base).map(to_value).map_err(Into::into).boxed(),
-			Err(e) => futures::failed(e).boxed(),
+			Ok(()) => Box::new((self)(base).map(to_value).map_err(Into::into)),
+			Err(e) => Box::new(futures::failed(e)),
 		}
 	}
 }
@@ -334,8 +334,8 @@ impl<B, M, OUT, E> WrapMeta<B, M> for fn(&B, M) -> BoxFuture<OUT, E>
 {
 	fn wrap_rpc(&self, base: &B, params: Params, meta: M) -> BoxFuture<Value, Error> {
 		match expect_no_params(params) {
-			Ok(()) => (self)(base, meta).map(to_value).map_err(Into::into).boxed(),
-			Err(e) => futures::failed(e.into()).boxed(),
+			Ok(()) => Box::new((self)(base, meta).map(to_value).map_err(Into::into)),
+			Err(e) => Box::new(futures::failed(e.into())),
 		}
 	}
 }
@@ -382,8 +382,8 @@ macro_rules! wrap {
 		> WrapAsync<BASE> for fn(&BASE, $($x,)+ ) -> BoxFuture<OUT, ERR> {
 			fn wrap_rpc(&self, base: &BASE, params: Params) -> BoxFuture<Value, Error> {
 				match params.parse::<($($x,)+)>() {
-					Ok(($($x,)+)) => (self)(base, $($x,)+).map(to_value).map_err(Into::into).boxed(),
-					Err(e) => futures::failed(e).boxed(),
+					Ok(($($x,)+)) => Box::new((self)(base, $($x,)+).map(to_value).map_err(Into::into)),
+					Err(e) => Box::new(futures::failed(e)),
 				}
 			}
 		}
@@ -398,8 +398,8 @@ macro_rules! wrap {
 		> WrapMeta<BASE, META> for fn(&BASE, META, $($x,)+) -> BoxFuture<OUT, ERR> {
 			fn wrap_rpc(&self, base: &BASE, params: Params, meta: META) -> BoxFuture<Value, Error> {
 				match params.parse::<($($x,)+)>() {
-					Ok(($($x,)+)) => (self)(base, meta, $($x,)+).map(to_value).map_err(Into::into).boxed(),
-					Err(e) => futures::failed(e).boxed(),
+					Ok(($($x,)+)) => Box::new((self)(base, meta, $($x,)+).map(to_value).map_err(Into::into)),
+					Err(e) => Box::new(futures::failed(e)),
 				}
 			}
 		}
@@ -468,8 +468,8 @@ impl<B, OUT, T, E> WrapAsync<B> for fn(&B, Trailing<T>) -> BoxFuture<OUT, E>
 		let id = parse_trailing_param(params);
 
 		match id {
-			Ok((id,)) => (self)(base, Trailing(id)).map(to_value).map_err(Into::into).boxed(),
-			Err(e) => futures::failed(e).boxed(),
+			Ok((id,)) => Box::new((self)(base, Trailing(id)).map(to_value).map_err(Into::into)),
+			Err(e) => Box::new(futures::failed(e)),
 		}
 	}
 }
@@ -481,8 +481,8 @@ impl<B, M, OUT, T, E> WrapMeta<B, M> for fn(&B, M, Trailing<T>) -> BoxFuture<OUT
 		let id = parse_trailing_param(params);
 
 		match id {
-			Ok((id,)) => (self)(base, meta, Trailing(id)).map(to_value).map_err(Into::into).boxed(),
-			Err(e) => futures::failed(e).boxed(),
+			Ok((id,)) => Box::new((self)(base, meta, Trailing(id)).map(to_value).map_err(Into::into)),
+			Err(e) => Box::new(futures::failed(e)),
 		}
 	}
 }
@@ -541,7 +541,7 @@ macro_rules! wrap_with_trailing {
 			fn wrap_rpc(&self, base: &BASE, params: Params) -> BoxFuture<Value, Error> {
 				let len = match require_len(&params, $num) {
 					Ok(len) => len,
-					Err(e) => return futures::failed(e).boxed(),
+					Err(e) => return Box::new(futures::failed(e)),
 				};
 
 				let params = match len - $num {
@@ -553,8 +553,8 @@ macro_rules! wrap_with_trailing {
 				};
 
 				match params {
-					Ok(($($x,)+ id)) => (self)(base, $($x,)+ Trailing(id)).map(to_value).map_err(Into::into).boxed(),
-					Err(e) => futures::failed(e).boxed(),
+					Ok(($($x,)+ id)) => Box::new((self)(base, $($x,)+ Trailing(id)).map(to_value).map_err(Into::into)),
+					Err(e) => Box::new(futures::failed(e)),
 				}
 			}
 		}
@@ -571,7 +571,7 @@ macro_rules! wrap_with_trailing {
 			fn wrap_rpc(&self, base: &BASE, params: Params, meta: META) -> BoxFuture<Value, Error> {
 				let len = match require_len(&params, $num) {
 					Ok(len) => len,
-					Err(e) => return futures::failed(e).boxed(),
+					Err(e) => return Box::new(futures::failed(e)),
 				};
 
 				let params = match len - $num {
@@ -583,8 +583,8 @@ macro_rules! wrap_with_trailing {
 				};
 
 				match params {
-					Ok(($($x,)+ id)) => (self)(base, meta, $($x,)+ Trailing(id)).map(to_value).map_err(Into::into).boxed(),
-					Err(e) => futures::failed(e).boxed(),
+					Ok(($($x,)+ id)) => Box::new((self)(base, meta, $($x,)+ Trailing(id)).map(to_value).map_err(Into::into)),
+					Err(e) => Box::new(futures::failed(e)),
 				}
 			}
 		}

--- a/macros/src/delegates.rs
+++ b/macros/src/delegates.rs
@@ -23,7 +23,7 @@ impl<T, M, F> RpcMethod<M> for DelegateMethod<T, F> where
 {
 	fn call(&self, params: Params, _meta: M) -> AsyncData {
 		let closure = &self.closure;
-		futures::done(closure(&self.delegate, params)).boxed()
+		Box::new(futures::done(closure(&self.delegate, params)))
 	}
 }
 

--- a/macros/src/delegates.rs
+++ b/macros/src/delegates.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 use std::collections::HashMap;
 
 use jsonrpc_core::{Params, Value, Error};
-use jsonrpc_core::{Metadata, RemoteProcedure, RpcMethod, RpcNotification};
-use jsonrpc_core::futures::{self, BoxFuture, Future};
+use jsonrpc_core::{BoxFuture, Metadata, RemoteProcedure, RpcMethod, RpcNotification};
+use jsonrpc_core::futures::{self, Future};
 
 use jsonrpc_pubsub::{self, SubscriptionId, Subscriber, PubSubMetadata};
 

--- a/macros/src/delegates.rs
+++ b/macros/src/delegates.rs
@@ -2,8 +2,7 @@ use std::sync::Arc;
 use std::collections::HashMap;
 
 use jsonrpc_core::{Params, Value, Error};
-use jsonrpc_core::{BoxFuture, Metadata, RemoteProcedure, RpcMethod, RpcNotification};
-use jsonrpc_core::futures::{self, Future};
+use jsonrpc_core::{futures, BoxFuture, Metadata, RemoteProcedure, RpcMethod, RpcNotification};
 
 use jsonrpc_pubsub::{self, SubscriptionId, Subscriber, PubSubMetadata};
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -7,8 +7,8 @@
 //! ```
 //! extern crate jsonrpc_core;
 //! #[macro_use] extern crate jsonrpc_macros;
-//! use jsonrpc_core::{IoHandler, Error};
-//! use jsonrpc_core::futures::{self, BoxFuture, Future};
+//! use jsonrpc_core::{BoxFuture, IoHandler, Error};
+//! use jsonrpc_core::futures::{self, Future};
 //! build_rpc_trait! {
 //! 	pub trait Rpc {
 //! 		/// Returns a protocol version

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -35,7 +35,7 @@
 //! 	}
 //!
 //! 	fn call(&self, _: u64) -> BoxFuture<String, Error> {
-//! 		futures::finished("OK".to_owned()).boxed()
+//! 		Box::new(futures::finished("OK".to_owned()))
 //! 	}
 //! }
 //!

--- a/macros/tests/pubsub-macros.rs
+++ b/macros/tests/pubsub-macros.rs
@@ -5,9 +5,9 @@ extern crate jsonrpc_pubsub;
 extern crate jsonrpc_macros;
 
 use std::sync::Arc;
-use jsonrpc_core::futures::{future, BoxFuture, Future};
+use jsonrpc_core::futures::{future, Future};
 use jsonrpc_core::futures::sync::mpsc;
-use jsonrpc_core::Error;
+use jsonrpc_core::{BoxFuture, Error};
 use jsonrpc_pubsub::{PubSubHandler, SubscriptionId, Session, PubSubMetadata};
 use jsonrpc_macros::{pubsub, Trailing};
 

--- a/macros/tests/pubsub-macros.rs
+++ b/macros/tests/pubsub-macros.rs
@@ -5,7 +5,7 @@ extern crate jsonrpc_pubsub;
 extern crate jsonrpc_macros;
 
 use std::sync::Arc;
-use jsonrpc_core::futures::{future, Future};
+use jsonrpc_core::futures::future;
 use jsonrpc_core::futures::sync::mpsc;
 use jsonrpc_core::{BoxFuture, Error};
 use jsonrpc_pubsub::{PubSubHandler, SubscriptionId, Session, PubSubMetadata};

--- a/macros/tests/pubsub-macros.rs
+++ b/macros/tests/pubsub-macros.rs
@@ -38,7 +38,7 @@ impl Rpc for RpcImpl {
 	}
 
 	fn unsubscribe(&self, _id: SubscriptionId) -> BoxFuture<bool, Error> {
-		future::ok(true).boxed()
+		Box::new(future::ok(true))
 	}
 }
 

--- a/minihttp/src/lib.rs
+++ b/minihttp/src/lib.rs
@@ -40,8 +40,8 @@ use std::sync::{Arc, mpsc};
 use std::net::SocketAddr;
 use std::thread;
 use parking_lot::RwLock;
-use jsonrpc::futures::{self, future, Future, BoxFuture};
-use jsonrpc::MetaIoHandler;
+use jsonrpc::futures::{self, future, Future};
+use jsonrpc::{BoxFuture, MetaIoHandler};
 use jsonrpc_server_utils::hosts;
 
 pub use jsonrpc_server_utils::cors;

--- a/minihttp/src/tests.rs
+++ b/minihttp/src/tests.rs
@@ -26,7 +26,7 @@ fn serve() -> Server {
 	let mut io = IoHandler::default();
 	io.add_method("hello", |_params: Params| Ok(Value::String("world".into())));
 	io.add_async_method("hello_async", |_params: Params| {
-		futures::finished(Value::String("world".into())).boxed()
+		Box::new(futures::finished(Value::String("world".into())))
 	});
 	io.add_async_method("hello_async2", |_params: Params| {
 		let (c, p) = futures::oneshot();
@@ -34,7 +34,7 @@ fn serve() -> Server {
 			thread::sleep(::std::time::Duration::from_millis(10));
 			c.send(Value::String("world".into())).unwrap();
 		});
-		p.map_err(|_| Error::invalid_request()).boxed()
+		Box::new(p.map_err(|_| Error::invalid_request()))
 	});
 
 	ServerBuilder::new(io)

--- a/pubsub/examples/pubsub.rs
+++ b/pubsub/examples/pubsub.rs
@@ -72,9 +72,9 @@ fn main() {
 				}
 			});
 		}),
-		("remove_hello", |_id: SubscriptionId| -> futures::BoxFuture<Value, Error> {
+		("remove_hello", |_id: SubscriptionId| -> BoxFuture<Value, Error> {
 			println!("Closing subscription");
-			futures::future::ok(Value::Bool(true)).boxed()
+			Box::new(futures::future::ok(Value::Bool(true)))
 		}),
 	);
 

--- a/pubsub/src/handler.rs
+++ b/pubsub/src/handler.rs
@@ -1,5 +1,4 @@
-use core;
-use core::futures::BoxFuture;
+use core::{self, BoxFuture};
 
 use types::{PubSubMetadata, SubscriptionId};
 use subscription::{Subscriber, new_subscription};

--- a/pubsub/src/handler.rs
+++ b/pubsub/src/handler.rs
@@ -128,7 +128,7 @@ mod tests {
 				// Should be called because session is dropped.
 				called2.store(true, Ordering::SeqCst);
 				assert_eq!(id, SubscriptionId::Number(5));
-				future::ok(core::Value::Bool(true)).boxed()
+				Box::new(future::ok(core::Value::Bool(true))) as BoxFuture<_, _>
 			}),
 		);
 

--- a/pubsub/src/handler.rs
+++ b/pubsub/src/handler.rs
@@ -94,8 +94,8 @@ mod tests {
 	use std::sync::Arc;
 	use std::sync::atomic::{AtomicBool, Ordering};
 
-	use core;
-	use core::futures::{future, Future};
+	use core::{self, BoxFuture};
+	use core::futures::future;
 	use core::futures::sync::mpsc;
 	use subscription::{Session, Subscriber};
 	use types::{PubSubMetadata, SubscriptionId};

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -274,7 +274,7 @@ mod tests {
 	use std::sync::Arc;
 	use std::sync::atomic::{AtomicBool, Ordering};
 	use core;
-	use core::RpcMethod;
+	use core::{BoxFuture, RpcMethod};
 	use core::futures::{future, Async, Future, Stream};
 	use core::futures::sync::{mpsc, oneshot};
 	use types::{SubscriptionId, PubSubMetadata};

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use parking_lot::Mutex;
 
-use core;
-use core::futures::{self, future, Sink as FuturesSink, Future, BoxFuture};
+use core::{self, BoxFuture};
+use core::futures::{self, future, Sink as FuturesSink, Future};
 use core::futures::sync::oneshot;
 
 use handler::{SubscribeRpcMethod, UnsubscribeRpcMethod};

--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -11,11 +11,9 @@ documentation = "https://paritytech.github.io/jsonrpc/json_tcp_server/index.html
 [dependencies]
 log = "0.3"
 parking_lot = "0.4"
-serde_json = "1.0"
 tokio-service = "0.1"
 jsonrpc-core = { version = "7.1", path = "../core" }
 jsonrpc-server-utils = { version = "7.1", path = "../server-utils" }
-bytes = "0.4"
 
 [dev-dependencies]
 lazy_static = "0.2"

--- a/tcp/src/lib.rs
+++ b/tcp/src/lib.rs
@@ -25,9 +25,7 @@
 extern crate jsonrpc_core as jsonrpc;
 extern crate jsonrpc_server_utils as server_utils;
 extern crate parking_lot;
-extern crate serde_json;
 extern crate tokio_service;
-extern crate bytes;
 
 #[macro_use] extern crate log;
 

--- a/tcp/src/service.rs
+++ b/tcp/src/service.rs
@@ -3,8 +3,7 @@ use std::net::SocketAddr;
 
 use tokio_service;
 
-use jsonrpc::{Metadata, MetaIoHandler, Middleware, NoopMiddleware};
-use jsonrpc::futures::BoxFuture;
+use jsonrpc::{BoxFuture, Metadata, MetaIoHandler, Middleware, NoopMiddleware};
 
 pub struct Service<M: Metadata = (), S: Middleware<M> = NoopMiddleware> {
 	handler: Arc<MetaIoHandler<M, S>>,

--- a/tcp/src/tests.rs
+++ b/tcp/src/tests.rs
@@ -187,7 +187,7 @@ impl MetaExtractor<SocketMetadata> for PeerMetaExtractor {
 fn meta_server() -> ServerBuilder<SocketMetadata> {
 	let mut io = MetaIoHandler::<SocketMetadata>::default();
 	io.add_method_with_meta("say_hello", |_params, meta: SocketMetadata| {
-		future::ok(Value::String(format!("hello, {}", meta.addr()))).boxed()
+		Box::new(future::ok(Value::String(format!("hello, {}", meta.addr()))))
 	});
 	ServerBuilder::new(io).session_meta_extractor(PeerMetaExtractor)
 }
@@ -232,7 +232,7 @@ fn message() {
 	let addr: SocketAddr = "127.0.0.1:17790".parse().unwrap();
 	let mut io = MetaIoHandler::<SocketMetadata>::default();
 	io.add_method_with_meta("say_hello", |_params, _: SocketMetadata| {
-		future::ok(Value::String("hello".to_owned())).boxed()
+		Box::new(future::ok(Value::String("hello".to_owned())))
 	});
 	let extractor = PeerListMetaExtractor::default();
 	let peer_list = extractor.peers.clone();


### PR DESCRIPTION
Futures 0.1.15 deprecates the `BoxFuture` type and the `.boxed()` method on `Future`. The [issue](https://github.com/alexcrichton/futures-rs/issues/228) talking about that recommend that people use `Box::new(...)` instead because it allows the compiler to figure out some magic better. So I went ahead and fixed that.