### PR TITLE
Add on_call to the middleware.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 	"pubsub",
 	"pubsub/more-examples",
 	"server-utils",
+	"stdio",
 	"tcp",
 	"test",
 	"ws",

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Transport-agnostic `core` and transport servers for `http`, `ipc`, `websockets` 
 - [jsonrpc-ipc-server](./ipc)
 - [jsonrpc-tcp-server](./tcp) [![crates.io][tcp-server-image]][tcp-server-url]
 - [jsonrpc-ws-server](./ws)
+- [jsonrpc-stdio-server](./stdio)
 - [jsonrpc-macros](./macros) [![crates.io][macros-image]][macros-url]
 - [jsonrpc-server-utils](./server-utils) [![crates.io][server-utils-image]][server-utils-url]
 - [jsonrpc-pubsub](./pubsub) [![crates.io][pubsub-image]][pubsub-url]

--- a/core/examples/middlewares.rs
+++ b/core/examples/middlewares.rs
@@ -14,6 +14,7 @@ impl Metadata for Meta {}
 struct MyMiddleware(AtomicUsize);
 impl Middleware<Meta> for MyMiddleware {
 	type Future = FutureResponse;
+	type CallFuture = middleware::NoopCallFuture;
 
 	fn on_request<F, X>(&self, request: Request, meta: Meta, next: F) -> Either<Self::Future, X> where
 		F: FnOnce(Request, Meta) -> X + Send,

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -7,7 +7,7 @@ use futures::{self, future, Future};
 
 use calls::{RemoteProcedure, Metadata, RpcMethodSimple, RpcMethod, RpcNotificationSimple, RpcNotification};
 use middleware::{self, Middleware};
-use types::{Params, Error, ErrorCode, Version};
+use types::{Error, ErrorCode, Version};
 use types::{Request, Response, Call, Output};
 
 /// A type representing middleware or RPC response before serialization.
@@ -244,7 +244,7 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 
 		self.middleware.on_call(call, meta, |call, meta| match call {
 			Call::MethodCall(method) => {
-				let params = method.params.unwrap_or(Params::None);
+				let params = method.params;
 				let id = method.id;
 				let jsonrpc = method.jsonrpc;
 				let valid_version = self.compatibility.is_version_valid(jsonrpc);
@@ -272,7 +272,7 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 				}
 			},
 			Call::Notification(notification) => {
-				let params = notification.params.unwrap_or(Params::None);
+				let params = notification.params;
 				let jsonrpc = notification.jsonrpc;
 				if !self.compatibility.is_version_valid(jsonrpc) {
 					return B(futures::finished(None));
@@ -292,7 +292,7 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 
 				B(futures::finished(None))
 			},
-			Call::Invalid(id) => {
+			Call::Invalid { id } => {
 				B(futures::finished(Some(Output::invalid_request(id, self.compatibility.default_version()))))
 			},
 		})

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -35,7 +35,7 @@ pub extern crate serde_json;
 mod calls;
 mod io;
 
-mod middleware;
+pub mod middleware;
 pub mod types;
 
 /// A `Future` trait object.
@@ -46,5 +46,5 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 
 pub use calls::{RemoteProcedure, Metadata, RpcMethodSimple, RpcMethod, RpcNotificationSimple, RpcNotification};
 pub use io::{Compatibility, IoHandler, MetaIoHandler, FutureOutput, FutureResult, FutureResponse, FutureRpcResult};
-pub use middleware::{Middleware, Noop as NoopMiddleware};
+pub use middleware::Middleware;
 pub use types::*;

--- a/core/src/middleware.rs
+++ b/core/src/middleware.rs
@@ -1,40 +1,56 @@
 //! `IoHandler` middlewares
 
 use calls::Metadata;
-use types::{Request, Response};
+use types::{Request, Response, Call, Output};
 use futures::{future::Either, Future};
 
 /// RPC middleware
 pub trait Middleware<M: Metadata>: Send + Sync + 'static {
-	/// A returned future.
+	/// A returned request future.
 	type Future: Future<Item=Option<Response>, Error=()> + Send + 'static;
+
+	/// A returned call future.
+	type CallFuture: Future<Item=Option<Output>, Error=()> + Send + 'static;
 
 	/// Method invoked on each request.
 	/// Allows you to either respond directly (without executing RPC call)
 	/// or do any additional work before and/or after processing the request.
 	fn on_request<F, X>(&self, request: Request, meta: M, next: F) -> Either<Self::Future, X> where
 		F: FnOnce(Request, M) -> X + Send,
-		X: Future<Item=Option<Response>, Error=()> + Send + 'static;
+		X: Future<Item=Option<Response>, Error=()> + Send + 'static,
+	{
+		Either::B(next(request, meta))
+	}
+
+	/// Method invoked on each call inside a request.
+	///
+	/// Allows you to either handle the call directly (without executing RPC call).
+	fn on_call<F, X>(&self, call: Call, meta: M, next: F) -> Either<Self::CallFuture, X> where
+		F: FnOnce(Call, M) -> X + Send,
+		X: Future<Item=Option<Output>, Error=()> + Send + 'static,
+	{
+		Either::B(next(call, meta))
+	}
 }
+
+/// Dummy future used as a noop result of middleware.
+pub type NoopFuture = Box<Future<Item=Option<Response>, Error=()> + Send>;
+/// Dummy future used as a noop call result of middleware.
+pub type NoopCallFuture = Box<Future<Item=Option<Output>, Error=()> + Send>;
 
 /// No-op middleware implementation
 #[derive(Debug, Default)]
 pub struct Noop;
 impl<M: Metadata> Middleware<M> for Noop {
-	type Future = Box<Future<Item=Option<Response>, Error=()> + Send>;
-
-	fn on_request<F, X>(&self, request: Request, meta: M, process: F) -> Either<Self::Future, X> where
-		F: FnOnce(Request, M) -> X + Send,
-		X: Future<Item=Option<Response>, Error=()> + Send + 'static,
-	{
-		Either::B(process(request, meta))
-	}
+	type Future = NoopFuture;
+	type CallFuture = NoopCallFuture;
 }
 
 impl<M: Metadata, A: Middleware<M>, B: Middleware<M>>
 	Middleware<M> for (A, B)
 {
 	type Future = Either<A::Future, B::Future>;
+	type CallFuture = Either<A::CallFuture, B::CallFuture>;
 
 	fn on_request<F, X>(&self, request: Request, meta: M, process: F) -> Either<Self::Future, X> where
 		F: FnOnce(Request, M) -> X + Send,
@@ -44,12 +60,22 @@ impl<M: Metadata, A: Middleware<M>, B: Middleware<M>>
 			self.1.on_request(request, meta, process)
 		}))
 	}
+
+	fn on_call<F, X>(&self, call: Call, meta: M, process: F) -> Either<Self::CallFuture, X> where
+		F: FnOnce(Call, M) -> X + Send,
+		X: Future<Item=Option<Output>, Error=()> + Send + 'static,
+	{
+		repack(self.0.on_call(call, meta, move |call, meta| {
+			self.1.on_call(call, meta, process)
+		}))
+	}
 }
 
 impl<M: Metadata, A: Middleware<M>, B: Middleware<M>, C: Middleware<M>>
 	Middleware<M> for (A, B, C)
 {
 	type Future = Either<A::Future, Either<B::Future, C::Future>>;
+	type CallFuture = Either<A::CallFuture, Either<B::CallFuture, C::CallFuture>>;
 
 	fn on_request<F, X>(&self, request: Request, meta: M, process: F) -> Either<Self::Future, X> where
 		F: FnOnce(Request, M) -> X + Send,
@@ -61,12 +87,24 @@ impl<M: Metadata, A: Middleware<M>, B: Middleware<M>, C: Middleware<M>>
 			}))
 		}))
 	}
