### PR TITLE
DOC: Updated example code in README

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -31,6 +31,6 @@ fn main() {
 		.start_http(&"127.0.0.1:3030".parse().unwrap())
 		.expect("Unable to start RPC server");
 
-	server.wait().unwrap();
+	server.wait();
 }
 ```


### PR DESCRIPTION
`server.wait().unwrap();` throws "no method named `unwrap` found for type `()` in the current scope". Removing the `unwrap()` call makes the code run.