### PR TITLE
Use serde attributes instead of custom ser/de

### DIFF
--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -263,7 +263,7 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 
 				B(futures::finished(None))
 			},
-			Call::Invalid(id) => {
+			Call::Invalid { id } => {
 				B(futures::finished(Some(Output::invalid_request(id, self.compatibility.default_version()))))
 			},
 		}

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -7,7 +7,7 @@ use futures::{self, future, Future};
 
 use calls::{RemoteProcedure, Metadata, RpcMethodSimple, RpcMethod, RpcNotificationSimple, RpcNotification};
 use middleware::{self, Middleware};
-use types::{Params, Error, ErrorCode, Version};
+use types::{Error, ErrorCode, Version};
 use types::{Request, Response, Call, Output};
 
 /// A type representing middleware or RPC response before serialization.
@@ -215,7 +215,7 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 
 		match call {
 			Call::MethodCall(method) => {
-				let params = method.params.unwrap_or(Params::None);
+				let params = method.params;
 				let id = method.id;
 				let jsonrpc = method.jsonrpc;
 				let valid_version = self.compatibility.is_version_valid(jsonrpc);
@@ -243,7 +243,7 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 				}
 			},
 			Call::Notification(notification) => {
-				let params = notification.params.unwrap_or(Params::None);
+				let params = notification.params;
 				let jsonrpc = notification.jsonrpc;
 				if !self.compatibility.is_version_valid(jsonrpc) {
 					return B(futures::finished(None));

--- a/core/src/types/id.rs
+++ b/core/src/types/id.rs
@@ -1,62 +1,15 @@
 //! jsonrpc id field
-use std::fmt;
-
-use serde::{Serialize, Serializer, Deserialize, Deserializer};
-use serde::de::{self, Visitor};
 
 /// Request Id
-#[derive(Debug, PartialEq, Clone, Hash, Eq)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum Id {
 	/// No id (notification)
 	Null,
-	/// String id
-	Str(String),
 	/// Numeric id
 	Num(u64),
-}
-
-impl Serialize for Id {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where S: Serializer {
-		match *self {
-			Id::Null => serializer.serialize_unit(),
-			Id::Str(ref v) => serializer.serialize_str(v),
-			Id::Num(v) => serializer.serialize_u64(v)
-		}
-	}
-}
-
-impl<'a> Deserialize<'a> for Id {
-	fn deserialize<D>(deserializer: D) -> Result<Id, D::Error>
-	where D: Deserializer<'a> {
-		deserializer.deserialize_any(IdVisitor)
-	}
-}
-
-struct IdVisitor;
-
-impl<'a> Visitor<'a> for IdVisitor {
-	type Value = Id;
-
-	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-		formatter.write_str("a unit, integer or string")
-	}
-
-	fn visit_unit<E>(self) -> Result<Self::Value, E> where E: de::Error {
-		Ok(Id::Null)
-	}
-
-	fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> where E: de::Error {
-		Ok(Id::Num(value))
-	}
-
-	fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> where E: de::Error {
-		self.visit_string(value.to_owned())
-	}
-
-	fn visit_string<E>(self, value: String) -> Result<Self::Value, E> where E: de::Error {
-		value.parse::<u64>().map(Id::Num).or(Ok(Id::Str(value)))
-	}
+	/// String id
+	Str(String),
 }
 
 #[cfg(test)]
