### PR TITLE
Get rid of Default bound for Metadata.

### DIFF
--- a/core/examples/middlewares.rs
+++ b/core/examples/middlewares.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{self, AtomicUsize};
 use jsonrpc_core::*;
 use jsonrpc_core::futures::Future;
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Debug)]
 struct Meta(usize);
 impl Metadata for Meta {}
 

--- a/core/src/calls.rs
+++ b/core/src/calls.rs
@@ -5,7 +5,7 @@ use futures::{Future, IntoFuture};
 use BoxFuture;
 
 /// Metadata trait
-pub trait Metadata: Default + Clone + Send + 'static {}
+pub trait Metadata: Clone + Send + 'static {}
 impl Metadata for () {}
 
 /// Asynchronous Method

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -287,7 +287,7 @@ impl IoHandler {
 	}
 }
 
-impl<M: Metadata> IoHandler<M> {
+impl<M: Metadata + Default> IoHandler<M> {
 	/// Handle given string request asynchronously.
 	pub fn handle_request(&self, request: &str) -> FutureResult<FutureResponse> {
 		self.0.handle_request(request, M::default())

--- a/ipc/src/meta.rs
+++ b/ipc/src/meta.rs
@@ -29,6 +29,6 @@ impl<M, F> MetaExtractor<M> for F where
 
 /// Noop-extractor
 pub struct NoopExtractor;
-impl<M: Metadata> MetaExtractor<M> for NoopExtractor {
+impl<M: Metadata + Default> MetaExtractor<M> for NoopExtractor {
 	fn extract(&self, _context: &RequestContext) -> M { M::default() }
 }

--- a/ipc/src/server.rs
+++ b/ipc/src/server.rs
@@ -49,14 +49,24 @@ pub struct ServerBuilder<M: Metadata = (), S: Middleware<M> = NoopMiddleware> {
 	outgoing_separator: codecs::Separator,
 }
 
-impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
-	///
+impl<M: Metadata + Default, S: Middleware<M>> ServerBuilder<M, S> {
+	/// Creates new IPC server build given the `IoHandler`.
 	pub fn new<T>(io_handler: T) -> ServerBuilder<M, S> where
 		T: Into<MetaIoHandler<M, S>>,
 	{
+		Self::with_meta_extractor(io_handler, NoopExtractor)
+	}
+}
+
+impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
+	/// Creates new IPC server build given the `IoHandler` and metadata extractor.
+	pub fn with_meta_extractor<T, E>(io_handler: T, extractor: E) -> ServerBuilder<M, S> where
+		T: Into<MetaIoHandler<M, S>>,
+		E: MetaExtractor<M>,
+	{
 		ServerBuilder {
 			handler: Arc::new(io_handler.into()),
-			meta_extractor: Arc::new(NoopExtractor),
+			meta_extractor: Arc::new(extractor),
 			session_stats: None,
 			remote: reactor::UninitializedRemote::Unspawned,
 			incoming_separator: codecs::Separator::Empty,

--- a/macros/examples/meta-macros.rs
+++ b/macros/examples/meta-macros.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 use jsonrpc_core::{futures, MetaIoHandler, Metadata, Error, Value, Result};
 use jsonrpc_core::futures::future::FutureResult;
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 struct Meta(String);
 impl Metadata for Meta {}
 
@@ -62,8 +62,8 @@ fn main() {
 
 	io.extend_with(rpc.to_delegate());
 
-	let server = jsonrpc_tcp_server::ServerBuilder::new(io)
-		.session_meta_extractor(|context: &jsonrpc_tcp_server::RequestContext| {
+	let server = jsonrpc_tcp_server::ServerBuilder
+		::with_meta_extractor(io, |context: &jsonrpc_tcp_server::RequestContext| {
 			Meta(format!("{}", context.peer_addr))
 		})
 		.start(&"0.0.0.0:3030".parse().unwrap())

--- a/macros/examples/pubsub-macros.rs
+++ b/macros/examples/pubsub-macros.rs
@@ -14,15 +14,15 @@ use jsonrpc_pubsub::{Session, PubSubMetadata, PubSubHandler, SubscriptionId};
 
 use jsonrpc_macros::pubsub;
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 struct Meta {
-	session: Option<Arc<Session>>,
+	session: Arc<Session>,
 }
 
 impl Metadata for Meta {}
 impl PubSubMetadata for Meta {
 	fn session(&self) -> Option<Arc<Session>> {
-		self.session.clone()
+		Some(self.session.clone())
 	}
 }
 
@@ -108,10 +108,10 @@ fn main() {
 
 	io.extend_with(rpc.to_delegate());
 
-	let server = jsonrpc_tcp_server::ServerBuilder::new(io)
-		.session_meta_extractor(|context: &jsonrpc_tcp_server::RequestContext| {
+	let server = jsonrpc_tcp_server::ServerBuilder
+		::with_meta_extractor(io, |context: &jsonrpc_tcp_server::RequestContext| {
 			Meta {
-				session: Some(Arc::new(Session::new(context.sender.clone()))),
+				session: Arc::new(Session::new(context.sender.clone())),
 			}
 		})
 		.start(&"0.0.0.0:3030".parse().unwrap())

--- a/pubsub/more-examples/examples/pubsub_ipc.rs
+++ b/pubsub/more-examples/examples/pubsub_ipc.rs
@@ -13,21 +13,13 @@ use jsonrpc_core::futures::Future;
 
 #[derive(Clone)]
 struct Meta {
-	session: Option<Arc<Session>>,
-}
-
-impl Default for Meta {
-	fn default() -> Self {
-		Meta {
-			session: None,
-		}
-	}
+	session: Arc<Session>,
 }
 
 impl Metadata for Meta {}
 impl PubSubMetadata for Meta {
 	fn session(&self) -> Option<Arc<Session>> {
-		self.session.clone()
+		Some(self.session.clone())
 	}
 }
 
@@ -78,10 +70,9 @@ fn main() {
 		}),
 	);
 
-	let server = ServerBuilder::new(io)
-		.session_metadata_extractor(|context: &RequestContext| {
+	let server = ServerBuilder::with_meta_extractor(io, |context: &RequestContext| {
 			Meta {
-				session: Some(Arc::new(Session::new(context.sender.clone()))),
+				session: Arc::new(Session::new(context.sender.clone())),
 			}
 		})
 		.session_stats(Stats)

--- a/pubsub/more-examples/examples/pubsub_ws.rs
+++ b/pubsub/more-examples/examples/pubsub_ws.rs
@@ -13,21 +13,13 @@ use jsonrpc_core::futures::Future;
 
 #[derive(Clone)]
 struct Meta {
-	session: Option<Arc<Session>>,
-}
-
-impl Default for Meta {
-	fn default() -> Self {
-		Meta {
-			session: None,
-		}
-	}
+	session: Arc<Session>,
 }
 
 impl Metadata for Meta {}
 impl PubSubMetadata for Meta {
 	fn session(&self) -> Option<Arc<Session>> {
-		self.session.clone()
+		Some(self.session.clone())
 	}
 }
 
@@ -94,10 +86,9 @@ fn main() {
 		}),
 	);
 
-	let server = ServerBuilder::new(io)
-		.session_meta_extractor(|context: &RequestContext| {
+	let server = ServerBuilder::with_meta_extractor(io, |context: &RequestContext| {
 			Meta {
-				session: Some(Arc::new(Session::new(context.sender()))),
+				session: Arc::new(Session::new(context.sender())),
 			}
 		})
 		.start(&"127.0.0.1:3030".parse().unwrap())

--- a/tcp/src/meta.rs
+++ b/tcp/src/meta.rs
@@ -28,6 +28,6 @@ impl<M, F> MetaExtractor<M> for F where
 
 /// Noop-extractor
 pub struct NoopExtractor;
-impl<M: Metadata> MetaExtractor<M> for NoopExtractor {
+impl<M: Metadata + Default> MetaExtractor<M> for NoopExtractor {
 	fn extract(&self, _context: &RequestContext) -> M { M::default() }
 }

--- a/tcp/src/server.rs
+++ b/tcp/src/server.rs
@@ -20,19 +20,29 @@ pub struct ServerBuilder<M: Metadata = (), S: Middleware<M> = NoopMiddleware> {
 	handler: Arc<MetaIoHandler<M, S>>,
 	meta_extractor: Arc<MetaExtractor<M>>,
 	channels: Arc<SenderChannels>,
-	incoming_separator: codecs::Separator, 
+	incoming_separator: codecs::Separator,
 	outgoing_separator: codecs::Separator,
+}
+
+impl<M: Metadata + Default, S: Middleware<M> + 'static> ServerBuilder<M, S> {
+	/// Creates new `SeverBuilder` wih given `IoHandler`
+	pub fn new<T>(handler: T) -> Self where
+		T: Into<MetaIoHandler<M, S>>,
+	{
+		Self::with_meta_extractor(handler, NoopExtractor)
+	}
 }
 
 impl<M: Metadata, S: Middleware<M> + 'static> ServerBuilder<M, S> {
 	/// Creates new `SeverBuilder` wih given `IoHandler`
-	pub fn new<T>(handler: T) -> Self where
-		T: Into<MetaIoHandler<M, S>>
+	pub fn with_meta_extractor<T, E>(handler: T, extractor: E) -> Self where
+		T: Into<MetaIoHandler<M, S>>,
+		E: MetaExtractor<M> + 'static,
 	{
 		ServerBuilder {
 			remote: reactor::UninitializedRemote::Unspawned,
 			handler: Arc::new(handler.into()),
-			meta_extractor: Arc::new(NoopExtractor),
+			meta_extractor: Arc::new(extractor),
 			channels: Default::default(),
 			incoming_separator: Default::default(),
 			outgoing_separator: Default::default(),

--- a/ws/src/metadata.rs
+++ b/ws/src/metadata.rs
@@ -101,9 +101,7 @@ impl fmt::Debug for RequestContext {
 /// Metadata extractor from session data.
 pub trait MetaExtractor<M: core::Metadata>: Send + Sync + 'static {
 	/// Extract metadata for given session
-	fn extract(&self, _context: &RequestContext) -> M {
-		Default::default()
-	}
+	fn extract(&self, _context: &RequestContext) -> M;
 }
 
 impl<M, F> MetaExtractor<M> for F where
@@ -118,7 +116,9 @@ impl<M, F> MetaExtractor<M> for F where
 /// Dummy metadata extractor
 #[derive(Debug, Clone)]
 pub struct NoopExtractor;
-impl<M: core::Metadata> MetaExtractor<M> for NoopExtractor {}
+impl<M: core::Metadata + Default> MetaExtractor<M> for NoopExtractor {
+	fn extract(&self, _context: &RequestContext) -> M { M::default() }
+}
 
 struct SenderFuture(Sender, mpsc::Receiver<String>);
 impl futures::Future for SenderFuture {

--- a/ws/src/server_builder.rs
+++ b/ws/src/server_builder.rs
@@ -24,14 +24,24 @@ pub struct ServerBuilder<M: core::Metadata, S: core::Middleware<M>> {
 	remote: UninitializedRemote,
 }
 
-impl<M: core::Metadata, S: core::Middleware<M>> ServerBuilder<M, S> {
+impl<M: core::Metadata + Default, S: core::Middleware<M>> ServerBuilder<M, S> {
 	/// Creates new `ServerBuilder`
 	pub fn new<T>(handler: T) -> Self where
 		T: Into<core::MetaIoHandler<M, S>>,
 	{
+		Self::with_meta_extractor(handler, NoopExtractor)
+	}
+}
+
+impl<M: core::Metadata, S: core::Middleware<M>> ServerBuilder<M, S> {
+	/// Creates new `ServerBuilder`
+	pub fn with_meta_extractor<T, E>(handler: T, extractor: E) -> Self where
+		T: Into<core::MetaIoHandler<M, S>>,
+		E: MetaExtractor<M>,
+	{
 		ServerBuilder {
 			handler: Arc::new(handler.into()),
-			meta_extractor: Arc::new(NoopExtractor),
+			meta_extractor: Arc::new(extractor),
 			allowed_origins: None,
 			allowed_hosts: None,
 			request_middleware: None,


### PR DESCRIPTION
Whole `Metadata` doesn't really require `Default` bound, it's only needed to use some methods from `IoHandler`, so the bound has been moved there.