+
+	fn on_call<F, X>(&self, call: Call, meta: M, process: F) -> Either<Self::CallFuture, X> where
+		F: FnOnce(Call, M) -> X + Send,
+		X: Future<Item=Option<Output>, Error=()> + Send + 'static,
+	{
+		repack(self.0.on_call(call, meta, move |call, meta| {
+			repack(self.1.on_call(call, meta, move |call, meta| {
+				self.2.on_call(call, meta, process)
+			}))
+		}))
+	}
 }
 
 impl<M: Metadata, A: Middleware<M>, B: Middleware<M>, C: Middleware<M>, D: Middleware<M>>
 	Middleware<M> for (A, B, C, D)
 {
 	type Future = Either<A::Future, Either<B::Future, Either<C::Future, D::Future>>>;
+	type CallFuture = Either<A::CallFuture, Either<B::CallFuture, Either<C::CallFuture, D::CallFuture>>>;
 
 	fn on_request<F, X>(&self, request: Request, meta: M, process: F) -> Either<Self::Future, X> where
 		F: FnOnce(Request, M) -> X + Send,
@@ -76,6 +114,19 @@ impl<M: Metadata, A: Middleware<M>, B: Middleware<M>, C: Middleware<M>, D: Middl
 			repack(self.1.on_request(request, meta, move |request, meta| {
 				repack(self.2.on_request(request, meta, move |request, meta| {
 					self.3.on_request(request, meta, process)
+				}))
+			}))
+		}))
+	}
+
+	fn on_call<F, X>(&self, call: Call, meta: M, process: F) -> Either<Self::CallFuture, X> where
+		F: FnOnce(Call, M) -> X + Send,
+		X: Future<Item=Option<Output>, Error=()> + Send + 'static,
+	{
+		repack(self.0.on_call(call, meta, move |call, meta| {
+			repack(self.1.on_call(call, meta, move |call, meta| {
+				repack(self.2.on_call(call, meta, move |call, meta| {
+					self.3.on_call(call, meta, process)
 				}))
 			}))
 		}))

--- a/core/src/types/id.rs
+++ b/core/src/types/id.rs
@@ -1,62 +1,15 @@
 //! jsonrpc id field
-use std::fmt;
-
-use serde::{Serialize, Serializer, Deserialize, Deserializer};
-use serde::de::{self, Visitor};
 
 /// Request Id
-#[derive(Debug, PartialEq, Clone, Hash, Eq)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum Id {
 	/// No id (notification)
 	Null,
-	/// String id
-	Str(String),
 	/// Numeric id
 	Num(u64),
-}
-
-impl Serialize for Id {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where S: Serializer {
-		match *self {
-			Id::Null => serializer.serialize_unit(),
-			Id::Str(ref v) => serializer.serialize_str(v),
-			Id::Num(v) => serializer.serialize_u64(v)
-		}
-	}
-}
-
-impl<'a> Deserialize<'a> for Id {
-	fn deserialize<D>(deserializer: D) -> Result<Id, D::Error>
-	where D: Deserializer<'a> {
-		deserializer.deserialize_any(IdVisitor)
-	}
-}
-
-struct IdVisitor;
-
-impl<'a> Visitor<'a> for IdVisitor {
-	type Value = Id;
-
-	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-		formatter.write_str("a unit, integer or string")
-	}
-
-	fn visit_unit<E>(self) -> Result<Self::Value, E> where E: de::Error {
-		Ok(Id::Null)
-	}
-
-	fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> where E: de::Error {
-		Ok(Id::Num(value))
-	}
-
-	fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> where E: de::Error {
-		self.visit_string(value.to_owned())
-	}
-
-	fn visit_string<E>(self, value: String) -> Result<Self::Value, E> where E: de::Error {
-		value.parse::<u64>().map(Id::Num).or(Ok(Id::Str(value)))
-	}
+	/// String id
+	Str(String),
 }
 
 #[cfg(test)]