@@ -68,6 +21,10 @@ mod tests {
 	fn id_deserialization() {
 		let s = r#""2""#;
 		let deserialized: Id = serde_json::from_str(s).unwrap();
+		assert_eq!(deserialized, Id::Str("2".into()));
+
+		let s = r#"2"#;
+		let deserialized: Id = serde_json::from_str(s).unwrap();
 		assert_eq!(deserialized, Id::Num(2));
 
 		let s = r#""2x""#;
@@ -76,7 +33,7 @@ mod tests {
 
 		let s = r#"[null, 0, 2, "3"]"#;
 		let deserialized: Vec<Id> = serde_json::from_str(s).unwrap();
-		assert_eq!(deserialized, vec![Id::Null, Id::Num(0), Id::Num(2), Id::Num(3)]);
+		assert_eq!(deserialized, vec![Id::Null, Id::Num(0), Id::Num(2), Id::Str("3".into())]);
 	}
 
 	#[test]

--- a/core/src/types/params.rs
+++ b/core/src/types/params.rs
@@ -1,15 +1,14 @@
 //! jsonrpc params field
-use std::fmt;
 
-use serde::{Serialize, Serializer, Deserialize, Deserializer};
-use serde::de::{Visitor, SeqAccess, MapAccess, DeserializeOwned};
+use serde::de::{DeserializeOwned};
 use serde_json;
 use serde_json::value::from_value;
 
 use super::{Value, Error};
 
 /// Request parameters
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum Params {
 	/// Array of values
 	Array(Vec<Value>),
@@ -34,60 +33,6 @@ impl Params {
 	}
 }
 
-impl Serialize for Params {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where S: Serializer {
-		match *self {
-			Params::Array(ref vec) => vec.serialize(serializer),
-			Params::Map(ref map) => map.serialize(serializer),
-			Params::None => ([0u8; 0]).serialize(serializer)
-		}
-	}
-}
-
-struct ParamsVisitor;
-
-impl<'a> Deserialize<'a> for Params {
-	fn deserialize<D>(deserializer: D) -> Result<Params, D::Error>
-	where D: Deserializer<'a> {
-		deserializer.deserialize_any(ParamsVisitor)
-	}
-}
-
-impl<'a> Visitor<'a> for ParamsVisitor {
-	type Value = Params;
-
-	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-		formatter.write_str("a map or sequence")
-	}
-
-	fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
-	where V: SeqAccess<'a> {
-		let mut values = Vec::new();
-
-		while let Some(value) = visitor.next_element()? {
-			values.push(value);
-		}
-
-		if values.is_empty() {
-			Ok(Params::None)
-		} else {
-			Ok(Params::Array(values))
-		}
-	}
-
-	fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
-	where V: MapAccess<'a> {
-		let mut values = serde_json::Map::new();
-
-		while let Some((key, value)) = visitor.next_entry()? {
-			values.insert(key, value);
-		}
-
-		Ok(if values.is_empty() { Params::None } else { Params::Map(values) })
-	}
-}
-
 #[cfg(test)]
 mod tests {
 	use serde_json;
@@ -96,8 +41,7 @@ mod tests {
 
 	#[test]
 	fn params_deserialization() {
-
-		let s = r#"[null, true, -1, 4, 2.3, "hello", [0], {"key": "value"}]"#;
+		let s = r#"[null, true, -1, 4, 2.3, "hello", [0], {"key": "value"}, []]"#;
 		let deserialized: Params = serde_json::from_str(s).unwrap();
 
 		let mut map = serde_json::Map::new();
@@ -106,7 +50,9 @@ mod tests {
 		assert_eq!(Params::Array(vec![
 								 Value::Null, Value::Bool(true), Value::from(-1), Value::from(4),
 								 Value::from(2.3), Value::String("hello".to_string()),
-								 Value::Array(vec![Value::from(0)]), Value::Object(map)]), deserialized);
+								 Value::Array(vec![Value::from(0)]), Value::Object(map),
+								 Value::Array(vec![]),
+		]), deserialized);
 	}
 
 	#[test]

