### PR TITLE
Add helper methods to Output

### DIFF
--- a/core/src/types/response.rs
+++ b/core/src/types/response.rs
@@ -78,10 +78,12 @@ impl Output {
 			Output::Failure(ref f) => &f.id,
 		}
 	}
+}
 
+impl From<Output> for Result<Value, Error> {
 	/// Convert into a result. Will be `Ok` if it is a `Success` and `Err` if `Failure`.
-	pub fn into_result(self) -> Result<Value, Error> {
-		match self {
+	fn from(output: Output) -> Result<Value, Error> {
+		match output {
 			Output::Success(s) => Ok(s.result),
 			Output::Failure(f) => Err(f.error),
 		}

--- a/core/src/types/response.rs
+++ b/core/src/types/response.rs
@@ -62,6 +62,30 @@ impl Output {
 			error: Error::new(ErrorCode::InvalidRequest),
 		})
 	}
+
+	/// Get the jsonrpc protocol version.
+	pub fn version(&self) -> Option<Version> {
+		match *self {
+			Output::Success(ref s) => s.jsonrpc,
+			Output::Failure(ref f) => f.jsonrpc,
+		}
+	}
+
+	/// Get the correlation id.
+	pub fn id(&self) -> &Id {
+		match *self {
+			Output::Success(ref s) => &s.id,
+			Output::Failure(ref f) => &f.id,
+		}
+	}
+
+	/// Convert into a result. Will be `Ok` if it is a `Success` and `Err` if `Failure`.
+	pub fn into_result(self) -> Result<Value, Error> {
+		match self {
+			Output::Success(s) => Ok(s.result),
+			Output::Failure(f) => Err(f.error),
+		}
+	}
 }
 
 impl<'a> Deserialize<'a> for Output {


### PR DESCRIPTION
Handy methods to get the `Id` and `Version` from an `Output` without having to pattern match every time. Very useful for checking incoming `Output` objects that they have the correct id and version before handling the actual content.

Also added the `into_result` since it felt useful.