### PR TITLE
Enable sleep on IO errors to handle large amount of paralell requests…

### DIFF
--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -430,6 +430,7 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 			let http = {
 				let mut http = server::Http::new();
 				http.keep_alive(keep_alive);
+				http.sleep_on_errors(true);
 				http
 			};
 			listener.incoming()


### PR DESCRIPTION
… gracefuly.