### PR TITLE
Add CloseHandle for IPC server

### DIFF
--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -14,11 +14,11 @@ tokio-service = "0.1"
 jsonrpc-core = { version = "8.0", path = "../core" }
 jsonrpc-server-utils = { version = "8.0", path = "../server-utils" }
 parity-tokio-ipc = { git = "https://github.com/nikvolf/parity-tokio-ipc" }
+parking_lot = "0.6"
 
 [dev-dependencies]
 env_logger = "0.5"
 lazy_static = "1.0"
-parking_lot = "0.6"
 
 [target.'cfg(not(windows))'.dev-dependencies]
 tokio-uds = "0.2"

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -5,6 +5,7 @@
 extern crate jsonrpc_server_utils as server_utils;
 extern crate parity_tokio_ipc;
 extern crate tokio_service;
+extern crate parking_lot;
 
 pub extern crate jsonrpc_core;
 
@@ -21,7 +22,7 @@ mod meta;
 use jsonrpc_core as jsonrpc;
 
 pub use meta::{MetaExtractor, RequestContext};
-pub use server::{Server, ServerBuilder};
+pub use server::{Server, ServerBuilder, CloseHandle};
 
 pub use self::server_utils::tokio_core;
 pub use self::server_utils::session::{SessionStats, SessionId};


### PR DESCRIPTION
Hiya, as we're moving to use an `IPC` from websockets, #148 struck once more. These changes address that.