@@ -68,6 +21,10 @@ mod tests {
 	fn id_deserialization() {
 		let s = r#""2""#;
 		let deserialized: Id = serde_json::from_str(s).unwrap();
+		assert_eq!(deserialized, Id::Str("2".into()));
+
+		let s = r#"2"#;
+		let deserialized: Id = serde_json::from_str(s).unwrap();
 		assert_eq!(deserialized, Id::Num(2));
 
 		let s = r#""2x""#;
@@ -76,7 +33,7 @@ mod tests {
 
 		let s = r#"[null, 0, 2, "3"]"#;
 		let deserialized: Vec<Id> = serde_json::from_str(s).unwrap();
-		assert_eq!(deserialized, vec![Id::Null, Id::Num(0), Id::Num(2), Id::Num(3)]);
+		assert_eq!(deserialized, vec![Id::Null, Id::Num(0), Id::Num(2), Id::Str("3".into())]);
 	}
 
 	#[test]

--- a/core/src/types/request.rs
+++ b/core/src/types/request.rs
@@ -1,9 +1,6 @@
 //! jsonrpc request
-use serde::de::{Deserialize, Deserializer, Error as DeError};
-use serde::ser::{Serialize, Serializer, Error as SerError};
-use serde_json::{from_value, Error as JsonError};
 
-use super::{Id, Params, Version, Value};
+use super::{Id, Params, Version};
 
 /// Represents jsonrpc request which is a method call.
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
@@ -15,7 +12,8 @@ pub struct MethodCall {
 	pub method: String,
 	/// A Structured value that holds the parameter values to be used
 	/// during the invocation of the method. This member MAY be omitted.
-	pub params: Option<Params>,
+	#[serde(default = "default_params")]
+	pub params: Params,
 	/// An identifier established by the Client that MUST contain a String,
 	/// Number, or NULL value if included. If it is not included it is assumed
 	/// to be a notification.
@@ -32,18 +30,32 @@ pub struct Notification {
 	pub method: String,
 	/// A Structured value that holds the parameter values to be used
 	/// during the invocation of the method. This member MAY be omitted.
-	pub params: Option<Params>,
+	#[serde(default = "default_params")]
+	pub params: Params,
 }
 
 /// Represents single jsonrpc call.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum Call {
 	/// Call method
 	MethodCall(MethodCall),
 	/// Fire notification
 	Notification(Notification),
 	/// Invalid call
-	Invalid(Id),
+	Invalid {
+		/// Call id (if known)
+		#[serde(default = "default_id")]
+		id: Id,
+	},
+}
+
+fn default_params() -> Params {
+	Params::None
+}
+
+fn default_id() -> Id {
+	Id::Null
 }
 
 impl From<MethodCall> for Call {
@@ -58,35 +70,9 @@ impl From<Notification> for Call {
 	}
 }
 
-impl Serialize for Call {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where S: Serializer {
-		match *self {
-			Call::MethodCall(ref m) => m.serialize(serializer),
-			Call::Notification(ref n) => n.serialize(serializer),
-			Call::Invalid(_) => Err(S::Error::custom("invalid call"))
-		}
-	}
-}
-
-impl<'a> Deserialize<'a> for Call {
-	fn deserialize<D>(deserializer: D) -> Result<Call, D::Error>
-	where D: Deserializer<'a> {
-		let v: Value = try!(Deserialize::deserialize(deserializer));
-		from_value(v.clone()).map(Call::Notification)
-			.or_else(|_: JsonError| from_value(v.clone()).map(Call::MethodCall))
-			.or_else(|_: JsonError| {
-				let id = v.get("id")
-					.and_then(|id| from_value(id.clone()).ok())
-					.unwrap_or(Id::Null);
-				Ok(Call::Invalid(id))
-			})
-			.map_err(|_: JsonError| D::Error::custom("")) // make the types match
-	}
-}
-
 /// Represents jsonrpc request.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum Request {
 	/// Single request (call)
 	Single(Call),
@@ -94,175 +80,189 @@ pub enum Request {
 	Batch(Vec<Call>)
 }
 
-impl Serialize for Request {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where S: Serializer {
-		match *self {
-			Request::Single(ref call) => call.serialize(serializer),
-			Request::Batch(ref calls) => calls.serialize(serializer),
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use serde_json::Value;
+
+	#[test]
+	fn method_call_serialize() {
+		use serde_json;
+		use serde_json::Value;
+
+		let m = MethodCall {
+			jsonrpc: Some(Version::V2),
+			method: "update".to_owned(),
+			params: Params::Array(vec![Value::from(1), Value::from(2)]),
+			id: Id::Num(1)
+		};
+
+		let serialized = serde_json::to_string(&m).unwrap();
+		assert_eq!(serialized, r#"{"jsonrpc":"2.0","method":"update","params":[1,2],"id":1}"#);
+	}
+
+	#[test]
+	fn notification_serialize() {
+		use serde_json;
+		use serde_json::Value;
+
+		let n = Notification {
+			jsonrpc: Some(Version::V2),
+			method: "update".to_owned(),
+			params: Params::Array(vec![Value::from(1), Value::from(2)])
+		};
+
+		let serialized = serde_json::to_string(&n).unwrap();
+		assert_eq!(serialized, r#"{"jsonrpc":"2.0","method":"update","params":[1,2]}"#);
+	}
+
+	#[test]
+	fn call_serialize() {
+		use serde_json;
+		use serde_json::Value;
+
+		let n = Call::Notification(Notification {
+			jsonrpc: Some(Version::V2),
+			method: "update".to_owned(),
+			params: Params::Array(vec![Value::from(1)])
+		});
+
+		let serialized = serde_json::to_string(&n).unwrap();
+		assert_eq!(serialized, r#"{"jsonrpc":"2.0","method":"update","params":[1]}"#);
+	}
+
+	#[test]
+	fn request_serialize_batch() {
+		use serde_json;
+
+		let batch = Request::Batch(vec![
+			Call::MethodCall(MethodCall {
+				jsonrpc: Some(Version::V2),
+				method: "update".to_owned(),
+				params: Params::Array(vec![Value::from(1), Value::from(2)]),
+				id: Id::Num(1)
+			}),
+			Call::Notification(Notification {
+				jsonrpc: Some(Version::V2),
+				method: "update".to_owned(),
+				params: Params::Array(vec![Value::from(1)])
+			})
+		]);
+
+		let serialized = serde_json::to_string(&batch).unwrap();
+		assert_eq!(serialized, r#"[{"jsonrpc":"2.0","method":"update","params":[1,2],"id":1},{"jsonrpc":"2.0","method":"update","params":[1]}]"#);
+
+	}
+
+	#[test]
+	fn notification_deserialize() {
+		use serde_json;
+		use serde_json::Value;
+
+		let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1,2]}"#;
+		let deserialized: Notification = serde_json::from_str(s).unwrap();
+
+		assert_eq!(deserialized, Notification {
+			jsonrpc: Some(Version::V2),
+			method: "update".to_owned(),
+			params: Params::Array(vec![Value::from(1), Value::from(2)])
+		});
+
+		let s = r#"{"jsonrpc": "2.0", "method": "foobar"}"#;
+		let deserialized: Notification = serde_json::from_str(s).unwrap();
+
+		assert_eq!(deserialized, Notification {
+			jsonrpc: Some(Version::V2),
+			method: "foobar".to_owned(),
+			params: Params::None,
+		});
+
+		let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1,2], "id": 1}"#;
+		let deserialized: Result<Notification, _> = serde_json::from_str(s);
+		assert!(deserialized.is_err())
+	}
+
+	#[test]
+	fn call_deserialize() {
+		use serde_json;
+
+		let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1]}"#;
+		let deserialized: Call = serde_json::from_str(s).unwrap();
+		assert_eq!(deserialized, Call::Notification(Notification {
+			jsonrpc: Some(Version::V2),
+			method: "update".to_owned(),
+			params: Params::Array(vec![Value::from(1)])
+		}));
+
+		let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1], "id": 1}"#;
+		let deserialized: Call = serde_json::from_str(s).unwrap();
+		assert_eq!(deserialized, Call::MethodCall(MethodCall {
+			jsonrpc: Some(Version::V2),
+			method: "update".to_owned(),
+			params: Params::Array(vec![Value::from(1)]),
+			id: Id::Num(1)
+		}));
+
+		let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [], "id": 1}"#;
+		let deserialized: Call = serde_json::from_str(s).unwrap();
+		assert_eq!(deserialized, Call::MethodCall(MethodCall {
+			jsonrpc: Some(Version::V2),
+			method: "update".to_owned(),
+			params: Params::Array(vec![]),
+			id: Id::Num(1)
+		}));
+
+		let s = r#"{"jsonrpc": "2.0", "method": "update", "params": null, "id": 1}"#;
+		let deserialized: Call = serde_json::from_str(s).unwrap();
+		assert_eq!(deserialized, Call::MethodCall(MethodCall {
+			jsonrpc: Some(Version::V2),
+			method: "update".to_owned(),
+			params: Params::None,
+			id: Id::Num(1)
+		}));
+
+
+		let s = r#"{"jsonrpc": "2.0", "method": "update", "id": 1}"#;
+		let deserialized: Call = serde_json::from_str(s).unwrap();
+		assert_eq!(deserialized, Call::MethodCall(MethodCall {
+			jsonrpc: Some(Version::V2),
+			method: "update".to_owned(),
+			params: Params::None,
+			id: Id::Num(1)
+		}));
+	}
+
+	#[test]
+	fn request_deserialize_batch() {
+		use serde_json;
+
+		let s = r#"[{}, {"jsonrpc": "2.0", "method": "update", "params": [1,2], "id": 1},{"jsonrpc": "2.0", "method": "update", "params": [1]}]"#;
+		let deserialized: Request = serde_json::from_str(s).unwrap();
+		assert_eq!(deserialized, Request::Batch(vec![
+			Call::Invalid { id: Id::Null },
+			Call::MethodCall(MethodCall {
+				jsonrpc: Some(Version::V2),
+				method: "update".to_owned(),
+				params: Params::Array(vec![Value::from(1), Value::from(2)]),
+				id: Id::Num(1)
+			}),
+			Call::Notification(Notification {
+				jsonrpc: Some(Version::V2),
+				method: "update".to_owned(),
+				params: Params::Array(vec![Value::from(1)])
+			})
+		]))
+	}
+
+	#[test]
+	fn request_invalid_returns_id() {
+		use serde_json;
+
+		let s = r#"{"id":120,"method":"my_method","params":["foo", "bar"],"extra_field":[]}"#;
+		let deserialized: Request = serde_json::from_str(s).unwrap();
+		match deserialized {
+			Request::Single(Call::Invalid { id: Id::Num(120) }) => {},
+			_ => panic!("Request wrongly deserialized: {:?}", deserialized),
 		}
-	}
-}
-
-impl<'a> Deserialize<'a> for Request {
-	fn deserialize<D>(deserializer: D) -> Result<Request, D::Error>
-	where D: Deserializer<'a> {
-		let v: Value = try!(Deserialize::deserialize(deserializer));
-		from_value(v.clone()).map(Request::Batch)
-			.or_else(|_| from_value(v).map(Request::Single))
-			.map_err(|_| D::Error::custom("")) // unreachable, but types must match
-	}
-}
-
-#[test]
-fn method_call_serialize() {
-	use serde_json;
-	use serde_json::Value;
-
-	let m = MethodCall {
-		jsonrpc: Some(Version::V2),
-		method: "update".to_owned(),
-		params: Some(Params::Array(vec![Value::from(1), Value::from(2)])),
-		id: Id::Num(1)
-	};
-
-	let serialized = serde_json::to_string(&m).unwrap();
-	assert_eq!(serialized, r#"{"jsonrpc":"2.0","method":"update","params":[1,2],"id":1}"#);
-}
-
-#[test]
-fn notification_serialize() {
-	use serde_json;
-	use serde_json::Value;
-
-	let n = Notification {
-		jsonrpc: Some(Version::V2),
-		method: "update".to_owned(),
-		params: Some(Params::Array(vec![Value::from(1), Value::from(2)]))
-	};
-
-	let serialized = serde_json::to_string(&n).unwrap();
-	assert_eq!(serialized, r#"{"jsonrpc":"2.0","method":"update","params":[1,2]}"#);
-}
-
-#[test]
-fn call_serialize() {
-	use serde_json;
-	use serde_json::Value;
-
-	let n = Call::Notification(Notification {
-		jsonrpc: Some(Version::V2),
-		method: "update".to_owned(),
-		params: Some(Params::Array(vec![Value::from(1)]))
-	});
-
-	let serialized = serde_json::to_string(&n).unwrap();
-	assert_eq!(serialized, r#"{"jsonrpc":"2.0","method":"update","params":[1]}"#);
-}
-
-#[test]
-fn request_serialize_batch() {
-	use serde_json;
-
-	let batch = Request::Batch(vec![
-		Call::MethodCall(MethodCall {
-			jsonrpc: Some(Version::V2),
-			method: "update".to_owned(),
-			params: Some(Params::Array(vec![Value::from(1), Value::from(2)])),
-			id: Id::Num(1)
-		}),
-		Call::Notification(Notification {
-			jsonrpc: Some(Version::V2),
-			method: "update".to_owned(),
-			params: Some(Params::Array(vec![Value::from(1)]))
-		})
-	]);
-
-	let serialized = serde_json::to_string(&batch).unwrap();
-	assert_eq!(serialized, r#"[{"jsonrpc":"2.0","method":"update","params":[1,2],"id":1},{"jsonrpc":"2.0","method":"update","params":[1]}]"#);
-
-}
-
-#[test]
-fn notification_deserialize() {
-	use serde_json;
-	use serde_json::Value;
-
-	let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1,2]}"#;
-	let deserialized: Notification = serde_json::from_str(s).unwrap();
-
-	assert_eq!(deserialized, Notification {
-		jsonrpc: Some(Version::V2),
-		method: "update".to_owned(),
-		params: Some(Params::Array(vec![Value::from(1), Value::from(2)]))
-	});
-
-	let s = r#"{"jsonrpc": "2.0", "method": "foobar"}"#;
-	let deserialized: Notification = serde_json::from_str(s).unwrap();
-
-	assert_eq!(deserialized, Notification {
-		jsonrpc: Some(Version::V2),
-		method: "foobar".to_owned(),
-		params: None
-	});
-
-	let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1,2], "id": 1}"#;
-	let deserialized: Result<Notification, _> = serde_json::from_str(s);
-	assert!(deserialized.is_err())
-}
-
-#[test]
-fn call_deserialize() {
-	use serde_json;
-
-	let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1]}"#;
-	let deserialized: Call = serde_json::from_str(s).unwrap();
-	assert_eq!(deserialized, Call::Notification(Notification {
-		jsonrpc: Some(Version::V2),
-		method: "update".to_owned(),
-		params: Some(Params::Array(vec![Value::from(1)]))
-	}));
-
-	let s = r#"{"jsonrpc": "2.0", "method": "update", "params": [1], "id": 1}"#;
-	let deserialized: Call = serde_json::from_str(s).unwrap();
-	assert_eq!(deserialized, Call::MethodCall(MethodCall {
-		jsonrpc: Some(Version::V2),
-		method: "update".to_owned(),
-		params: Some(Params::Array(vec![Value::from(1)])),
-		id: Id::Num(1)
-	}));
-}
-
-#[test]
-fn request_deserialize_batch() {
-	use serde_json;
-
-	let s = r#"[1, {"jsonrpc": "2.0", "method": "update", "params": [1,2], "id": 1},{"jsonrpc": "2.0", "method": "update", "params": [1]}]"#;
-	let deserialized: Request = serde_json::from_str(s).unwrap();
-	assert_eq!(deserialized, Request::Batch(vec![
-		Call::Invalid(Id::Null),
-		Call::MethodCall(MethodCall {
-			jsonrpc: Some(Version::V2),
-			method: "update".to_owned(),
-			params: Some(Params::Array(vec![Value::from(1), Value::from(2)])),
-			id: Id::Num(1)
-		}),
-		Call::Notification(Notification {
-			jsonrpc: Some(Version::V2),
-			method: "update".to_owned(),
-			params: Some(Params::Array(vec![Value::from(1)]))
-		})
-	]))
-}
-
-#[test]
-fn request_invalid_returns_id() {
-	use serde_json;
-
-	let s = r#"{"id":120,"method":"my_method","params":["foo", "bar"],"extra_field":[]}"#;
-	let deserialized: Request = serde_json::from_str(s).unwrap();
-	match deserialized {
-		Request::Single(Call::Invalid(Id::Num(120))) => {},
-		_ => panic!("Request wrongly deserialized: {:?}", deserialized),
 	}
 }