--- a/core/src/types/params.rs
+++ b/core/src/types/params.rs
@@ -10,12 +10,12 @@ use super::{Value, Error};
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Params {
+	/// No parameters
+	None,
 	/// Array of values
 	Array(Vec<Value>),
 	/// Map of values
 	Map(serde_json::Map<String, Value>),
-	/// No parameters
-	None
 }
 
 impl Params {

--- a/core/src/types/request.rs
+++ b/core/src/types/request.rs
@@ -1,9 +1,6 @@
 //! jsonrpc request
-use serde::de::{Deserialize, Deserializer, Error as DeError};
-use serde::ser::{Serialize, Serializer, Error as SerError};
-use serde_json::{from_value, Error as JsonError};
 
-use super::{Id, Params, Version, Value};
+use super::{Id, Params, Version};
 
 /// Represents jsonrpc request which is a method call.
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
@@ -36,14 +33,23 @@ pub struct Notification {
 }
 
 /// Represents single jsonrpc call.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum Call {
 	/// Call method
 	MethodCall(MethodCall),
 	/// Fire notification
 	Notification(Notification),
 	/// Invalid call
-	Invalid(Id),
+	Invalid {
+		/// Call id (if known)
+		#[serde(default = "default_id")]
+		id: Id,
+	},
+}
+
+fn default_id() -> Id {
+	Id::Null
 }
 
 impl From<MethodCall> for Call {
@@ -58,35 +64,9 @@ impl From<Notification> for Call {
 	}
 }
 
-impl Serialize for Call {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where S: Serializer {
-		match *self {
-			Call::MethodCall(ref m) => m.serialize(serializer),
-			Call::Notification(ref n) => n.serialize(serializer),
-			Call::Invalid(_) => Err(S::Error::custom("invalid call"))
-		}
-	}
-}
-
-impl<'a> Deserialize<'a> for Call {
-	fn deserialize<D>(deserializer: D) -> Result<Call, D::Error>
-	where D: Deserializer<'a> {
-		let v: Value = try!(Deserialize::deserialize(deserializer));
-		from_value(v.clone()).map(Call::Notification)
-			.or_else(|_: JsonError| from_value(v.clone()).map(Call::MethodCall))
-			.or_else(|_: JsonError| {
-				let id = v.get("id")
-					.and_then(|id| from_value(id.clone()).ok())
-					.unwrap_or(Id::Null);
-				Ok(Call::Invalid(id))
-			})
-			.map_err(|_: JsonError| D::Error::custom("")) // make the types match
-	}
-}
-
 /// Represents jsonrpc request.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum Request {
 	/// Single request (call)
 	Single(Call),
@@ -94,175 +74,161 @@ pub enum Request {
 	Batch(Vec<Call>)
 }
 
