### PR TITLE
initial commit to confirm location of issue

### DIFF
--- a/server-utils/src/cors.rs
+++ b/server-utils/src/cors.rs
@@ -102,6 +102,9 @@ impl ops::Deref for Origin {
 
 /// Origins allowed to access
 #[derive(Debug, Clone, PartialEq, Eq)]
+
+/// 1) Adding new CORS protocol to enum below
+
 pub enum AccessControlAllowOrigin {
 	/// Specific hostname
 	Value(Origin),
@@ -274,6 +277,8 @@ mod tests {
 		assert_eq!(res, CorsHeader::NotRequired);
 	}
 
+// 2) This test needs to pass when new CORS requirements added
+
 	#[test]
 	fn should_return_domain_when_all_are_allowed() {
 		// given
@@ -316,6 +321,8 @@ mod tests {
 		// then
 		assert_eq!(res, CorsHeader::NotRequired);
 	}
+
+// 2.5) Need to make sure this still "passes" (i.e. request fails), correct?
 
 	#[test]
 	fn should_return_none_for_not_matching_origin() {

--- a/server-utils/src/cors.rs
+++ b/server-utils/src/cors.rs
@@ -136,6 +136,14 @@ impl<T: Into<String>> From<T> for AccessControlAllowOrigin {
 
 /// CORS Header Result.
 #[derive(Debug, Clone, PartialEq, Eq)]
+
+pub enum AllowedCorsHeaders {
+	/// Accept all incoming header requests
+	Any,
+	/// Accept only headers listed below:
+	Only(Vec<CorsHeader>),
+}
+
 pub enum CorsHeader<T = AccessControlAllowOrigin> {
 	/// CORS header was not required. Origin is not present in the request.
 	NotRequired,


### PR DESCRIPTION
This is in regards to [issue #6616](https://github.com/paritytech/parity/issues/6616) filed in `paritytech/parity`, but actually traces back to this dependency. 

From the issue:

```
For maximum compatibility, Parity should echo back all the headers from Access-Control-Request-Headers in Access-Control-Allow-Headers. There could be a blacklist of headers that web pages should be prohibited from sending, but I don't think Parity trusts the RPC headers at all anyway, so I can't think of a reason not to just let pages send whatever they want.
```

@tomusdrw I wanted to check with you (and whoever else) to make sure I'm correct in the placement of the new code and the tests that need to be adjusted / passed to make sure my code will play well with others.