--- a/core/src/types/version.rs
+++ b/core/src/types/version.rs
@@ -43,4 +43,3 @@ impl<'a> Visitor<'a> for VersionVisitor {
 		}
 	}
 }
-

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -152,7 +152,7 @@ impl<M: jsonrpc::Metadata + Default> MetaExtractor<M> for NoopExtractor {
 }
 //
 /// RPC Handler bundled with metadata extractor.
-pub struct Rpc<M: jsonrpc::Metadata = (), S: jsonrpc::Middleware<M> = jsonrpc::NoopMiddleware> {
+pub struct Rpc<M: jsonrpc::Metadata = (), S: jsonrpc::Middleware<M> = jsonrpc::middleware::Noop> {
 	/// RPC Handler
 	pub handler: Arc<MetaIoHandler<M, S>>,
 	/// Metadata extractor
@@ -190,7 +190,7 @@ pub enum RestApi {
 }
 
 /// Convenient JSON-RPC HTTP Server builder.
-pub struct ServerBuilder<M: jsonrpc::Metadata = (), S: jsonrpc::Middleware<M> = jsonrpc::NoopMiddleware> {
+pub struct ServerBuilder<M: jsonrpc::Metadata = (), S: jsonrpc::Middleware<M> = jsonrpc::middleware::Noop> {
 	handler: Arc<MetaIoHandler<M, S>>,
 	remote: UninitializedRemote,
 	meta_extractor: Arc<MetaExtractor<M>>,

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -42,6 +42,7 @@ mod tests;
 use std::io;
 use std::sync::{mpsc, Arc};
 use std::net::SocketAddr;
+use std::thread;
 
 use hyper::server;
 use jsonrpc_core as jsonrpc;
@@ -196,14 +197,14 @@ pub struct ServerBuilder<M: jsonrpc::Metadata = (), S: jsonrpc::Middleware<M> = 
 	meta_extractor: Arc<MetaExtractor<M>>,
 	request_middleware: Arc<RequestMiddleware>,
 	cors_domains: CorsDomains,
+	cors_max_age: Option<u32>,
 	allowed_hosts: AllowedHosts,
 	rest_api: RestApi,
+	health_api: Option<(String, String)>,
 	keep_alive: bool,
 	threads: usize,
 	max_request_body_size: usize,
 }
-
-const SENDER_PROOF: &'static str = "Server initialization awaits local address.";
 
 impl<M: jsonrpc::Metadata + Default, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 	/// Creates new `ServerBuilder` for given `IoHandler`.
@@ -234,8 +235,10 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 			meta_extractor: Arc::new(extractor),
 			request_middleware: Arc::new(NoopRequestMiddleware::default()),
 			cors_domains: None,
+			cors_max_age: None,
 			allowed_hosts: None,
 			rest_api: RestApi::Disabled,
+			health_api: None,
 			keep_alive: true,
 			threads: 1,
 			max_request_body_size: 5 * 1024 * 1024,
@@ -243,21 +246,40 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 	}
 
 	/// Utilize existing event loop remote to poll RPC results.
+	///
 	/// Applies only to 1 of the threads. Other threads will spawn their own Event Loops.
 	pub fn event_loop_remote(mut self, remote: tokio_core::reactor::Remote) -> Self {
 		self.remote = UninitializedRemote::Shared(remote);
 		self
 	}
 
-	/// Enable the REST -> RPC converter. Allows you to invoke RPCs
-	/// by sending `POST /<method>/<param1>/<param2>` requests
+	/// Enable the REST -> RPC converter.
+	///
+	/// Allows you to invoke RPCs by sending `POST /<method>/<param1>/<param2>` requests
 	/// (with no body). Disabled by default.
 	pub fn rest_api(mut self, rest_api: RestApi) -> Self {
 		self.rest_api = rest_api;
 		self
 	}
 
-	/// Sets Enables or disables HTTP keep-alive.
+	/// Enable health endpoint.
+	///
+	/// Allows you to expose one of the methods under `GET /<path>`
+	/// The method will be invoked with no parameters.
+	/// Error returned from the method will be converted to status `500` response.
+	///
+	/// Expects a tuple with `(<path>, <rpc-method-name>)`.
+	pub fn health_api<A, B, T>(mut self, health_api: T) -> Self where
+		T: Into<Option<(A, B)>>,
+		A: Into<String>,
+		B: Into<String>,
+	{
+		self.health_api = health_api.into().map(|(a, b)| (a.into(), b.into()));
+		self
+	}
+
+	/// Enables or disables HTTP keep-alive.
+	///
 	/// Default is true.
 	pub fn keep_alive(mut self, val: bool) -> Self {
 		self.keep_alive  = val;
@@ -265,6 +287,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 	}
 
 	/// Sets number of threads of the server to run.
+	///
 	/// Panics when set to `0`.
 	#[cfg(not(unix))]
 	pub fn threads(mut self, _threads: usize) -> Self {
@@ -273,6 +296,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 	}
 
 	/// Sets number of threads of the server to run.
+	///
 	/// Panics when set to `0`.
 	#[cfg(unix)]
 	pub fn threads(mut self, threads: usize) -> Self {
@@ -283,6 +307,16 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 	/// Configures a list of allowed CORS origins.
 	pub fn cors(mut self, cors_domains: DomainsValidation<AccessControlAllowOrigin>) -> Self {
 		self.cors_domains = cors_domains.into();
+		self
+	}
+
+	/// Configure CORS `AccessControlMaxAge` header returned.
+	///
+	/// Passing `Some(millis)` informs the client that the CORS preflight request is not necessary
+	/// for at list `millis` ms.
+	/// Disabled by default.
+	pub fn cors_max_age<T: Into<Option<u32>>>(mut self, cors_max_age: T) -> Self {
+		self.cors_max_age = cors_max_age.into();
 		self
 	}
 
@@ -319,6 +353,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 	/// Start this JSON-RPC HTTP server trying to bind to specified `SocketAddr`.
 	pub fn start_http(self, addr: &SocketAddr) -> io::Result<Server> {
 		let cors_domains = self.cors_domains;
+		let cors_max_age = self.cors_max_age;
 		let request_middleware = self.request_middleware;
 		let allowed_hosts = self.allowed_hosts;
 		let jsonrpc_handler = Rpc {
@@ -326,6 +361,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 			extractor: self.meta_extractor,
 		};
 		let rest_api = self.rest_api;
+		let health_api = self.health_api;
 		let keep_alive = self.keep_alive;
 		let reuse_port = self.threads > 1;
 
@@ -338,10 +374,12 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 			eloop.remote(),
 			addr.to_owned(),
 			cors_domains.clone(),
+			cors_max_age,
 			request_middleware.clone(),
 			allowed_hosts.clone(),
 			jsonrpc_handler.clone(),
 			rest_api,
+			health_api.clone(),
 			keep_alive,
 			reuse_port,
 			req_max_size,
@@ -355,10 +393,12 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 				eloop.remote(),
 				addr.to_owned(),
 				cors_domains.clone(),
+				cors_max_age,
 				request_middleware.clone(),
 				allowed_hosts.clone(),
 				jsonrpc_handler.clone(),
 				rest_api,
+				health_api.clone(),
 				keep_alive,
 				reuse_port,
 				req_max_size,
@@ -395,10 +435,12 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 	remote: tokio_core::reactor::Remote,
 	addr: SocketAddr,
 	cors_domains: CorsDomains,
+	cors_max_age: Option<u32>,
 	request_middleware: Arc<RequestMiddleware>,
 	allowed_hosts: AllowedHosts,
 	jsonrpc_handler: Rpc<M, S>,
 	rest_api: RestApi,
+	health_api: Option<(String, String)>,
 	keep_alive: bool,
 	reuse_port: bool,
 	max_request_body_size: usize,
@@ -427,13 +469,17 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 		let bind_result = match bind() {
 			Ok((listener, local_addr)) => {
 				// Send local address
-				local_addr_tx.send(Ok(local_addr)).expect(SENDER_PROOF);
-
-				futures::future::ok((listener, local_addr))
+				match local_addr_tx.send(Ok(local_addr)) {
+					Ok(_) => futures::future::ok((listener, local_addr)),
+					Err(_) => {
+						warn!("Thread {:?} unable to reach receiver, closing server", thread::current().name());
+						futures::future::err(())
+					},
+				}
 			},
 			Err(err) => {
 				// Send error
-				local_addr_tx.send(Err(err)).expect(SENDER_PROOF);
+				let _send_result = local_addr_tx.send(Err(err));
 
 				futures::future::err(())
 			}
@@ -454,9 +500,11 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 					http.bind_connection(&handle, socket, addr, ServerHandler::new(
 						jsonrpc_handler.clone(),
 						cors_domains.clone(),
+						cors_max_age,
 						allowed_hosts.clone(),
 						request_middleware.clone(),
 						rest_api,
+						health_api.clone(),
 						max_request_body_size,
 					));
 					Ok(())
@@ -529,4 +577,3 @@ impl Drop for Server {
 		});
 	}
 }
-

--- a/http/src/response.rs
+++ b/http/src/response.rs
@@ -30,12 +30,21 @@ impl Response {
 		}
 	}
 
-	/// Create a response for internal error.
-	pub fn internal_error() -> Self {
+	/// Create a response for plaintext internal error.
+	pub fn internal_error<T: Into<String>>(msg: T) -> Self {
 		Response {
-			code: StatusCode::Forbidden,
+			code: StatusCode::InternalServerError,
 			content_type: header::ContentType::plaintext(),
-			content: "Provided Host header is not whitelisted.\n".to_owned(),
+			content: format!("Internal Server Error: {}", msg.into()),
+		}
+	}
+
+	/// Create a json response for service unavailable.
+	pub fn service_unavailable<T: Into<String>>(msg: T) -> Self {
+		Response {
+			code: StatusCode::ServiceUnavailable,
+			content_type: header::ContentType::json(),
+			content: msg.into(),
 		}
 	}
 

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -13,12 +13,12 @@ log = "0.4"
 tokio-service = "0.1"
 jsonrpc-core = { version = "8.0", path = "../core" }
 jsonrpc-server-utils = { version = "8.0", path = "../server-utils" }
-parity-tokio-ipc = { git = "https://github.com/nikvolf/parity-tokio-ipc" }
+parity-tokio-ipc = { git = "https://github.com/nikvolf/parity-tokio-ipc", branch = "stable" }
+parking_lot = "0.6"
 
 [dev-dependencies]
 env_logger = "0.5"
 lazy_static = "1.0"
-parking_lot = "0.6"
 
 [target.'cfg(not(windows))'.dev-dependencies]
 tokio-uds = "0.2"

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -5,6 +5,7 @@
 extern crate jsonrpc_server_utils as server_utils;
 extern crate parity_tokio_ipc;
 extern crate tokio_service;
+extern crate parking_lot;
 
 pub extern crate jsonrpc_core;
 
@@ -20,8 +21,8 @@ mod meta;
 
 use jsonrpc_core as jsonrpc;
 
-pub use meta::{MetaExtractor, RequestContext};
-pub use server::{Server, ServerBuilder};
+pub use meta::{MetaExtractor, NoopExtractor, RequestContext};
+pub use server::{Server, ServerBuilder, CloseHandle,SecurityAttributes};
 
 pub use self::server_utils::tokio_core;
 pub use self::server_utils::session::{SessionStats, SessionId};

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -24,5 +24,5 @@ use jsonrpc_core as jsonrpc;
 pub use meta::{MetaExtractor, NoopExtractor, RequestContext};
 pub use server::{Server, ServerBuilder, CloseHandle,SecurityAttributes};
 
-pub use self::server_utils::tokio_core;
+pub use self::server_utils::{tokio_core, codecs::Separator};
 pub use self::server_utils::session::{SessionStats, SessionId};

--- a/ipc/src/server.rs
+++ b/ipc/src/server.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std;
 use std::sync::Arc;
 
@@ -10,8 +12,12 @@ use server_utils::tokio_core::reactor::Remote;
 use server_utils::tokio_io::AsyncRead;
 use server_utils::{reactor, session, codecs};
 
+use parking_lot::Mutex;
+
 use meta::{MetaExtractor, NoopExtractor, RequestContext};
 use select_with_weak::SelectWithWeakExt;
+use parity_tokio_ipc::Endpoint;
+pub use parity_tokio_ipc::SecurityAttributes;
 
 /// IPC server session
 pub struct Service<M: Metadata = (), S: Middleware<M> = middleware::Noop> {
@@ -48,6 +54,7 @@ pub struct ServerBuilder<M: Metadata = (), S: Middleware<M> = middleware::Noop> 
 	remote: reactor::UninitializedRemote,
 	incoming_separator: codecs::Separator,
 	outgoing_separator: codecs::Separator,
+	security_attributes: SecurityAttributes,
 }
 
 impl<M: Metadata + Default, S: Middleware<M>> ServerBuilder<M, S> {
@@ -72,6 +79,7 @@ impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
 			remote: reactor::UninitializedRemote::Unspawned,
 			incoming_separator: codecs::Separator::Empty,
 			outgoing_separator: codecs::Separator::default(),
+			security_attributes: SecurityAttributes::empty(),
 		}
 	}
 
@@ -82,7 +90,7 @@ impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
 	}
 
 	/// Sets session metadata extractor.