-impl Serialize for Request {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where S: Serializer {
-		match *self {
-			Request::Single(ref call) => call.serialize(serializer),
-			Request::Batch(ref calls) => calls.serialize(serializer),
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use serde_json::Value;
+
+	#[test]
+	fn method_call_serialize() {
+		use serde_json;
+		use serde_json::Value;
+
+		let m = MethodCall {
+			jsonrpc: Some(Version::V2),
+			method: "update".to_owned(),
+			params: Some(Params::Array(vec![Value::from(1), Value::from(2)])),
+			id: Id::Num(1)
+		};
+
+		let serialized = serde_json::to_string(&m).unwrap();
+		assert_eq!(serialized, r#"{"jsonrpc":"2.0","method":"update","params":[1,2],"id":1}"#);
+	}
+
+	#[test]
+	fn notification_serialize() {
+		use serde_json;
+		use serde_json::Value;
+
+		let n = Notification {
+			jsonrpc: Some(Version::V2),
+			method: "update".to_owned(),
+			params: Some(Params::Array(vec![Value::from(1), Value::from(2)]))
+		};
+
+		let serialized = serde_json::to_string(&n).unwrap();
+		assert_eq!(serialized, r#"{"jsonrpc":"2.0","method":"update","params":[1,2]}"#);
+	}
+
+	#[test]
+	fn call_serialize() {
+		use serde_json;
+		use serde_json::Value;
+
+		let n = Call::Notification(Notification {
+			jsonrpc: Some(Version::V2),
+			method: "update".to_owned(),
+			params: Some(Params::Array(vec![Value::from(1)]))
+		});
+
+		let serialized = serde_json::to_string(&n).unwrap();
+		assert_eq!(serialized, r#"{"jsonrpc":"2.0","method":"update","params":[1]}"#);
+	}
+
+	#[test]
+	fn request_serialize_batch() {
+		use serde_json;
+
+		let batch = Request::Batch(vec![
+			Call::MethodCall(MethodCall {
+				jsonrpc: Some(Version::V2),
+				method: "update".to_owned(),
+				params: Some(Params::Array(vec![Value::from(1), Value::from(2)])),
+				id: Id::Num(1)
+			}),
+			Call::Notification(Notification {
+				jsonrpc: Some(Version::V2),
+				method: "update".to_owned(),
+				params: Some(Params::Array(vec![Value::from(1)]))
+			})
+		]);
+
+		let serialized = serde_json::to_string(&batch).unwrap();
+		assert_eq!(serialized, r#"[{"jsonrpc":"2.0","method":"update","params":[1,2],"id":1},{"jsonrpc":"2.0","method":"update","params":[1]}]"#);
+
+	}
+
+	#[test]
+	fn notification_deserialize() {
+		use serde_json;
+		use serde_json::Value;
+
+		let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1,2]}"#;
+		let deserialized: Notification = serde_json::from_str(s).unwrap();
+
+		assert_eq!(deserialized, Notification {
+			jsonrpc: Some(Version::V2),
+			method: "update".to_owned(),
+			params: Some(Params::Array(vec![Value::from(1), Value::from(2)]))
+		});
+
+		let s = r#"{"jsonrpc": "2.0", "method": "foobar"}"#;
+		let deserialized: Notification = serde_json::from_str(s).unwrap();
+
+		assert_eq!(deserialized, Notification {
+			jsonrpc: Some(Version::V2),
+			method: "foobar".to_owned(),
+			params: None
+		});
+
+		let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1,2], "id": 1}"#;
+		let deserialized: Result<Notification, _> = serde_json::from_str(s);
+		assert!(deserialized.is_err())
+	}
+
+	#[test]
+	fn call_deserialize() {
+		use serde_json;
+
+		let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1]}"#;
+		let deserialized: Call = serde_json::from_str(s).unwrap();
+		assert_eq!(deserialized, Call::Notification(Notification {
+			jsonrpc: Some(Version::V2),
+			method: "update".to_owned(),
+			params: Some(Params::Array(vec![Value::from(1)]))
+		}));
+
+		let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1], "id": 1}"#;
+		let deserialized: Call = serde_json::from_str(s).unwrap();
+		assert_eq!(deserialized, Call::MethodCall(MethodCall {
+			jsonrpc: Some(Version::V2),
+			method: "update".to_owned(),
+			params: Some(Params::Array(vec![Value::from(1)])),
+			id: Id::Num(1)
+		}));
+	}
+
+	#[test]
+	fn request_deserialize_batch() {
+		use serde_json;
+
+		let s = r#"[{}, {"jsonrpc": "2.0", "method": "update", "params": [1,2], "id": 1},{"jsonrpc": "2.0", "method": "update", "params": [1]}]"#;
+		let deserialized: Request = serde_json::from_str(s).unwrap();
+		assert_eq!(deserialized, Request::Batch(vec![
+			Call::Invalid { id: Id::Null },
+			Call::MethodCall(MethodCall {
+				jsonrpc: Some(Version::V2),
+				method: "update".to_owned(),
+				params: Some(Params::Array(vec![Value::from(1), Value::from(2)])),
+				id: Id::Num(1)
+			}),
+			Call::Notification(Notification {
+				jsonrpc: Some(Version::V2),
+				method: "update".to_owned(),
+				params: Some(Params::Array(vec![Value::from(1)]))
+			})
+		]))
+	}
+
+	#[test]
+	fn request_invalid_returns_id() {
+		use serde_json;
+
+		let s = r#"{"id":120,"method":"my_method","params":["foo", "bar"],"extra_field":[]}"#;
+		let deserialized: Request = serde_json::from_str(s).unwrap();
+		match deserialized {
+			Request::Single(Call::Invalid { id: Id::Num(120) }) => {},
+			_ => panic!("Request wrongly deserialized: {:?}", deserialized),
 		}
-	}
-}
-
-impl<'a> Deserialize<'a> for Request {
-	fn deserialize<D>(deserializer: D) -> Result<Request, D::Error>
-	where D: Deserializer<'a> {
-		let v: Value = try!(Deserialize::deserialize(deserializer));
-		from_value(v.clone()).map(Request::Batch)
-			.or_else(|_| from_value(v).map(Request::Single))
-			.map_err(|_| D::Error::custom("")) // unreachable, but types must match
-	}
-}
-
-#[test]
-fn method_call_serialize() {
-	use serde_json;
-	use serde_json::Value;
-
-	let m = MethodCall {
-		jsonrpc: Some(Version::V2),
-		method: "update".to_owned(),
-		params: Some(Params::Array(vec![Value::from(1), Value::from(2)])),
-		id: Id::Num(1)
-	};
-
-	let serialized = serde_json::to_string(&m).unwrap();
-	assert_eq!(serialized, r#"{"jsonrpc":"2.0","method":"update","params":[1,2],"id":1}"#);
-}
-
-#[test]
-fn notification_serialize() {
-	use serde_json;
-	use serde_json::Value;
-
-	let n = Notification {
-		jsonrpc: Some(Version::V2),
-		method: "update".to_owned(),
-		params: Some(Params::Array(vec![Value::from(1), Value::from(2)]))
-	};
-
-	let serialized = serde_json::to_string(&n).unwrap();
-	assert_eq!(serialized, r#"{"jsonrpc":"2.0","method":"update","params":[1,2]}"#);
-}
-
-#[test]
-fn call_serialize() {
-	use serde_json;
-	use serde_json::Value;
-
-	let n = Call::Notification(Notification {
-		jsonrpc: Some(Version::V2),
-		method: "update".to_owned(),
-		params: Some(Params::Array(vec![Value::from(1)]))
-	});
-
-	let serialized = serde_json::to_string(&n).unwrap();
-	assert_eq!(serialized, r#"{"jsonrpc":"2.0","method":"update","params":[1]}"#);
-}
-
-#[test]
-fn request_serialize_batch() {
-	use serde_json;
-
-	let batch = Request::Batch(vec![
-		Call::MethodCall(MethodCall {
-			jsonrpc: Some(Version::V2),
-			method: "update".to_owned(),
-			params: Some(Params::Array(vec![Value::from(1), Value::from(2)])),
-			id: Id::Num(1)
-		}),
-		Call::Notification(Notification {
-			jsonrpc: Some(Version::V2),
-			method: "update".to_owned(),
-			params: Some(Params::Array(vec![Value::from(1)]))
-		})
-	]);
-
-	let serialized = serde_json::to_string(&batch).unwrap();
-	assert_eq!(serialized, r#"[{"jsonrpc":"2.0","method":"update","params":[1,2],"id":1},{"jsonrpc":"2.0","method":"update","params":[1]}]"#);
-
-}
-
-#[test]
-fn notification_deserialize() {
-	use serde_json;
-	use serde_json::Value;
-
-	let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1,2]}"#;
-	let deserialized: Notification = serde_json::from_str(s).unwrap();
-
-	assert_eq!(deserialized, Notification {
-		jsonrpc: Some(Version::V2),
-		method: "update".to_owned(),
-		params: Some(Params::Array(vec![Value::from(1), Value::from(2)]))
-	});
-
-	let s = r#"{"jsonrpc": "2.0", "method": "foobar"}"#;
-	let deserialized: Notification = serde_json::from_str(s).unwrap();
-
-	assert_eq!(deserialized, Notification {
-		jsonrpc: Some(Version::V2),
-		method: "foobar".to_owned(),
-		params: None
-	});
-
-	let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1,2], "id": 1}"#;
-	let deserialized: Result<Notification, _> = serde_json::from_str(s);
-	assert!(deserialized.is_err())
-}
-
-#[test]
-fn call_deserialize() {
-	use serde_json;
-
-	let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1]}"#;
-	let deserialized: Call = serde_json::from_str(s).unwrap();
-	assert_eq!(deserialized, Call::Notification(Notification {
-		jsonrpc: Some(Version::V2),
-		method: "update".to_owned(),
-		params: Some(Params::Array(vec![Value::from(1)]))
-	}));
-
-	let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1], "id": 1}"#;
-	let deserialized: Call = serde_json::from_str(s).unwrap();
-	assert_eq!(deserialized, Call::MethodCall(MethodCall {
-		jsonrpc: Some(Version::V2),
-		method: "update".to_owned(),
-		params: Some(Params::Array(vec![Value::from(1)])),
-		id: Id::Num(1)
-	}));
-}
-
-#[test]
-fn request_deserialize_batch() {
-	use serde_json;
-
-	let s = r#"[1, {"jsonrpc": "2.0", "method": "update", "params": [1,2], "id": 1},{"jsonrpc": "2.0", "method": "update", "params": [1]}]"#;
-	let deserialized: Request = serde_json::from_str(s).unwrap();
-	assert_eq!(deserialized, Request::Batch(vec![
-		Call::Invalid(Id::Null),
-		Call::MethodCall(MethodCall {
-			jsonrpc: Some(Version::V2),
-			method: "update".to_owned(),
-			params: Some(Params::Array(vec![Value::from(1), Value::from(2)])),
-			id: Id::Num(1)
-		}),
-		Call::Notification(Notification {
-			jsonrpc: Some(Version::V2),
-			method: "update".to_owned(),
-			params: Some(Params::Array(vec![Value::from(1)]))
-		})
-	]))
-}
-
-#[test]
-fn request_invalid_returns_id() {
-	use serde_json;
-
-	let s = r#"{"id":120,"method":"my_method","params":["foo", "bar"],"extra_field":[]}"#;
-	let deserialized: Request = serde_json::from_str(s).unwrap();
-	match deserialized {
-		Request::Single(Call::Invalid(Id::Num(120))) => {},
-		_ => panic!("Request wrongly deserialized: {:?}", deserialized),
 	}
 }

