### PR TITLE
http: handle charset=utf-8 for application/json

### DIFF
--- a/http/src/handler.rs
+++ b/http/src/handler.rs
@@ -310,8 +310,11 @@ impl<M: Metadata, S: Middleware<M>> RpcHandler<M, S> {
 	}
 
 	fn is_json(content_type: Option<&header::ContentType>) -> bool {
+		const APPLICATION_JSON_UTF_8: &str = "application/json; charset=utf-8";
+
 		match content_type {
-			Some(&header::ContentType(ref mime)) if *mime == mime::APPLICATION_JSON => true,
+			Some(&header::ContentType(ref mime))
+				if *mime == mime::APPLICATION_JSON || *mime == APPLICATION_JSON_UTF_8 => true,
 			_ => false
 		}
 	}

--- a/http/src/tests.rs
+++ b/http/src/tests.rs
@@ -417,6 +417,30 @@ fn should_allow_if_host_is_valid() {
 }
 
 #[test]
+fn should_allow_application_json_utf8() {
+    // given
+	let server = serve_hosts(vec!["parity.io".into()]);
+
+	// when
+	let req = r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#;
+	let response = request(server,
+		&format!("\
+			POST / HTTP/1.1\r\n\
+			Host: parity.io\r\n\
+			Connection: close\r\n\
+			Content-Type: application/json; charset=utf-8\r\n\
+			Content-Length: {}\r\n\
+			\r\n\
+			{}\r\n\
+		", req.as_bytes().len(), req)
+	);
+
+	// then
+	assert_eq!(response.status, "HTTP/1.1 200 OK".to_owned());
+	assert_eq!(response.body, method_not_found());
+}
+
+#[test]
 fn should_always_allow_the_bind_address() {
 	// given
 	let server = serve_hosts(vec!["parity.io".into()]);

--- a/http/src/tests.rs
+++ b/http/src/tests.rs
@@ -418,7 +418,7 @@ fn should_allow_if_host_is_valid() {
 
 #[test]
 fn should_allow_application_json_utf8() {
-    // given
+	// given
 	let server = serve_hosts(vec!["parity.io".into()]);
 
 	// when


### PR DESCRIPTION
Sometimes the browser would send content type as `application/json; charset=utf-8`. `jsonrpc` sees it is not equal to `application/json`, and reject that request.

In the mime crate there are also constants like `TEXT_PLAIN_UTF_8`, so I think using `APPLICATION_JSON_UTF_8` is the right way to handle this.