### PR TITLE
Only process request bodies up to a maximum size.

### DIFF
--- a/http/src/handler.rs
+++ b/http/src/handler.rs
@@ -1,6 +1,6 @@
 use Rpc;
 
-use std::{fmt, mem};
+use std::{fmt, mem, str};
 use std::sync::Arc;
 
 use hyper::{self, mime, server, Method};
@@ -22,6 +22,7 @@ pub struct ServerHandler<M: Metadata = (), S: Middleware<M> = NoopMiddleware> {
 	cors_domains: CorsDomains,
 	middleware: Arc<RequestMiddleware>,
 	rest_api: RestApi,
+	max_request_body_size: usize,
 }
 
 impl<M: Metadata, S: Middleware<M>> ServerHandler<M, S> {
@@ -32,6 +33,7 @@ impl<M: Metadata, S: Middleware<M>> ServerHandler<M, S> {
 		allowed_hosts: AllowedHosts,
 		middleware: Arc<RequestMiddleware>,
 		rest_api: RestApi,
+		max_request_body_size: usize,
 	) -> Self {
 		ServerHandler {
 			jsonrpc_handler,
@@ -39,6 +41,7 @@ impl<M: Metadata, S: Middleware<M>> ServerHandler<M, S> {
 			cors_domains,
 			middleware,
 			rest_api,
+			max_request_body_size,
 		}
 	}
 }
@@ -81,6 +84,7 @@ impl<M: Metadata, S: Middleware<M>> server::Service for ServerHandler<M, S> {
 					is_options: false,
 					cors_header: cors::CorsHeader::NotRequired,
 					rest_api: self.rest_api,
+					max_request_body_size: self.max_request_body_size,
 				})
 			}
 		}
@@ -173,6 +177,7 @@ pub struct RpcHandler<M: Metadata, S: Middleware<M>> {
 	is_options: bool,
 	cors_header: cors::CorsHeader<header::AccessControlAllowOrigin>,
 	rest_api: RestApi,
+	max_request_body_size: usize,
 }
 
 impl<M: Metadata, S: Middleware<M>> Future for RpcHandler<M, S> {
@@ -189,7 +194,19 @@ impl<M: Metadata, S: Middleware<M>> Future for RpcHandler<M, S> {
 				RpcPollState::Ready(self.read_headers(request, continue_on_invalid_cors))
 			},
 			RpcHandlerState::ReadingBody { body, request, metadata, uri, } => {
-				self.process_body(body, request, uri, metadata)?
+				match self.process_body(body, request, uri, metadata) {
+					Err(BodyError::Utf8(ref e)) => {
+						let mesg = format!("utf-8 encoding error at byte {} in request body", e.valid_up_to());
+						let resp = Response::bad_request(mesg);
+						RpcPollState::Ready(RpcHandlerState::Writing(resp))
+					}
+					Err(BodyError::TooLarge) => {
+						let resp = Response::bad_request("request body size exceeds allowed maximum");
+						RpcPollState::Ready(RpcHandlerState::Writing(resp))
+					}
+					Err(BodyError::Hyper(e)) => return Err(e),
+					Ok(state) => state,
+				}
 			},
 			RpcHandlerState::ProcessRest { uri, metadata } => {
 				self.process_rest(uri, metadata)?
@@ -228,6 +245,20 @@ impl<M: Metadata, S: Middleware<M>> Future for RpcHandler<M, S> {
 				}
 			},
 		}
+	}
+}
+
+// Intermediate and internal error type to better distinguish
+// error cases occuring during request body processing.
+enum BodyError {
+	Hyper(hyper::Error),
+	Utf8(str::Utf8Error),
+	TooLarge,
+}
+
+impl From<hyper::Error> for BodyError {
+	fn from(e: hyper::Error) -> BodyError {
+		BodyError::Hyper(e)
 	}
 }
 
@@ -319,11 +350,17 @@ impl<M: Metadata, S: Middleware<M>> RpcHandler<M, S> {
 		mut request: Vec<u8>,
 		uri: Option<hyper::Uri>,
 		metadata: M,
-	) -> Result<RpcPollState<M, S::Future>, hyper::Error> {
+	) -> Result<RpcPollState<M, S::Future>, BodyError> {
 		loop {
 			match body.poll()? {
-				// TODO [ToDr] reject too large requests?
 				Async::Ready(Some(chunk)) => {
+					// first check if this chunk itself is too large (in case it is already
+					// equal to `usize::MAX` where addition would overflow)
+					if chunk.len() > self.max_request_body_size
+						|| request.len() + chunk.len() > self.max_request_body_size
+					{
+						return Err(BodyError::TooLarge)
+					}
 					request.extend_from_slice(&*chunk)
 				},
 				Async::Ready(None) => {
@@ -334,11 +371,11 @@ impl<M: Metadata, S: Middleware<M>> RpcHandler<M, S> {
 						}));
 					}
 
-					let content = match ::std::str::from_utf8(&request) {
+					let content = match str::from_utf8(&request) {
 						Ok(content) => content,
 						Err(err) => {
 							// Return utf error.
-							return Err(hyper::Error::Utf8(err));
+							return Err(BodyError::Utf8(err));
 						},
 					};
 

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -196,6 +196,7 @@ pub struct ServerBuilder<M: jsonrpc::Metadata = (), S: jsonrpc::Middleware<M> = 
 	rest_api: RestApi,
 	keep_alive: bool,
 	threads: usize,
+	max_request_body_size: usize,
 }
 
 const SENDER_PROOF: &'static str = "Server initialization awaits local address.";
@@ -233,6 +234,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 			rest_api: RestApi::Disabled,
 			keep_alive: true,
 			threads: 1,
+			max_request_body_size: 5 * 1024 * 1024,
 		}
 	}
 
