### PR TITLE
Backports of #243, #244, #249 into 1.9

### DIFF
--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -193,6 +193,7 @@ pub struct ServerBuilder<M: jsonrpc::Metadata = (), S: jsonrpc::Middleware<M> = 
 	rest_api: RestApi,
 	keep_alive: bool,
 	threads: usize,
+	max_request_body_size: usize,
 }
 
 const SENDER_PROOF: &'static str = "Server initialization awaits local address.";
@@ -219,6 +220,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 			rest_api: RestApi::Disabled,
 			keep_alive: true,
 			threads: 1,
+			max_request_body_size: 5 * 1024 * 1024,
 		}
 	}
 
@@ -290,6 +292,12 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 		self
 	}
 
+	/// Sets the maximum size of a request body in bytes (default is 5 MiB).
+	pub fn max_request_body_size(mut self, val: usize) -> Self {
+		self.max_request_body_size = val;
+		self
+	}
+
 	/// Start this JSON-RPC HTTP server trying to bind to specified `SocketAddr`.
 	pub fn start_http(self, addr: &SocketAddr) -> io::Result<Server> {
 		let cors_domains = self.cors_domains;
@@ -306,6 +314,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 		let (local_addr_tx, local_addr_rx) = mpsc::channel();
 		let (close, shutdown_signal) = oneshot::channel();
 		let eloop = self.remote.init_with_name("http.worker0")?;
+		let req_max_size = self.max_request_body_size;
 		serve(
 			(shutdown_signal, local_addr_tx),
 			eloop.remote(),
@@ -317,6 +326,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 			rest_api,
 			keep_alive,
 			reuse_port,
+			req_max_size,
 		);
 		let handles = (0..self.threads - 1).map(|i| {
 			let (local_addr_tx, local_addr_rx) = mpsc::channel();
@@ -333,6 +343,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 				rest_api,
 				keep_alive,
 				reuse_port,
+				req_max_size,
 			);
 			Ok((eloop, close, local_addr_rx))
 		}).collect::<io::Result<Vec<_>>>()?;
@@ -372,6 +383,7 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 	rest_api: RestApi,
 	keep_alive: bool,
 	reuse_port: bool,
+	max_request_body_size: usize,
 ) {
 	let (shutdown_signal, local_addr_tx) = signals;
 	remote.spawn(move |handle| {
@@ -426,6 +438,7 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 						allowed_hosts.clone(),
 						request_middleware.clone(),
 						rest_api,
+						max_request_body_size,
 					));
 					Ok(())
 				})

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -428,6 +428,7 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 			let http = {
 				let mut http = server::Http::new();
 				http.keep_alive(keep_alive);
+				http.sleep_on_errors(true);
 				http
 			};
 			listener.incoming()

--- a/http/src/response.rs
+++ b/http/src/response.rs
@@ -74,6 +74,24 @@ impl Response {
 			content: "Origin of the request is not whitelisted. CORS headers would not be sent and any side-effects were cancelled as well.\n".to_owned(),
 		}
 	}
+
+	/// Create a response for bad request
+	pub fn bad_request<S: Into<String>>(msg: S) -> Self {
+		Response {
+			code: StatusCode::BadRequest,
+			content_type: header::ContentType::plaintext(),
+			content: msg.into()
+		}
+	}
+
+	/// Create a response for too large (413)
+	pub fn too_large<S: Into<String>>(msg: S) -> Self {
+		Response {
+			code: StatusCode::PayloadTooLarge,
+			content_type: header::ContentType::plaintext(),
+			content: msg.into()
+		}
+	}
 }
 
 impl Into<server::Response> for Response {

--- a/http/src/tests.rs
+++ b/http/src/tests.rs
@@ -352,6 +352,27 @@ fn should_add_cors_header_for_null_origin() {
 }
 
 #[test]
+fn should_not_allow_request_larger_than_max() {
+	let server = ServerBuilder::new(IoHandler::default())
+		.max_request_body_size(7)
+		.start_http(&"127.0.0.1:0".parse().unwrap())
+		.unwrap();
+
+	let response = request(server,
+		"\
+			POST / HTTP/1.1\r\n\
+			Host: 127.0.0.1:8080\r\n\
+			Connection: close\r\n\
+			Content-Length: 8\r\n\
+			Content-Type: application/json\r\n\
+			\r\n\
+			12345678\r\n\
+		"
+	);
+	assert_eq!(response.status, "HTTP/1.1 413 Payload Too Large".to_owned());
+}
+
+#[test]
 fn should_reject_invalid_hosts() {
 	// given
 	let server = serve_hosts(vec!["parity.io".into()]);

--- a/ws/src/server.rs
+++ b/ws/src/server.rs
@@ -52,8 +52,14 @@ impl Server {
 	) -> Result<Server> {
 		let config = {
 			let mut config = ws::Settings::default();
+			// don't grow non-final fragments (to prevent DOS)
+			config.fragments_grow = false;
+			// don't accept super large requests
+			config.max_in_buffer = 5 * 1024 * 1024; // 5MB
 			// accept only handshakes beginning with GET
 			config.method_strict = true;
+			// require masking
+			config.masking_strict = true;
 			// Was shutting down server when suspending on linux:
 			config.shutdown_on_interrupt = false;
 			config


### PR DESCRIPTION
* Only process request bodies up to a maximum size.

Return 400 response if request body size exceeds maximum.

* Return 413 response if body too large.

Also use `checked_add` to determine body length.