-	pub fn session_metadata_extractor<X>(mut self, meta_extractor: X) -> Self where
+	pub fn session_meta_extractor<X>(mut self, meta_extractor: X) -> Self where
 		X: MetaExtractor<M>,
 	{
 		self.meta_extractor = Arc::new(meta_extractor);
@@ -102,7 +110,13 @@ impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
 		self
 	}
 
-	/// Run server (in a separate thread)
+	/// Sets the security attributes for the underlying IPC socket/pipe
+	pub fn set_security_attributes(mut self, attr: SecurityAttributes) -> Self {
+		self.security_attributes = attr;
+		self
+	}
+
+	/// Creates a new server from the given endpoint.
 	pub fn start(self, path: &str) -> std::io::Result<Server> {
 		let remote = self.remote.initialize()?;
 		let rpc_handler = self.handler;
@@ -113,19 +127,24 @@ impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
 		let outgoing_separator = self.outgoing_separator;
 		let (stop_signal, stop_receiver) = oneshot::channel();
 		let (start_signal, start_receiver) = oneshot::channel();
+		let (wait_signal, wait_receiver) = oneshot::channel();
+		let security_attributes = self.security_attributes;
 
 		remote.remote().spawn(move |handle| {
-			use parity_tokio_ipc::Endpoint;
+
+			let mut endpoint = Endpoint::new(endpoint_addr);
+			endpoint.set_security_attributes(security_attributes);
 
 			if cfg!(unix) {
 				// warn about existing file and remove it
-				if ::std::fs::remove_file(&endpoint_addr).is_ok() {
-					warn!("Removed existing file '{}'.", &endpoint_addr);
+				if ::std::fs::remove_file(endpoint.path()).is_ok() {
+					warn!("Removed existing file '{}'.", endpoint.path());
 				}
 			}
 
-			let listener = match Endpoint::new(endpoint_addr, handle) {
-				Ok(l) => l,
+			let endpoint_handle = handle.clone();
+			let connections = match endpoint.incoming(endpoint_handle) {
+				Ok(connections) => connections,
 				Err(e) => {
 					start_signal.send(Err(e)).expect("Cannot fail since receiver never dropped before receiving");
 					return future::Either::A(future::ok(()));
@@ -133,7 +152,6 @@ impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
 			};
 
 			let remote = handle.remote().clone();
-			let connections = listener.incoming();
 			let mut id = 0u64;
 
 			let server = connections.for_each(move |(io_stream, remote_id)| {
@@ -194,13 +212,25 @@ impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
 			let stop = stop_receiver.map_err(|_| std::io::ErrorKind::Interrupted.into());
 			future::Either::B(
 				server.select(stop)
-					.map(|_| ())
+					.map(|_| {
+						let _ = wait_signal.send(());
+						()
+					})
 					.map_err(|_| ())
 			)
 		});
 
+		let handle = InnerHandles {
+						remote: Some(remote),
+						stop: Some(stop_signal),
+						path: path.to_owned(),
+		};
+
 		match start_receiver.wait().expect("Message should always be sent") {
-			Ok(()) => Ok(Server { path: path.to_owned(), remote: Some(remote), stop: Some(stop_signal) }),
+			Ok(()) => Ok(Server {
+							handles: Arc::new(Mutex::new(handle)),
+							wait_handle: Some(wait_receiver),
+			}),
 			Err(e) => Err(e)
 		}
 	}
@@ -208,36 +238,63 @@ impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
 
 
 /// IPC Server handle
+#[derive(Debug)]
 pub struct Server {
-	path: String,
-	remote: Option<reactor::Remote>,
-	stop: Option<oneshot::Sender<()>>,
+	handles: Arc<Mutex<InnerHandles>>,
+	wait_handle: Option<oneshot::Receiver<()>>,
 }
 
 impl Server {
 	/// Closes the server (waits for finish)
-	pub fn close(mut self) {
-		self.stop.take().map(|stop| stop.send(()));
-		self.remote.take().unwrap().close();
-		self.clear_file();
+	pub fn close(self) {
+		self.handles.lock().close();
+	}
+
+	/// Creates a close handle that can be used to stop the server remotely
+	pub fn close_handle(&self) -> CloseHandle {
+		CloseHandle {
+			inner: self.handles.clone(),
+		}
 	}
 
 	/// Wait for the server to finish
 	pub fn wait(mut self) {
-		self.remote.take().unwrap().wait();
+		self.wait_handle.take().map(|wait_receiver| wait_receiver.wait());
 	}
 
-	/// Remove socket file
-	fn clear_file(&self) {
+}
+
+
+#[derive(Debug)]
+struct InnerHandles {
+	remote: Option<reactor::Remote>,
+	stop: Option<oneshot::Sender<()>>,
+	path: String,
+}
+
+impl InnerHandles {
+	pub fn close(&mut self) {
+		let _ = self.stop.take().map(|stop| stop.send(()));
+		self.remote.take().map(|remote| remote.close());
 		let _ = ::std::fs::remove_file(&self.path); // ignore error, file could have been gone somewhere
 	}
 }
 
-impl Drop for Server {
+impl Drop for InnerHandles {
 	fn drop(&mut self) {
-		let _ = self.stop.take().map(|stop| stop.send(()));
-		self.remote.take().map(|remote| remote.close());
-		self.clear_file();
+		self.close();
+	}
+}
+/// `CloseHandle` allows one to stop an `IpcServer` remotely.
+#[derive(Clone)]
+pub struct CloseHandle {
+	inner: Arc<Mutex<InnerHandles>>,
+}
+
+impl CloseHandle {
+	/// `close` closes the corresponding `IpcServer` instance.
+	pub fn close(self) {
+		self.inner.lock().close();
 	}
 }
 
@@ -245,19 +302,21 @@ impl Drop for Server {
 #[cfg(not(windows))]
 mod tests {
 	extern crate tokio_uds;
-	extern crate parking_lot;
 
 	use std::thread;
 	use std::sync::Arc;
+	use std::time;
 	use super::{ServerBuilder, Server};
 	use jsonrpc::{MetaIoHandler, Value};
 	use jsonrpc::futures::{Future, future, Stream, Sink};
 	use jsonrpc::futures::sync::{mpsc, oneshot};
 	use self::tokio_uds::UnixStream;
-	use self::parking_lot::Mutex;
+	use parking_lot::Mutex;
 	use server_utils::tokio_io::AsyncRead;
 	use server_utils::codecs;
-	use meta::{MetaExtractor, RequestContext};
+	use tokio_core::reactor::{Timeout, Core};
+	use meta::{MetaExtractor, RequestContext, NoopExtractor};
+	use super::SecurityAttributes;
 
 	fn server_builder() -> ServerBuilder {
 		let mut io = MetaIoHandler::<()>::default();
@@ -486,5 +545,57 @@ mod tests {
 			.and_then(|drop_receiver| drop_receiver.0.unwrap().map_err(|_| ()))
 			.wait().unwrap();
 		server.close();
+	}
+
+	#[test]
+	fn close_handle() {
+		::logger::init_log();
+		let path = "/tmp/test-ipc-90000";
+		let server = run(path);
+		let handle = server.close_handle();
+		handle.close();
+		assert!(UnixStream::connect(path).wait().is_err(), "Connection to the closed socket should fail");
+	}
+
+	#[test]
+	fn close_when_waiting() {
+		::logger::init_log();
+		let path = "/tmp/test-ipc-70000";
+		let server = run(path);
+		let close_handle = server.close_handle();
+		let (tx, rx) = oneshot::channel();
+
+		thread::spawn(move || {
+			thread::sleep(time::Duration::from_millis(100));
+			close_handle.close();
+		});
+		thread::spawn(move || {
+			server.wait();
+			tx.send(true).expect("failed to report that the server has stopped");
+		});
+
+		let mut core = Core::new().expect("failed to create a core");
+		let timeout = Timeout::new(time::Duration::from_millis(500), &core.handle())
+			.expect("failed to setup a timer")
+			.map(|_| false)
+			.map_err(|_| ());
+
+		let result_fut = rx.map_err(|_| ())
+			.select(timeout)
+			.map(|(result, _next_fut)| result)
+			.map_err(|_| ());
+		let result = core.run(result_fut);
+		assert_eq!(result, Ok(true), "Wait timeout exceeded");
+		assert!(UnixStream::connect(path).wait().is_err(), "Connection to the closed socket should fail");
+	}
+
+	#[test]
+	fn runs_with_security_attributes() {
+		let path = "/tmp/test-ipc-9001";
+		let io = MetaIoHandler::<Arc<()>>::default();
+		ServerBuilder::with_meta_extractor(io, NoopExtractor)
+			.set_security_attributes(SecurityAttributes::empty())
+			.start(path)
+			.expect("Server must run with no issues");
 	}
 }

--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -255,6 +255,12 @@ impl<T> Into<Option<T>> for Trailing<T> {
 	}
 }
 
+impl<T> From<Option<T>> for Trailing<T> {
+	fn from(o: Option<T>) -> Self {
+		Trailing(o)
+	}
+}
+
 impl<T: DeserializeOwned> Trailing<T> {
 	/// Returns a underlying value if present or provided value.
 	pub fn unwrap_or(self, other: T) -> T {

--- a/macros/src/util.rs
+++ b/macros/src/util.rs
@@ -17,6 +17,7 @@ pub fn invalid_params<T>(param: &str, details: T) -> Error where T: fmt::Debug {
 pub fn expect_no_params(params: Params) -> core::Result<()> {
 	match params {
 		Params::None => Ok(()),
+		Params::Array(ref v) if v.is_empty() => Ok(()),
 		p => Err(invalid_params("No parameters were expected", p)),
 	}
 }

--- a/macros/tests/macros.rs
+++ b/macros/tests/macros.rs
@@ -1,0 +1,73 @@
+
+extern crate serde_json;
+extern crate jsonrpc_core;
+#[macro_use]
+extern crate jsonrpc_macros;
+
+use jsonrpc_core::{IoHandler, Response};
+
+pub enum MyError {}
+impl From<MyError> for jsonrpc_core::Error {
+	fn from(_e: MyError) -> Self {
+		unreachable!()
+	}
+}
+
+type Result<T> = ::std::result::Result<T, MyError>;
+
+build_rpc_trait! {
+	pub trait Rpc {
+		/// Returns a protocol version
+		#[rpc(name = "protocolVersion")]
+		fn protocol_version(&self) -> Result<String>;
+
+		/// Adds two numbers and returns a result
+		#[rpc(name = "add")]
+		fn add(&self, u64, u64) -> Result<u64>;
+	}
+}
+
+#[derive(Default)]
+struct RpcImpl;
+
+impl Rpc for RpcImpl {
+	fn protocol_version(&self) -> Result<String> {
+		Ok("version1".into())
+	}
+
+	fn add(&self, a: u64, b: u64) -> Result<u64> {
+		Ok(a + b)
+	}
+}
+
+#[test]
+fn should_accept_empty_array_as_no_params() {
+	let mut io = IoHandler::new();
+	let rpc = RpcImpl::default();
+	io.extend_with(rpc.to_delegate());
+
+	// when
+	let req1 = r#"{"jsonrpc":"2.0","id":1,"method":"protocolVersion","params":[]}"#;
+	let req2 = r#"{"jsonrpc":"2.0","id":1,"method":"protocolVersion","params":null}"#;
+	let req3 = r#"{"jsonrpc":"2.0","id":1,"method":"protocolVersion"}"#;
+
+	let res1 = io.handle_request_sync(req1);
+	let res2 = io.handle_request_sync(req2);
+	let res3 = io.handle_request_sync(req3);
+	let expected = r#"{
+		"jsonrpc": "2.0",
+		"result": "version1",
+		"id": 1
+	}"#;
+	let expected: Response = serde_json::from_str(expected).unwrap();
+
+	// then
+	let result1: Response = serde_json::from_str(&res1.unwrap()).unwrap();
+	assert_eq!(expected, result1);
+
+	let result2: Response = serde_json::from_str(&res2.unwrap()).unwrap();
+	assert_eq!(expected, result2);
+
+	let result3: Response = serde_json::from_str(&res3.unwrap()).unwrap();
+	assert_eq!(expected, result3);
+}

--- a/minihttp/src/tests.rs
+++ b/minihttp/src/tests.rs
@@ -215,7 +215,7 @@ fn should_return_method_not_found() {
 	let response = request(server,
 		Method::Post,
 		content_type_json(),
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -236,7 +236,7 @@ fn should_add_cors_headers() {
 			headers.set(header::Origin::new("http", "parity.io", None));
 			headers
 		},
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -261,7 +261,7 @@ fn should_add_cors_headers_for_options() {
 			headers.set(header::Origin::new("http", "parity.io", None));
 			headers
 		},
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -287,7 +287,7 @@ fn should_not_process_request_with_invalid_cors() {
 			headers.set(header::Origin::new("http", "fake.io", None));
 			headers
 		},
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -308,7 +308,7 @@ fn should_add_cors_header_for_null_origin() {
 			headers.append_raw("origin", b"null".to_vec());
 			headers
 		},
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -333,7 +333,7 @@ fn should_reject_invalid_hosts() {
 			headers.set_raw("Host", vec![b"127.0.0.1:8080".to_vec()]);
 			headers
 		},
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -354,7 +354,7 @@ fn should_allow_if_host_is_valid() {
 			headers.set_raw("Host", vec![b"parity.io".to_vec()]);
 			headers
 		},
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -376,7 +376,7 @@ fn should_always_allow_the_bind_address() {
 			headers.set_raw("Host", vec![format!("{}", addr).as_bytes().to_vec()]);
 			headers
 		},
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -398,7 +398,7 @@ fn should_always_allow_the_bind_address_as_localhost() {
 			headers.set_raw("Host", vec![format!("localhost:{}", addr.port()).as_bytes().to_vec()]);
 			headers
 		},
-		r#"{"jsonrpc":"2.0","id":"1","method":"x"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"x"}"#,
 	);
 
 	// then
@@ -415,7 +415,7 @@ fn should_handle_sync_requests_correctly() {
 	let response = request(server,
 		Method::Post,
 		content_type_json(),
-		r#"{"jsonrpc":"2.0","id":"1","method":"hello"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"hello"}"#,
 	);
 
 	// then
@@ -432,7 +432,7 @@ fn should_handle_async_requests_with_immediate_response_correctly() {
 	let response = request(server,
 		Method::Post,
 		content_type_json(),
-		r#"{"jsonrpc":"2.0","id":"1","method":"hello_async"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"hello_async"}"#,
 	);
 
 	// then
@@ -449,7 +449,7 @@ fn should_handle_async_requests_correctly() {
 	let response = request(server,
 		Method::Post,
 		content_type_json(),
-		r#"{"jsonrpc":"2.0","id":"1","method":"hello_async2"}"#,
+		r#"{"jsonrpc":"2.0","id":1,"method":"hello_async2"}"#,
 	);
 
 	// then
@@ -466,7 +466,7 @@ fn should_handle_sync_batch_requests_correctly() {
 	let response = request(server,
 		Method::Post,
 		content_type_json(),
-		r#"[{"jsonrpc":"2.0","id":"1","method":"hello"}]"#,
+		r#"[{"jsonrpc":"2.0","id":1,"method":"hello"}]"#,
 	);
 
 	// then

--- a/pubsub/src/handler.rs
+++ b/pubsub/src/handler.rs
@@ -39,7 +39,7 @@ impl<F, I> UnsubscribeRpcMethod for F where
 }
 
 /// Publish-Subscribe extension of `IoHandler`.
-pub struct PubSubHandler<T: PubSubMetadata, S: core::Middleware<T> = core::NoopMiddleware> {
+pub struct PubSubHandler<T: PubSubMetadata, S: core::Middleware<T> = core::middleware::Noop> {
 	handler: core::MetaIoHandler<T, S>,
 }
 

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -104,11 +104,11 @@ impl Sink {
 		let notification = core::Notification {
 			jsonrpc: Some(core::Version::V2),
 			method: self.notification.clone(),
-			params: Some(val),
+			params: val,
 		};
 		(
 			core::to_string(&notification).expect("Notification serialization never fails."),
-			notification.params.expect("Always Some"),
+			notification.params,
 		)
 	}
 }

--- a/stdio/Cargo.toml
+++ b/stdio/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "jsonrpc-stdio-server"
+description = "STDIN/STDOUT server for JSON-RPC"
+version = "0.1.0"
+authors = ["cmichi <mich@elmueller.net>"]
+license = "MIT"
+homepage = "https://github.com/paritytech/jsonrpc"
+repository = "https://github.com/paritytech/jsonrpc"
+documentation = "https://paritytech.github.io/jsonrpc/jsonrpc_stdio_server/index.html"
+
+[dependencies]
+futures = "0.1.23"
+jsonrpc-core = { version = "8.0", path = "../core" }
+log = "0.4"
+tokio = "0.1.7"
+tokio-codec = "0.1.0"
+tokio-io = "0.1.7"
+tokio-stdin-stdout = "0.1.4"
+
+[dev-dependencies]
+lazy_static = "1.0"
+env_logger = "0.5"
+
+[badges]
+travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/stdio/README.md
+++ b/stdio/README.md
@@ -1,0 +1,32 @@
+# jsonrpc-stdio-server
+STDIN/STDOUT server for JSON-RPC 2.0.
+Takes one request per line and outputs each response on a new line.
+
+[Documentation](http://paritytech.github.io/jsonrpc/jsonrpc_stdio_server/index.html)
+
+## Example
+
+`Cargo.toml`
+
+```
+[dependencies]
+jsonrpc-stdio-server = { git = "https://github.com/paritytech/jsonrpc" }
+```
+
+`main.rs`
+
+```rust
+extern crate jsonrpc_stdio_server;
+
+use jsonrpc_stdio_server::server;
+use jsonrpc_stdio_server::jsonrpc_core::*;
+
+fn main() {
+	let mut io = IoHandler::default();
+	io.add_method("say_hello", |_params| {
+		Ok(Value::String("hello".to_owned()))
+	});
+
+	ServerBuilder::new(io).build();
+}
+```

--- a/stdio/examples/stdio.rs
+++ b/stdio/examples/stdio.rs
@@ -1,0 +1,13 @@
+extern crate jsonrpc_stdio_server;
+
+use jsonrpc_stdio_server::ServerBuilder;
+use jsonrpc_stdio_server::jsonrpc_core::*;
+
+fn main() {
+	let mut io = IoHandler::default();
+	io.add_method("say_hello", |_params| {
+		Ok(Value::String("hello".to_owned()))
+	});
+
+	ServerBuilder::new(io).build();
+}

--- a/stdio/src/lib.rs
+++ b/stdio/src/lib.rs
@@ -1,0 +1,76 @@
+//! jsonrpc server using stdin/stdout
+//!
+//! ```no_run
+//! extern crate jsonrpc_stdio_server;
+//!
+//! use jsonrpc_stdio_server::ServerBuilder;
+//! use jsonrpc_stdio_server::jsonrpc_core::*;
+//!
+//! fn main() {
+//! 	let mut io = IoHandler::default();
+//! 	io.add_method("say_hello", |_params| {
+//! 		Ok(Value::String("hello".to_owned()))
+//! 	});
+//!
+//! 	ServerBuilder::new(io).build();
+//! }
+//! ```
+
+#![warn(missing_docs)]
+
+extern crate futures;
+extern crate tokio;
+extern crate tokio_codec;
+extern crate tokio_io;
+extern crate tokio_stdin_stdout;
+#[macro_use] extern crate log;
+
+pub extern crate jsonrpc_core;
+
+use std::sync::Arc;
+use tokio::prelude::{Future, Stream};
+use tokio_codec::{FramedRead, FramedWrite, LinesCodec};
+use jsonrpc_core::{IoHandler};
+
+/// Stdio server builder
+pub struct ServerBuilder {
+	handler: Arc<IoHandler>,
+}
+
+impl ServerBuilder {
+	/// Returns a new server instance
+	pub fn new<T>(handler: T) -> Self where T: Into<IoHandler> {
+		ServerBuilder { handler: Arc::new(handler.into()) }
+	}
+
+	/// Will block until EOF is read or until an error occurs.
+	/// The server reads from STDIN line-by-line, one request is taken
+	/// per line and each response is written to STDOUT on a new line.
+	pub fn build(&self) {
+		let stdin = tokio_stdin_stdout::stdin(0);
+		let stdout = tokio_stdin_stdout::stdout(0).make_sendable();
+
+		let framed_stdin = FramedRead::new(stdin, LinesCodec::new());
+		let framed_stdout = FramedWrite::new(stdout, LinesCodec::new());
+
+		let handler = self.handler.clone();
+		let future = framed_stdin
+			.and_then(move |line| process(&handler, line).map_err(|_| unreachable!()))
+			.forward(framed_stdout)
+			.map(|_| ())
+			.map_err(|e| panic!("{:?}", e));
+
+		tokio::run(future);
+	}
+}
+
+/// Process a request asynchronously
+fn process(io: &Arc<IoHandler>, input: String) -> impl Future<Item = String, Error = ()> + Send {
+	io.handle_request(&input).map(move |result| match result {
+		Some(res) => res,
+		None => {
+			info!("JSON RPC request produced no response: {:?}", input);
+			String::from("")
+		}
+	})
+}

--- a/tcp/src/lib.rs
+++ b/tcp/src/lib.rs
@@ -46,4 +46,4 @@ use jsonrpc_core as jsonrpc;
 pub use dispatch::{Dispatcher, PushMessageError};
 pub use meta::{MetaExtractor, RequestContext};
 pub use server::{ServerBuilder, Server};
-pub use self::server_utils::tokio_core;
+pub use self::server_utils::{tokio_core, codecs::Separator};

--- a/tcp/src/server.rs
+++ b/tcp/src/server.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use tokio_service::Service as TokioService;
 
-use jsonrpc::{MetaIoHandler, Metadata, Middleware, NoopMiddleware};
+use jsonrpc::{middleware, MetaIoHandler, Metadata, Middleware};
 use jsonrpc::futures::{future, Future, Stream, Sink};
 use jsonrpc::futures::sync::{mpsc, oneshot};
 use server_utils::{reactor, tokio_core, codecs};
@@ -15,7 +15,7 @@ use meta::{MetaExtractor, RequestContext, NoopExtractor};
 use service::Service;
 
 /// TCP server builder
-pub struct ServerBuilder<M: Metadata = (), S: Middleware<M> = NoopMiddleware> {
+pub struct ServerBuilder<M: Metadata = (), S: Middleware<M> = middleware::Noop> {
 	remote: reactor::UninitializedRemote,
 	handler: Arc<MetaIoHandler<M, S>>,
 	meta_extractor: Arc<MetaExtractor<M>>,

--- a/tcp/src/server.rs
+++ b/tcp/src/server.rs
@@ -25,7 +25,7 @@ pub struct ServerBuilder<M: Metadata = (), S: Middleware<M> = middleware::Noop> 
 }
 
 impl<M: Metadata + Default, S: Middleware<M> + 'static> ServerBuilder<M, S> {
-	/// Creates new `SeverBuilder` wih given `IoHandler`
+	/// Creates new `ServerBuilder` wih given `IoHandler`
 	pub fn new<T>(handler: T) -> Self where
 		T: Into<MetaIoHandler<M, S>>,
 	{
@@ -34,7 +34,7 @@ impl<M: Metadata + Default, S: Middleware<M> + 'static> ServerBuilder<M, S> {
 }
 
 impl<M: Metadata, S: Middleware<M> + 'static> ServerBuilder<M, S> {
-	/// Creates new `SeverBuilder` wih given `IoHandler`
+	/// Creates new `ServerBuilder` wih given `IoHandler`
 	pub fn with_meta_extractor<T, E>(handler: T, extractor: E) -> Self where
 		T: Into<MetaIoHandler<M, S>>,
 		E: MetaExtractor<M> + 'static,

--- a/tcp/src/service.rs
+++ b/tcp/src/service.rs
@@ -3,9 +3,9 @@ use std::net::SocketAddr;
 
 use tokio_service;
 
-use jsonrpc::{FutureResult, Metadata, MetaIoHandler, Middleware, NoopMiddleware};
+use jsonrpc::{middleware, FutureResult, Metadata, MetaIoHandler, Middleware};
 
-pub struct Service<M: Metadata = (), S: Middleware<M> = NoopMiddleware> {
+pub struct Service<M: Metadata = (), S: Middleware<M> = middleware::Noop> {
 	handler: Arc<MetaIoHandler<M, S>>,
 	peer_addr: SocketAddr,
 	meta: M,
@@ -26,7 +26,7 @@ impl<M: Metadata, S: Middleware<M>> tokio_service::Service for Service<M, S> {
 	type Error = ();
 
 	// The future for computing the response; box it for simplicity.
-	type Future = FutureResult<S::Future>;
+	type Future = FutureResult<S::Future, S::CallFuture>;
 
 	// Produce a future for computing a response from a request.
 	fn call(&self, req: Self::Request) -> Self::Future {


### PR DESCRIPTION
Built on top of #288 

This PR adds `on_call` method to the middleware, so you can easily intercept incoming calls.