### PR TITLE
[WIP] Re-export jsonrpc-core from servers

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -9,29 +9,27 @@ Rust http server using JSON-RPC 2.0.
 
 ```
 [dependencies]
-jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc" }
 jsonrpc-http-server = { git = "https://github.com/paritytech/jsonrpc" }
 ```
 
 `main.rs`
 
 ```rust
-extern crate jsonrpc_core;
 extern crate jsonrpc_http_server;
 
-use jsonrpc_core::*;
 use jsonrpc_http_server::*;
+use jsonrpc_http_server::jsonrpc_core::*;
 
 fn main() {
-    let mut io = IoHandler::default();
-    io.add_method("say_hello", |_| {
+	let mut io = IoHandler::default();
+	io.add_method("say_hello", |_| {
 		Ok(Value::String("hello".into()))
 	});
 
-    let server = ServerBuilder::new(io)
-			.cors(DomainsValidation::AllowOnly(vec![AccessControlAllowOrigin::Null]))
-			.start_http(&"127.0.0.1:3030".parse().unwrap())
-			.expect("Unable to start RPC server");
+	let server = ServerBuilder::new(io)
+		.cors(DomainsValidation::AllowOnly(vec![AccessControlAllowOrigin::Null]))
+		.start_http(&"127.0.0.1:3030".parse().unwrap())
+		.expect("Unable to start RPC server");
 
 	server.wait().unwrap();
 }

--- a/http/examples/http_async.rs
+++ b/http/examples/http_async.rs
@@ -1,8 +1,7 @@
-extern crate jsonrpc_core;
 extern crate jsonrpc_http_server;
 
-use jsonrpc_core::*;
 use jsonrpc_http_server::{ServerBuilder, DomainsValidation, AccessControlAllowOrigin};
+use jsonrpc_http_server::jsonrpc_core::*;
 
 fn main() {
 	let mut io = IoHandler::default();

--- a/http/examples/http_meta.rs
+++ b/http/examples/http_meta.rs
@@ -1,8 +1,7 @@
-extern crate jsonrpc_core;
 extern crate jsonrpc_http_server;
 
-use jsonrpc_core::*;
 use jsonrpc_http_server::{ServerBuilder, hyper, RestApi};
+use jsonrpc_http_server::jsonrpc_core::*;
 use self::hyper::header;
 
 #[derive(Default, Clone)]

--- a/http/examples/http_middleware.rs
+++ b/http/examples/http_middleware.rs
@@ -1,11 +1,10 @@
-extern crate jsonrpc_core;
 extern crate jsonrpc_http_server;
 
-use jsonrpc_core::{IoHandler, Value};
-use jsonrpc_core::futures;
 use jsonrpc_http_server::{
 	hyper, ServerBuilder, DomainsValidation, AccessControlAllowOrigin, Response, RestApi
 };
+use jsonrpc_http_server::jsonrpc_core::{IoHandler, Value};
+use jsonrpc_http_server::jsonrpc_core::futures;
 
 fn main() {
 	let mut io = IoHandler::default();

--- a/http/examples/server.rs
+++ b/http/examples/server.rs
@@ -1,8 +1,7 @@
-extern crate jsonrpc_core;
 extern crate jsonrpc_http_server;
 
-use jsonrpc_core::*;
 use jsonrpc_http_server::{ServerBuilder, DomainsValidation, AccessControlAllowOrigin, RestApi};
+use jsonrpc_http_server::jsonrpc_core::*;
 
 fn main() {
 	let mut io = IoHandler::default();

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -20,10 +20,10 @@
 #![warn(missing_docs)]
 
 extern crate unicase;
-extern crate jsonrpc_core as jsonrpc;
 extern crate jsonrpc_server_utils as server_utils;
 extern crate net2;
 
+pub extern crate jsonrpc_core;
 pub extern crate hyper;
 
 #[macro_use]
@@ -40,6 +40,7 @@ use std::sync::{mpsc, Arc};
 use std::net::SocketAddr;
 
 use hyper::server;
+use jsonrpc_core as jsonrpc;
 use jsonrpc::MetaIoHandler;
 use jsonrpc::futures::{self, Future, Stream};
 use jsonrpc::futures::sync::oneshot;

--- a/ipc/README.md
+++ b/ipc/README.md
@@ -9,18 +9,16 @@ IPC server (Windows & Linux) for JSON-RPC 2.0.
 
 ```
 [dependencies]
-jsonrpc-core = "6.0"
-jsonrpc-ipc-server = "6.0"
+jsonrpc-ipc-server = { git = "https://github.com/paritytech/jsonrpc" }
 ```
 
 `main.rs`
 
 ```rust
-extern crate jsonrpc_core;
 extern crate jsonrpc_ipc_server;
 