@@ -304,6 +306,12 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 		self
 	}
 
+	/// Sets the maximum size of a request body in bytes (default is 5 MiB).
+	pub fn max_request_body_size(mut self, val: usize) -> Self {
+		self.max_request_body_size = val;
+		self
+	}
+
 	/// Start this JSON-RPC HTTP server trying to bind to specified `SocketAddr`.
 	pub fn start_http(self, addr: &SocketAddr) -> io::Result<Server> {
 		let cors_domains = self.cors_domains;
@@ -320,6 +328,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 		let (local_addr_tx, local_addr_rx) = mpsc::channel();
 		let (close, shutdown_signal) = oneshot::channel();
 		let eloop = self.remote.init_with_name("http.worker0")?;
+		let req_max_size = self.max_request_body_size;
 		serve(
 			(shutdown_signal, local_addr_tx),
 			eloop.remote(),
@@ -331,6 +340,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 			rest_api,
 			keep_alive,
 			reuse_port,
+			req_max_size,
 		);
 		let handles = (0..self.threads - 1).map(|i| {
 			let (local_addr_tx, local_addr_rx) = mpsc::channel();
@@ -347,6 +357,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 				rest_api,
 				keep_alive,
 				reuse_port,
+				req_max_size,
 			);
 			Ok((eloop, close, local_addr_rx))
 		}).collect::<io::Result<Vec<_>>>()?;
@@ -386,6 +397,7 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 	rest_api: RestApi,
 	keep_alive: bool,
 	reuse_port: bool,
+	max_request_body_size: usize,
 ) {
 	let (shutdown_signal, local_addr_tx) = signals;
 	remote.spawn(move |handle| {
@@ -441,6 +453,7 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 						allowed_hosts.clone(),
 						request_middleware.clone(),
 						rest_api,
+						max_request_body_size,
 					));
 					Ok(())
 				})

--- a/http/src/response.rs
+++ b/http/src/response.rs
@@ -83,6 +83,15 @@ impl Response {
 			content: msg.into()
 		}
 	}
+
+	/// Create a response for too large (413)
+	pub fn too_large<S: Into<String>>(msg: S) -> Self {
+		Response {
+			code: StatusCode::PayloadTooLarge,
+			content_type: header::ContentType::plaintext(),
+			content: msg.into()
+		}
+	}
 }
 
 impl Into<server::Response> for Response {

--- a/http/src/response.rs
+++ b/http/src/response.rs
@@ -74,6 +74,15 @@ impl Response {
 			content: "Origin of the request is not whitelisted. CORS headers would not be sent and any side-effects were cancelled as well.\n".to_owned(),
 		}
 	}
+
+	/// Create a response for bad request
+	pub fn bad_request<S: Into<String>>(msg: S) -> Self {
+		Response {
+			code: StatusCode::BadRequest,
+			content_type: header::ContentType::plaintext(),
+			content: msg.into()
+		}
+	}
 }
 
 impl Into<server::Response> for Response {

--- a/http/src/tests.rs
+++ b/http/src/tests.rs
@@ -369,7 +369,7 @@ fn should_not_allow_request_larger_than_max() {
 			12345678\r\n\
 		"
 	);
-	assert_eq!(response.status, "HTTP/1.1 400 Bad Request".to_owned());
+	assert_eq!(response.status, "HTTP/1.1 413 Payload Too Large".to_owned());
 }
 
 #[test]

--- a/http/src/tests.rs
+++ b/http/src/tests.rs
@@ -352,6 +352,27 @@ fn should_add_cors_header_for_null_origin() {
 }
 
 #[test]
+fn should_not_allow_request_larger_than_max() {
+	let server = ServerBuilder::new(IoHandler::default())
+		.max_request_body_size(7)
+		.start_http(&"127.0.0.1:0".parse().unwrap())
+		.unwrap();
+
+	let response = request(server,
+		"\
+			POST / HTTP/1.1\r\n\
+			Host: 127.0.0.1:8080\r\n\
+			Connection: close\r\n\
+			Content-Length: 8\r\n\
+			Content-Type: application/json\r\n\
+			\r\n\
+			12345678\r\n\
+		"
+	);
+	assert_eq!(response.status, "HTTP/1.1 400 Bad Request".to_owned());
+}
+
+#[test]
 fn should_reject_invalid_hosts() {
 	// given
 	let server = serve_hosts(vec!["parity.io".into()]);


### PR DESCRIPTION
Return 400 response if request body size exceeds maximum.