### PR TITLE
Backports of #243, #244, #249 into 1.10

### DIFF
--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -441,6 +441,7 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 			let http = {
 				let mut http = server::Http::new();
 				http.keep_alive(keep_alive);
+				http.sleep_on_errors(true);
 				http
 			};
 			listener.incoming()

--- a/http/src/response.rs
+++ b/http/src/response.rs
@@ -74,6 +74,24 @@ impl Response {
 			content: "Origin of the request is not whitelisted. CORS headers would not be sent and any side-effects were cancelled as well.\n".to_owned(),
 		}
 	}
+
+	/// Create a response for bad request
+	pub fn bad_request<S: Into<String>>(msg: S) -> Self {
+		Response {
+			code: StatusCode::BadRequest,
+			content_type: header::ContentType::plaintext(),
+			content: msg.into()
+		}
+	}
+
+	/// Create a response for too large (413)
+	pub fn too_large<S: Into<String>>(msg: S) -> Self {
+		Response {
+			code: StatusCode::PayloadTooLarge,
+			content_type: header::ContentType::plaintext(),
+			content: msg.into()
+		}
+	}
 }
 
 impl Into<server::Response> for Response {

--- a/http/src/tests.rs
+++ b/http/src/tests.rs
@@ -352,6 +352,27 @@ fn should_add_cors_header_for_null_origin() {
 }
 
 #[test]
+fn should_not_allow_request_larger_than_max() {
+	let server = ServerBuilder::new(IoHandler::default())
+		.max_request_body_size(7)
+		.start_http(&"127.0.0.1:0".parse().unwrap())
+		.unwrap();
+
+	let response = request(server,
+		"\
+			POST / HTTP/1.1\r\n\
+			Host: 127.0.0.1:8080\r\n\
+			Connection: close\r\n\
+			Content-Length: 8\r\n\
+			Content-Type: application/json\r\n\
+			\r\n\
+			12345678\r\n\
+		"
+	);
+	assert_eq!(response.status, "HTTP/1.1 413 Payload Too Large".to_owned());
+}
+
+#[test]
 fn should_reject_invalid_hosts() {
 	// given
 	let server = serve_hosts(vec!["parity.io".into()]);

--- a/ws/src/server.rs
+++ b/ws/src/server.rs
@@ -52,8 +52,14 @@ impl Server {
 	) -> Result<Server> {
 		let config = {
 			let mut config = ws::Settings::default();
+			// don't grow non-final fragments (to prevent DOS)
+			config.fragments_grow = false;
+			// don't accept super large requests
+			config.max_in_buffer = 5 * 1024 * 1024; // 5MB
 			// accept only handshakes beginning with GET
 			config.method_strict = true;
+			// require masking
+			config.masking_strict = true;
 			// Was shutting down server when suspending on linux:
 			config.shutdown_on_interrupt = false;
 			config


### PR DESCRIPTION
* Only process request bodies up to a maximum size.

Return 400 response if request body size exceeds maximum.

* Return 413 response if body too large.

Also use `checked_add` to determine body length.