--- a/core/src/types/version.rs
+++ b/core/src/types/version.rs
@@ -43,4 +43,3 @@ impl<'a> Visitor<'a> for VersionVisitor {
 		}
 	}
 }
-

--- a/http/src/handler.rs
+++ b/http/src/handler.rs
@@ -332,7 +332,7 @@ impl<M: Metadata, S: Middleware<M>> RpcHandler<M, S> {
 		let call = Request::Single(Call::MethodCall(MethodCall {
 			jsonrpc: Some(Version::V2),
 			method: method.into(),
-			params: Some(Params::Array(params)),
+			params: Params::Array(params),
 			id: Id::Num(1),
 		}));
 

--- a/http/src/tests.rs
+++ b/http/src/tests.rs
@@ -216,7 +216,7 @@ fn should_return_method_not_found() {
 	let server = serve();
 
 	// when
-	let req = r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#;
+	let req = r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#;
 	let response = request(server,
 		&format!("\
 			POST / HTTP/1.1\r\n\
@@ -240,7 +240,7 @@ fn should_add_cors_headers() {
 	let server = serve();
 
 	// when
-	let req = r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#;
+	let req = r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#;
 	let response = request(server,
 		&format!("\
 			POST / HTTP/1.1\r\n\
@@ -266,7 +266,7 @@ fn should_not_add_cors_headers() {
 	let server = serve();
 
 	// when
-	let req = r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#;
+	let req = r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#;
 	let response = request(server,
 		&format!("\
 			POST / HTTP/1.1\r\n\
@@ -291,7 +291,7 @@ fn should_not_process_the_request_in_case_of_invalid_cors() {
 	let server = serve();
 
 	// when
-	let req = r#"{"jsonrpc":"2.0","id":"1","method":"hello"}"#;
+	let req = r#"{"jsonrpc":"2.0","id":1,"method":"hello"}"#;
 	let response = request(server,
 		&format!("\
 			OPTIONS / HTTP/1.1\r\n\
@@ -340,7 +340,7 @@ fn should_add_cors_header_for_null_origin() {
 	let server = serve();
 
 	// when
-	let req = r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#;
+	let req = r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#;
 	let response = request(server,
 		&format!("\
 			POST / HTTP/1.1\r\n\
@@ -366,7 +366,7 @@ fn should_add_cors_header_for_null_origin_when_all() {
 	let server = serve_rest(RestApi::Secure, true);
 
 	// when
-	let req = r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#;
+	let req = r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#;
 	let response = request(server,
 		&format!("\
 			POST / HTTP/1.1\r\n\
@@ -413,7 +413,7 @@ fn should_reject_invalid_hosts() {
 	let server = serve_hosts(vec!["parity.io".into()]);
 
 	// when
-	let req = r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#;
+	let req = r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#;
 	let response = request(server,
 		&format!("\
 			POST / HTTP/1.1\r\n\
@@ -437,7 +437,7 @@ fn should_reject_missing_host() {
 	let server = serve_hosts(vec!["parity.io".into()]);
 
 	// when
-	let req = r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#;
+	let req = r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#;
 	let response = request(server,
 		&format!("\
 			POST / HTTP/1.1\r\n\
@@ -460,7 +460,7 @@ fn should_allow_if_host_is_valid() {
 	let server = serve_hosts(vec!["parity.io".into()]);
 
 	// when
-	let req = r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#;
+	let req = r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#;
 	let response = request(server,
 		&format!("\
 			POST / HTTP/1.1\r\n\
@@ -484,7 +484,7 @@ fn should_allow_application_json_utf8() {
 	let server = serve_hosts(vec!["parity.io".into()]);
 
 	// when
-	let req = r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#;
+	let req = r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#;
 	let response = request(server,
 		&format!("\
 			POST / HTTP/1.1\r\n\
@@ -509,7 +509,7 @@ fn should_always_allow_the_bind_address() {
 	let addr = server.address().clone();
 
 	// when
-	let req = r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#;
+	let req = r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#;
 	let response = request(server,
 		&format!("\
 			POST / HTTP/1.1\r\n\
@@ -534,7 +534,7 @@ fn should_always_allow_the_bind_address_as_localhost() {
 	let addr = server.address().clone();
 
 	// when
-	let req = r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#;
+	let req = r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#;
 	let response = request(server,
 		&format!("\
 			POST / HTTP/1.1\r\n\
@@ -559,7 +559,7 @@ fn should_handle_sync_requests_correctly() {
 	let addr = server.address().clone();
 
 	// when
-	let req = r#"{"jsonrpc":"2.0","id":"1","method":"hello"}"#;
+	let req = r#"{"jsonrpc":"2.0","id":1,"method":"hello"}"#;
 	let response = request(server,
 		&format!("\
 			POST / HTTP/1.1\r\n\
@@ -584,7 +584,7 @@ fn should_handle_async_requests_with_immediate_response_correctly() {
 	let addr = server.address().clone();
 
 	// when
-	let req = r#"{"jsonrpc":"2.0","id":"1","method":"hello_async"}"#;
+	let req = r#"{"jsonrpc":"2.0","id":1,"method":"hello_async"}"#;
 	let response = request(server,
 		&format!("\
 			POST / HTTP/1.1\r\n\
@@ -609,7 +609,7 @@ fn should_handle_async_requests_correctly() {
 	let addr = server.address().clone();
 
 	// when
-	let req = r#"{"jsonrpc":"2.0","id":"1","method":"hello_async2"}"#;
+	let req = r#"{"jsonrpc":"2.0","id":1,"method":"hello_async2"}"#;
 	let response = request(server,
 		&format!("\
 			POST / HTTP/1.1\r\n\
@@ -634,7 +634,7 @@ fn should_handle_sync_batch_requests_correctly() {
 	let addr = server.address().clone();
 
 	// when
-	let req = r#"[{"jsonrpc":"2.0","id":"1","method":"hello"}]"#;
+	let req = r#"[{"jsonrpc":"2.0","id":1,"method":"hello"}]"#;
 	let response = request(server,
 		&format!("\
 			POST / HTTP/1.1\r\n\

--- a/minihttp/src/tests.rs
+++ b/minihttp/src/tests.rs
@@ -215,7 +215,7 @@ fn should_return_method_not_found() {
 	let response = request(server,
 		Method::Post,
 		content_type_json(),
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -236,7 +236,7 @@ fn should_add_cors_headers() {
 			headers.set(header::Origin::new("http", "parity.io", None));
 			headers
 		},
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -261,7 +261,7 @@ fn should_add_cors_headers_for_options() {
 			headers.set(header::Origin::new("http", "parity.io", None));
 			headers
 		},
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -287,7 +287,7 @@ fn should_not_process_request_with_invalid_cors() {
 			headers.set(header::Origin::new("http", "fake.io", None));
 			headers
 		},
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -308,7 +308,7 @@ fn should_add_cors_header_for_null_origin() {
 			headers.append_raw("origin", b"null".to_vec());
 			headers
 		},
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -333,7 +333,7 @@ fn should_reject_invalid_hosts() {
 			headers.set_raw("Host", vec![b"127.0.0.1:8080".to_vec()]);
 			headers
 		},
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -354,7 +354,7 @@ fn should_allow_if_host_is_valid() {
 			headers.set_raw("Host", vec![b"parity.io".to_vec()]);
 			headers
 		},
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -376,7 +376,7 @@ fn should_always_allow_the_bind_address() {
 			headers.set_raw("Host", vec![format!("{}", addr).as_bytes().to_vec()]);
 			headers
 		},
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -398,7 +398,7 @@ fn should_always_allow_the_bind_address_as_localhost() {
 			headers.set_raw("Host", vec![format!("localhost:{}", addr.port()).as_bytes().to_vec()]);
 			headers
 		},
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -415,7 +415,7 @@ fn should_handle_sync_requests_correctly() {
 	let response = request(server,
 		Method::Post,
 		content_type_json(),
-		r#"{"jsonrpc":"2.0","id":"1","method":"hello"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"hello"}"#,
 	);
 
 	// then
@@ -432,7 +432,7 @@ fn should_handle_async_requests_with_immediate_response_correctly() {
 	let response = request(server,
 		Method::Post,
 		content_type_json(),
-		r#"{"jsonrpc":"2.0","id":"1","method":"hello_async"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"hello_async"}"#,
 	);
 
 	// then
@@ -449,7 +449,7 @@ fn should_handle_async_requests_correctly() {
 	let response = request(server,
 		Method::Post,
 		content_type_json(),
-		r#"{"jsonrpc":"2.0","id":"1","method":"hello_async2"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"hello_async2"}"#,
 	);
 
 	// then
@@ -466,7 +466,7 @@ fn should_handle_sync_batch_requests_correctly() {
 	let response = request(server,
 		Method::Post,
 		content_type_json(),
-		r#"[{"jsonrpc":"2.0","id":"1","method":"hello"}]"#,
+		r#"[{"jsonrpc":"2.0","id":1,"method":"hello"}]"#,
 	);
 
 	// then

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -99,11 +99,11 @@ impl Sink {
 		let notification = core::Notification {
 			jsonrpc: Some(core::Version::V2),
 			method: self.notification.clone(),
-			params: Some(val),
+			params: val,
 		};
 		(
 			core::to_string(&notification).expect("Notification serialization never fails."),
-			notification.params.expect("Always Some"),
+			notification.params,
 		)
 	}
 }


### PR DESCRIPTION
Couple of breaking changes:
1. `Call::Invalid` now has `id` field
2. `params:[]` is no longer deserialized to `Params::None`, but rather to `Params::Array(vec![])`
3. Stringified `Id`s are no longer parsed to numbers so `"2"` is `Id::Str("2")` not `Id::Num(2)`
4. Passing a non-object (and non-array) as a `Request` is now parse error (earlier it was deserialized to invalid call).

I suspect this should give a slight performance gain as well, but haven't benchmark it yet.