-use jsonrpc_core::*;
 use jsonrpc_ipc_server::Server;
+use jsonrpc_ipc_server::jsonrpc_core::*;
 
 fn main() {
 	let mut io = IoHandler::new();

--- a/ipc/examples/ipc.rs
+++ b/ipc/examples/ipc.rs
@@ -1,7 +1,6 @@
-extern crate jsonrpc_core;
 extern crate jsonrpc_ipc_server;
 
-use jsonrpc_core::*;
+use jsonrpc_ipc_server::jsonrpc_core::*;
 
 fn main() {
 	let mut io = MetaIoHandler::<()>::default();
@@ -9,5 +8,5 @@ fn main() {
 		Ok(Value::String("hello".to_string()))
 	});
 	let _server = jsonrpc_ipc_server::ServerBuilder::new(io)
-			.start("/tmp/parity-example.ipc").expect("Server should start ok");
+		.start("/tmp/parity-example.ipc").expect("Server should start ok");
 }

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -2,10 +2,11 @@
 
 #![warn(missing_docs)]
 
-extern crate jsonrpc_core as jsonrpc;
 extern crate jsonrpc_server_utils as server_utils;
 extern crate parity_tokio_ipc;
 extern crate tokio_service;
+
+pub extern crate jsonrpc_core;
 
 #[macro_use] extern crate log;
 
@@ -15,6 +16,9 @@ extern crate tokio_service;
 
 mod server;
 mod meta;
+
+use jsonrpc_core as jsonrpc;
+
 pub use meta::{MetaExtractor, RequestContext};
 pub use server::{Server, ServerBuilder};
 

--- a/minihttp/README.md
+++ b/minihttp/README.md
@@ -9,18 +9,16 @@ Blazing fast HTTP server for JSON-RPC 2.0.
 
 ```
 [dependencies]
-jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc" }
 jsonrpc-minihttp-server = { git = "https://github.com/paritytech/jsonrpc" }
 ```
 
 `main.rs`
 
 ```rust
-extern crate jsonrpc_core;
 extern crate jsonrpc_minihttp_server;
 
-use jsonrpc_core::*;
 use jsonrpc_minihttp_server::*;
+use jsonrpc_minihttp_server::jsonrpc_core::*;
 
 fn main() {
     let mut io = IoHandler::default();
@@ -29,9 +27,9 @@ fn main() {
 	});
 
     let server = ServerBuilder::new(io)
-			.cors(DomainsValidation::AllowOnly(vec![AccessControlAllowOrigin::Null]))
-			.start_http(&"127.0.0.1:3030".parse().unwrap())
-			.expect("Unable to start RPC server");
+		.cors(DomainsValidation::AllowOnly(vec![AccessControlAllowOrigin::Null]))
+		.start_http(&"127.0.0.1:3030".parse().unwrap())
+		.expect("Unable to start RPC server");
 
 	server.wait().unwrap();
 }

--- a/minihttp/examples/http_async.rs
+++ b/minihttp/examples/http_async.rs
@@ -1,9 +1,7 @@
-extern crate jsonrpc_core;
 extern crate jsonrpc_minihttp_server;
 
-
-use jsonrpc_core::*;
 use jsonrpc_minihttp_server::{cors, ServerBuilder, DomainsValidation};
+use jsonrpc_minihttp_server::jsonrpc_core::*;
 
 fn main() {
 	let mut io = IoHandler::default();

--- a/minihttp/examples/http_meta.rs
+++ b/minihttp/examples/http_meta.rs
@@ -1,8 +1,7 @@
-extern crate jsonrpc_core;
 extern crate jsonrpc_minihttp_server;
 
-use jsonrpc_core::*;
 use jsonrpc_minihttp_server::{cors, ServerBuilder, DomainsValidation, Req};
+use jsonrpc_minihttp_server::jsonrpc_core::*;
 
 #[derive(Clone, Default)]
 struct Meta(usize);

--- a/minihttp/examples/server.rs
+++ b/minihttp/examples/server.rs
@@ -1,8 +1,7 @@
-extern crate jsonrpc_core;
 extern crate jsonrpc_minihttp_server;
 
-use jsonrpc_core::*;
 use jsonrpc_minihttp_server::{cors, ServerBuilder, DomainsValidation};
+use jsonrpc_minihttp_server::jsonrpc_core::*;
 
 fn main() {
 	let mut io = IoHandler::default();

--- a/minihttp/src/lib.rs
+++ b/minihttp/src/lib.rs
@@ -20,12 +20,13 @@
 #![warn(missing_docs)]
 
 extern crate bytes;
-extern crate jsonrpc_core as jsonrpc;
 extern crate jsonrpc_server_utils;
 extern crate parking_lot;
 extern crate tokio_proto;
 extern crate tokio_service;
 extern crate tokio_minihttp;
+
+pub extern crate jsonrpc_core;
 
 #[macro_use]
 extern crate log;
@@ -40,6 +41,7 @@ use std::sync::{Arc, mpsc};
 use std::net::SocketAddr;
 use std::thread;
 use parking_lot::RwLock;
+use jsonrpc_core as jsonrpc;
 use jsonrpc::futures::{self, future, Future};
 use jsonrpc::{FutureResult, MetaIoHandler, Response};
 use jsonrpc_server_utils::hosts;

--- a/tcp/README.md
+++ b/tcp/README.md
@@ -9,18 +9,16 @@ TCP server for JSON-RPC 2.0.
 
 ```
 [dependencies]
