### PR TITLE
Impl from on error kind

### DIFF
--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -64,11 +64,8 @@ impl From<i64> for ErrorCode {
 impl<'a> Deserialize<'a> for ErrorCode {
 	fn deserialize<D>(deserializer: D) -> Result<ErrorCode, D::Error>
 	where D: Deserializer<'a> {
-		let v: Value = try!(Deserialize::deserialize(deserializer));
-		match v.as_i64() {
-			Some(code) => Ok(ErrorCode::from(code)),
-			_ => unreachable!()
-		}
+		let code: i64 = try!(Deserialize::deserialize(deserializer));
+		Ok(ErrorCode::from(code))
 	}
 }
 

--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -48,20 +48,27 @@ impl ErrorCode {
 	}
 }
 
+impl From<i64> for ErrorCode {
+	fn from(code: i64) -> Self {
+		match code {
+			-32700 => ErrorCode::ParseError,
+			-32600 => ErrorCode::InvalidRequest,
+			-32601 => ErrorCode::MethodNotFound,
+			-32602 => ErrorCode::InvalidParams,
+			-32603 => ErrorCode::InternalError,
+			code => ErrorCode::ServerError(code),
+		}
+	}
+}
+
 impl<'a> Deserialize<'a> for ErrorCode {
 	fn deserialize<D>(deserializer: D) -> Result<ErrorCode, D::Error>
 	where D: Deserializer<'a> {
 		let v: Value = try!(Deserialize::deserialize(deserializer));
 		match v.as_i64() {
-			Some(-32700) => Ok(ErrorCode::ParseError),
-			Some(-32600) => Ok(ErrorCode::InvalidRequest),
-			Some(-32601) => Ok(ErrorCode::MethodNotFound),
-			Some(-32602) => Ok(ErrorCode::InvalidParams),
-			Some(-32603) => Ok(ErrorCode::InternalError),
-			Some(code) => Ok(ErrorCode::ServerError(code)),
+			Some(code) => Ok(ErrorCode::from(code)),
 			_ => unreachable!()
 		}
-
 	}
 }
 


### PR DESCRIPTION
There was no way to instantiate an `ErrorKind` without deserializing it. So I moved that code to a `From<i64>` impl and made use of it in the deserialization.

I also realized that deserializing an `ErrorCode` from something that was a valid json `Value`, but not an `i64` would trigger the `unimplemented!()` call. Panics are dangerous, especially in exposed APIs. I changed that and hopefully this should never panic.