### PR TITLE
Avoid Boxing in middleware

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -45,6 +45,6 @@ pub type BoxFuture<T> = Box<futures::Future<Item = T, Error = Error> + Send>;
 pub type Result<T> = ::std::result::Result<T, Error>;
 
 pub use calls::{RemoteProcedure, Metadata, RpcMethodSimple, RpcMethod, RpcNotificationSimple, RpcNotification};
-pub use io::{Compatibility, IoHandler, MetaIoHandler, FutureResponse, FutureResult};
+pub use io::{Compatibility, IoHandler, MetaIoHandler, FutureOutput, FutureResult, FutureResponse, FutureRpcResult};
 pub use middleware::{Middleware, Noop as NoopMiddleware};
 pub use types::*;

--- a/core/src/middleware.rs
+++ b/core/src/middleware.rs
@@ -2,7 +2,7 @@
 
 use calls::Metadata;
 use types::{Request, Response};
-use futures::Future;
+use futures::{future::Either, Future};
 
 /// RPC middleware
 pub trait Middleware<M: Metadata>: Send + Sync + 'static {
@@ -12,7 +12,7 @@ pub trait Middleware<M: Metadata>: Send + Sync + 'static {
 	/// Method invoked on each request.
 	/// Allows you to either respond directly (without executing RPC call)
 	/// or do any additional work before and/or after processing the request.
-	fn on_request<F, X>(&self, request: Request, meta: M, next: F) -> Self::Future where
+	fn on_request<F, X>(&self, request: Request, meta: M, next: F) -> Either<Self::Future, X> where
 		F: FnOnce(Request, M) -> X + Send,
 		X: Future<Item=Option<Response>, Error=()> + Send + 'static;
 }
@@ -23,61 +23,70 @@ pub struct Noop;
 impl<M: Metadata> Middleware<M> for Noop {
 	type Future = Box<Future<Item=Option<Response>, Error=()> + Send>;
 
-	fn on_request<F, X>(&self, request: Request, meta: M, process: F) -> Self::Future where
+	fn on_request<F, X>(&self, request: Request, meta: M, process: F) -> Either<Self::Future, X> where
 		F: FnOnce(Request, M) -> X + Send,
 		X: Future<Item=Option<Response>, Error=()> + Send + 'static,
 	{
-		Box::new(process(request, meta))
+		Either::B(process(request, meta))
 	}
 }
 
 impl<M: Metadata, A: Middleware<M>, B: Middleware<M>>
 	Middleware<M> for (A, B)
 {
-	type Future = A::Future;
+	type Future = Either<A::Future, B::Future>;
 
-	fn on_request<F, X>(&self, request: Request, meta: M, process: F) -> Self::Future where
+	fn on_request<F, X>(&self, request: Request, meta: M, process: F) -> Either<Self::Future, X> where
 		F: FnOnce(Request, M) -> X + Send,
 		X: Future<Item=Option<Response>, Error=()> + Send + 'static,
 	{
-		self.0.on_request(request, meta, move |request, meta| {
+		repack(self.0.on_request(request, meta, move |request, meta| {
 			self.1.on_request(request, meta, process)
-		})
+		}))
 	}
 }
 
 impl<M: Metadata, A: Middleware<M>, B: Middleware<M>, C: Middleware<M>>
 	Middleware<M> for (A, B, C)
 {
-	type Future = A::Future;
+	type Future = Either<A::Future, Either<B::Future, C::Future>>;
 
-	fn on_request<F, X>(&self, request: Request, meta: M, process: F) -> Self::Future where
+	fn on_request<F, X>(&self, request: Request, meta: M, process: F) -> Either<Self::Future, X> where
 		F: FnOnce(Request, M) -> X + Send,
 		X: Future<Item=Option<Response>, Error=()> + Send + 'static,
 	{
-		self.0.on_request(request, meta, move |request, meta| {
-			self.1.on_request(request, meta, move |request, meta| {
+		repack(self.0.on_request(request, meta, move |request, meta| {
+			repack(self.1.on_request(request, meta, move |request, meta| {
 				self.2.on_request(request, meta, process)
-			})
-		})
+			}))
+		}))
 	}
 }
 
 impl<M: Metadata, A: Middleware<M>, B: Middleware<M>, C: Middleware<M>, D: Middleware<M>>
 	Middleware<M> for (A, B, C, D)
 {
-	type Future = A::Future;
+	type Future = Either<A::Future, Either<B::Future, Either<C::Future, D::Future>>>;
 
-	fn on_request<F, X>(&self, request: Request, meta: M, process: F) -> Self::Future where
+	fn on_request<F, X>(&self, request: Request, meta: M, process: F) -> Either<Self::Future, X> where
 		F: FnOnce(Request, M) -> X + Send,
 		X: Future<Item=Option<Response>, Error=()> + Send + 'static,
 	{
-		self.0.on_request(request, meta, move |request, meta| {
-			self.1.on_request(request, meta, move |request, meta| {
-				self.2.on_request(request, meta, move |request, meta| {
+		repack(self.0.on_request(request, meta, move |request, meta| {
+			repack(self.1.on_request(request, meta, move |request, meta| {
+				repack(self.2.on_request(request, meta, move |request, meta| {
 					self.3.on_request(request, meta, process)
-				})
-			})
-		})
+				}))
+			}))
+		}))
+	}
+}
+
+#[inline(always)]
+fn repack<A, B, X>(result: Either<A, Either<B, X>>) -> Either<Either<A, B>, X> {
+	match result {
+		Either::A(a) => Either::A(Either::A(a)),
+		Either::B(Either::A(b)) => Either::A(Either::B(b)),
+		Either::B(Either::B(x)) => Either::B(x),
 	}
 }


### PR DESCRIPTION
Complicates the types a bit, but should work better.

I hoped to use `impl Future`, but at some point we use the returned type as associated type in a trait and using `impl Future` there is not yet possible (will it ever be?).

Other approach would be to use `impl Future` and then `Box` wherever we use associated type (kind of anticipating that it's going to be faster in (near) future), but I went for the performant option for now.