### PR TITLE
Fix Params deserialization on serde_json>=1.0.8

### DIFF
--- a/core/src/types/id.rs
+++ b/core/src/types/id.rs
@@ -29,7 +29,7 @@ impl Serialize for Id {
 impl<'a> Deserialize<'a> for Id {
 	fn deserialize<D>(deserializer: D) -> Result<Id, D::Error>
 	where D: Deserializer<'a> {
-		deserializer.deserialize_identifier(IdVisitor)
+		deserializer.deserialize_any(IdVisitor)
 	}
 }
 

--- a/core/src/types/params.rs
+++ b/core/src/types/params.rs
@@ -50,7 +50,7 @@ struct ParamsVisitor;
 impl<'a> Deserialize<'a> for Params {
 	fn deserialize<D>(deserializer: D) -> Result<Params, D::Error>
 	where D: Deserializer<'a> {
-		deserializer.deserialize_identifier(ParamsVisitor)
+		deserializer.deserialize_any(ParamsVisitor)
 	}
 }
 


### PR DESCRIPTION
Due to https://github.com/serde-rs/json/pull/389, serde_json no longer calls `deserialize_any` in `deserialize_identifer` (and all other default implemented methods). This causes `Params` to fail to deserialize maps and sequences since it has hinted that it expects an identifier.

This implements `deserialize` correctly, saying that it accepts any type.

cc @dtolnay (thought you might want to be aware of this regression/bug)