-jsonrpc-core = "6.0"
-jsonrpc-tcp-server = "6.0"
+jsonrpc-tcp-server = { git = "https://github.com/paritytech/jsonrpc" }
 ```
 
 `main.rs`
 
 ```rust
-extern crate jsonrpc_core;
 extern crate jsonrpc_tcp_server;
 
-use jsonrpc_core::*;
 use jsonrpc_tcp_server::*;
+use jsonrpc_tcp_server::jsonrpc_core::*;
 
 fn main() {
 	let mut io = IoHandler::default();

--- a/tcp/examples/tcp.rs
+++ b/tcp/examples/tcp.rs
@@ -1,8 +1,7 @@
-extern crate jsonrpc_core;
 extern crate jsonrpc_tcp_server;
 
-use jsonrpc_core::*;
 use jsonrpc_tcp_server::ServerBuilder;
+use jsonrpc_tcp_server::jsonrpc_core::*;
 
 fn main() {
 	let mut io = IoHandler::default();

--- a/tcp/src/lib.rs
+++ b/tcp/src/lib.rs
@@ -22,10 +22,11 @@
 
 #![warn(missing_docs)]
 
-extern crate jsonrpc_core as jsonrpc;
 extern crate jsonrpc_server_utils as server_utils;
 extern crate parking_lot;
 extern crate tokio_service;
+
+pub extern crate jsonrpc_core;
 
 #[macro_use] extern crate log;
 
@@ -39,6 +40,8 @@ mod service;
 
 #[cfg(test)] mod logger;
 #[cfg(test)] mod tests;
+
+use jsonrpc_core as jsonrpc;
 
 pub use dispatch::{Dispatcher, PushMessageError};
 pub use meta::{MetaExtractor, RequestContext};

--- a/ws/README.md
+++ b/ws/README.md
@@ -9,18 +9,16 @@ WebSockets server for JSON-RPC 2.0.
 
 ```
 [dependencies]
-jsonrpc-core = "6.0"
-jsonrpc-ws-server = "6.0"
+jsonrpc-ws-server = { git = "https://github.com/paritytech/jsonrpc" }
 ```
 
 `main.rs`
 
 ```rust
-extern crate jsonrpc_core;
 extern crate jsonrpc_ws_server;
 
-use jsonrpc_core::*;
 use jsonrpc_ws_server::*;
+use jsonrpc_ws_server::jsonrpc_core::*;
 
 fn main() {
 	let mut io = IoHandler::new();

--- a/ws/examples/ws.rs
+++ b/ws/examples/ws.rs
@@ -1,8 +1,7 @@
-extern crate jsonrpc_core;
 extern crate jsonrpc_ws_server;
 
-use jsonrpc_core::*;
 use jsonrpc_ws_server::ServerBuilder;
+use jsonrpc_ws_server::jsonrpc_core::*;
 
 fn main() {
 	let mut io = IoHandler::default();

--- a/ws/src/lib.rs
+++ b/ws/src/lib.rs
@@ -2,12 +2,12 @@
 
 #![warn(missing_docs)]
 
-extern crate jsonrpc_core as core;
 extern crate jsonrpc_server_utils as server_utils;
 extern crate parking_lot;
 extern crate slab;
 
 pub extern crate ws;
+pub extern crate jsonrpc_core;
 
 #[macro_use]
 extern crate error_chain;
@@ -21,6 +21,8 @@ mod server_builder;
 mod session;
 #[cfg(test)]
 mod tests;
+
+use jsonrpc_core as core;
 
 pub use self::error::{Error, ErrorKind, Result};
 pub use self::metadata::{RequestContext, MetaExtractor, NoopExtractor};


### PR DESCRIPTION
Closes #84 

Hello,

just opening this to ensure I am a right way.

Do we want to re-export `jsonrpc_core` like this? 
And then to use it in examples like 
```
extern crate jsonrpc_http_server;

use jsonrpc_http_server::*;
use jsonrpc_http_server::jsonrpc_core::*;

fn main() {...}
```

Or maybe we want to choose another name for re-exporting, e.g. just `core`?