### PR TITLE
REST -> RPC converter for HTTP server

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -28,6 +28,8 @@
 extern crate serde;
 
 pub extern crate futures;
+
+#[doc(hidden)]
 pub extern crate serde_json;
 
 mod calls;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -26,9 +26,9 @@
 #[macro_use] extern crate log;
 #[macro_use] extern crate serde_derive;
 extern crate serde;
-extern crate serde_json;
 
 pub extern crate futures;
+pub extern crate serde_json;
 
 mod calls;
 mod io;

--- a/http/examples/http_middleware.rs
+++ b/http/examples/http_middleware.rs
@@ -4,7 +4,9 @@ extern crate jsonrpc_http_server;
 
 use jsonrpc_core::{IoHandler, Value};
 use jsonrpc_core::futures;
-use jsonrpc_http_server::{hyper, ServerBuilder, DomainsValidation, AccessControlAllowOrigin, Response};
+use jsonrpc_http_server::{
+	hyper, ServerBuilder, DomainsValidation, AccessControlAllowOrigin, Response, RestApi
+};
 
 fn main() {
 	let mut io = IoHandler::default();
@@ -21,6 +23,7 @@ fn main() {
 				request.into()
 			}
 		})
+		.rest_api(RestApi::Unsecure)
 		.start_http(&"127.0.0.1:3030".parse().unwrap())
 		.expect("Unable to start RPC server");
 

--- a/http/examples/server.rs
+++ b/http/examples/server.rs
@@ -2,7 +2,7 @@ extern crate jsonrpc_core;
 extern crate jsonrpc_http_server;
 
 use jsonrpc_core::*;
-use jsonrpc_http_server::{ServerBuilder, DomainsValidation, AccessControlAllowOrigin};
+use jsonrpc_http_server::{ServerBuilder, DomainsValidation, AccessControlAllowOrigin, RestApi};
 
 fn main() {
 	let mut io = IoHandler::default();
@@ -12,6 +12,7 @@ fn main() {
 
 	let server = ServerBuilder::new(io)
 		.threads(3)
+		.rest_api(RestApi::Unsecure)
 		.cors(DomainsValidation::AllowOnly(vec![AccessControlAllowOrigin::Any]))
 		.start_http(&"127.0.0.1:3030".parse().unwrap())
 		.expect("Unable to start RPC server");

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -202,6 +202,24 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> Clone for Rpc<M, S> {
 type AllowedHosts = Option<Vec<Host>>;
 type CorsDomains = Option<Vec<AccessControlAllowOrigin>>;
 
+/// REST -> RPC converter state.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum RestApi {
+	/// The REST -> RPC converter is enabled
+	/// and requires `Content-Type: application/json` header
+	/// (even though the body should be empty).
+	/// This protects from submitting an RPC call
+	/// from unwanted origins.
+	Secure,
+	/// The REST -> RPC converter is enabled
+	/// and does not require any `Content-Type` headers.
+	/// NOTE: This allows sending RPCs via HTTP forms
+	/// from any website.
+	Unsecure,
+	/// The REST -> RPC converter is disabled.
+	Disabled,
+}
+
 /// Convenient JSON-RPC HTTP Server builder.
 pub struct ServerBuilder<M: jsonrpc::Metadata = (), S: jsonrpc::Middleware<M> = jsonrpc::NoopMiddleware> {
 	handler: Arc<MetaIoHandler<M, S>>,
@@ -210,6 +228,7 @@ pub struct ServerBuilder<M: jsonrpc::Metadata = (), S: jsonrpc::Middleware<M> = 
 	request_middleware: Arc<RequestMiddleware>,
 	cors_domains: CorsDomains,
 	allowed_hosts: AllowedHosts,
+	rest_api: RestApi,
 	keep_alive: bool,
 	threads: usize,
 }
@@ -235,6 +254,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 			request_middleware: Arc::new(NoopRequestMiddleware::default()),
 			cors_domains: None,
 			allowed_hosts: None,
+			rest_api: RestApi::Disabled,
 			keep_alive: true,
 			threads: 1,
 		}
@@ -244,6 +264,14 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 	/// Applies only to 1 of the threads. Other threads will spawn their own Event Loops.
 	pub fn event_loop_remote(mut self, remote: tokio_core::reactor::Remote) -> Self {
 		self.remote = UninitializedRemote::Shared(remote);
+		self
+	}
+
+	/// Enable the REST -> RPC converter. Allows you to invoke RPCs
+	/// by sending `POST /<method>/<param1>/<param2>` requests
+	/// (with no body). Disabled by default.
+	pub fn rest_api(mut self, rest_api: RestApi) -> Self {
+		self.rest_api = rest_api;
 		self
 	}
 
@@ -309,6 +337,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 			handler: self.handler,
 			extractor: self.meta_extractor,
 		};
+		let rest_api = self.rest_api;
 		let keep_alive = self.keep_alive;
 		let reuse_port = self.threads > 1;
 
@@ -323,6 +352,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 			request_middleware.clone(),
 			allowed_hosts.clone(),
 			jsonrpc_handler.clone(),
+			rest_api,
 			keep_alive,
 			reuse_port,
 		);
@@ -338,6 +368,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 				request_middleware.clone(),
 				allowed_hosts.clone(),
 				jsonrpc_handler.clone(),
+				rest_api,
 				keep_alive,
 				reuse_port,
 			);
@@ -376,6 +407,7 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 	request_middleware: Arc<RequestMiddleware>,
 	allowed_hosts: AllowedHosts,
 	jsonrpc_handler: Rpc<M, S>,
+	rest_api: RestApi,
 	keep_alive: bool,
 	reuse_port: bool,
 ) {
@@ -431,6 +463,7 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 						cors_domains.clone(),
 						allowed_hosts.clone(),
 						request_middleware.clone(),
+						rest_api,
 					));
 					Ok(())
 				})


### PR DESCRIPTION
Allows to send simple RPC requests using for instance `curl`:
```
curl -X POST http://localhost:3000/<method>/<param1>
```
Which get's converted to an actual request:
```
{ "id": 1, "jsonrpc": "2.0", "method": <method>, "params": [<param1>]}
```