### PR TITLE
Set Access-Control-Max-Age header to 600 to prevent every request having an OPTIONS request.

### DIFF
--- a/http/src/handler.rs
+++ b/http/src/handler.rs
@@ -413,6 +413,9 @@ impl<M: Metadata, S: Middleware<M>> RpcHandler<M, S> {
 				Ascii::new("content-type".to_owned()),
 				Ascii::new("accept".to_owned()),
 			]));
+			headers.set(header::AccessControlMaxAge(vec![
+				Ascii::new("600".to_owned()),
+			]));
 			headers.set(cors_domain);
 			headers.set(header::Vary::Items(vec![
 				Ascii::new("origin".to_owned())


### PR DESCRIPTION
How about this one?

https://github.com/paritytech/parity/issues/8542
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
https://stackoverflow.com/questions/17432982/should-i-expect-options-preflight-with-all-cors-requests