### PR TITLE
Return error when method is missing in unsecure REST.

### DIFF
--- a/http/src/handler.rs
+++ b/http/src/handler.rs
@@ -287,7 +287,7 @@ impl<M: Metadata, S: Middleware<M>> RpcHandler<M, S> {
 					body: request.body(),
 				}
 			},
-			Method::Post if self.rest_api == RestApi::Unsecure => {
+			Method::Post if self.rest_api == RestApi::Unsecure && request.uri().path().split('/').count() > 2 => {
 				RpcHandlerState::ProcessRest {
 					metadata,
 					uri: request.uri().clone(),


### PR DESCRIPTION
Currently you get "Method not found" error (since it tries to invoke method `""`). It's a bit misleading since we have both REST and regular RPC enabled and most likely you tried to use the latter but forgot to add the `Content-type` header.

(described situation actually happened in Polkadot RPC)