### PR TITLE
Generic trait definitions

### DIFF
--- a/macros/examples/generic-trait.rs
+++ b/macros/examples/generic-trait.rs
@@ -28,12 +28,13 @@ impl Rpc<u64, String> for RpcImpl {
 		Ok(100)
 	}
 
-	fn set_two(&self, x: String) -> Result<Two> {
+	fn set_two(&self, x: String) -> Result<()> {
 		println!("{}", x);
+		Ok(())
 	}
 
 	fn call(&self, num: u64) -> FutureResult<(u64, String), Error> {
-		::future::finished((999, "hello".into()))
+		::future::finished((num + 999, "hello".into()))
 	}
 }
 

--- a/macros/examples/generic-trait.rs
+++ b/macros/examples/generic-trait.rs
@@ -1,0 +1,46 @@
+extern crate jsonrpc_core;
+#[macro_use]
+extern crate jsonrpc_macros;
+
+use jsonrpc_core::{IoHandler, Error, Result};
+use jsonrpc_core::futures::future::{self, FutureResult};
+
+build_rpc_trait! {
+	pub trait Rpc<One, Two> {
+		/// Get One type.
+		#[rpc(name = "getOne")]
+		fn one(&self) -> Result<One>;
+
+		/// Adds two numbers and returns a result
+		#[rpc(name = "setTwo")]
+		fn set_two(&self, Two) -> Result<()>;
+
+		/// Performs asynchronous operation
+		#[rpc(name = "beFancy")]
+		fn call(&self, One) -> FutureResult<(One, Two), Error>;
+	}
+}
+
+struct RpcImpl;
+
+impl Rpc<u64, String> for RpcImpl {
+	fn one(&self) -> Result<u64> {
+		Ok(100)
+	}
+
+	fn set_two(&self, x: String) -> Result<Two> {
+		println!("{}", x);
+	}
+
+	fn call(&self, num: u64) -> FutureResult<(u64, String), Error> {
+		::future::finished((999, "hello".into()))
+	}
+}
+
+
+fn main() {
+	let mut io = IoHandler::new();
+	let rpc = RpcImpl;
+
+	io.extend_with(rpc.to_delegate())
+}

--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -75,7 +75,7 @@ macro_rules! build_rpc_trait {
 	// entry-point. todo: make another for traits w/ bounds.
 	(
 		$(#[$t_attr: meta])*
-		pub trait $name: ident $(<$($generics:ident ,)*>)* {
+		pub trait $name: ident $(<$($generics:ident),*>)* {
 			$(
 				$( #[doc=$m_doc:expr] )*
 				#[ rpc( $($t:tt)* ) ]
@@ -93,7 +93,7 @@ macro_rules! build_rpc_trait {
 			/// Transform this into an `IoDelegate`, automatically wrapping
 			/// the parameters.
 			fn to_delegate<M: $crate::jsonrpc_core::Metadata>(self) -> $crate::IoDelegate<Self, M>
-				where $($($generics: $crate::Serialize + $crate::Deserialize)*)*
+				where $($($generics: Send + Sync + 'static + $crate::Serialize + $crate::DeserializeOwned),*)*
 			{
 				let mut del = $crate::IoDelegate::new(self.into());
 				$(
@@ -110,7 +110,7 @@ macro_rules! build_rpc_trait {
 	// entry-point for trait with metadata methods
 	(
 		$(#[$t_attr: meta])*
-		pub trait $name: ident $(<$($generics:ident ,)*>)* {
+		pub trait $name: ident $(<$($generics:ident),*>)* {
 			type Metadata;
 
 			$(
@@ -154,7 +154,7 @@ macro_rules! build_rpc_trait {
 			/// Transform this into an `IoDelegate`, automatically wrapping
 			/// the parameters.
 			fn to_delegate(self) -> $crate::IoDelegate<Self, Self::Metadata>
-				where $($($generics: $crate::Serialize + $crate::Deserialize)*)*
+				where $($($generics: Send + Sync + 'static + $crate::Serialize + $crate::DeserializeOwned),*)*
 			{
 				let mut del = $crate::IoDelegate::new(self.into());
 				$(

--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -75,7 +75,7 @@ macro_rules! build_rpc_trait {
 	// entry-point. todo: make another for traits w/ bounds.
 	(
 		$(#[$t_attr: meta])*
-		pub trait $name: ident {
+		pub trait $name: ident $(<$($generics:ident ,)*>)* {
 			$(
 				$( #[doc=$m_doc:expr] )*
 				#[ rpc( $($t:tt)* ) ]
@@ -84,7 +84,7 @@ macro_rules! build_rpc_trait {
 		}
 	) => {
 		$(#[$t_attr])*
-		pub trait $name: Sized + Send + Sync + 'static {
+		pub trait $name $(<$($generics,)*>)* : Sized + Send + Sync + 'static {
 			$(
 				$(#[doc=$m_doc])*
 				fn $m_name ( $($p)* ) -> $result<$out $(, $error)* > ;
@@ -92,7 +92,9 @@ macro_rules! build_rpc_trait {
 
 			/// Transform this into an `IoDelegate`, automatically wrapping
 			/// the parameters.
-			fn to_delegate<M: $crate::jsonrpc_core::Metadata>(self) -> $crate::IoDelegate<Self, M> {
+			fn to_delegate<M: $crate::jsonrpc_core::Metadata>(self) -> $crate::IoDelegate<Self, M>
+				where $($($generics: $crate::Serialize + $crate::Deserialize)*)*
+			{
 				let mut del = $crate::IoDelegate::new(self.into());
 				$(
 					build_rpc_trait!(WRAP del =>
@@ -108,7 +110,7 @@ macro_rules! build_rpc_trait {
 	// entry-point for trait with metadata methods
 	(
 		$(#[$t_attr: meta])*
-		pub trait $name: ident {
+		pub trait $name: ident $(<$($generics:ident ,)*>)* {
 			type Metadata;
 
 			$(
@@ -131,7 +133,7 @@ macro_rules! build_rpc_trait {
 		}
 	) => {
 		$(#[$t_attr])*
-		pub trait $name: Sized + Send + Sync + 'static {
+		pub trait $name $(<$($generics,)*>)* : Sized + Send + Sync + 'static {
 			// Metadata bound differs for traits with subscription methods.
 			metadata! (
 				$( $sub_name )*
@@ -151,7 +153,9 @@ macro_rules! build_rpc_trait {
 
 			/// Transform this into an `IoDelegate`, automatically wrapping
 			/// the parameters.
-			fn to_delegate(self) -> $crate::IoDelegate<Self, Self::Metadata> {
+			fn to_delegate(self) -> $crate::IoDelegate<Self, Self::Metadata>
+				where $($($generics: $crate::Serialize + $crate::Deserialize)*)*
+			{
 				let mut del = $crate::IoDelegate::new(self.into());
 				$(
 					build_rpc_trait!(WRAP del =>

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -61,6 +61,10 @@ pub mod pubsub;
 
 #[doc(hidden)]
 pub use auto_args::{WrapAsync, WrapMeta, WrapSubscribe};
+
+#[doc(hidden)]
+pub use serde::{de::DeserializeOwned, Serialize};
+
 pub use auto_args::Trailing;
 pub use delegates::IoDelegate;
 pub use util::to_value;


### PR DESCRIPTION
It's not perfect since it generates the bounds for you, but it's the best we can do until `build_rpc_trait!` is rewritten as a proc-macro.