### PR TITLE
Ipc misc improvement

### DIFF
--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -21,7 +21,7 @@ mod meta;
 
 use jsonrpc_core as jsonrpc;
 
-pub use meta::{MetaExtractor, RequestContext};
+pub use meta::{MetaExtractor, NoopExtractor, RequestContext};
 pub use server::{Server, ServerBuilder, CloseHandle};
 
 pub use self::server_utils::tokio_core;

--- a/ipc/src/server.rs
+++ b/ipc/src/server.rs
@@ -269,6 +269,7 @@ impl Drop for InnerHandles {
 	}
 }
 /// `CloseHandle` allows one to stop an `IpcServer` remotely.
+#[derive(Clone)]
 pub struct CloseHandle {
 	inner: Arc<Mutex<InnerHandles>>,
 }

--- a/ipc/src/server.rs
+++ b/ipc/src/server.rs
@@ -84,7 +84,7 @@ impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
 	}
 
 	/// Sets session metadata extractor.
-	pub fn session_metadata_extractor<X>(mut self, meta_extractor: X) -> Self where
+	pub fn session_meta_extractor<X>(mut self, meta_extractor: X) -> Self where
 		X: MetaExtractor<M>,
 	{
 		self.meta_extractor = Arc::new(meta_extractor);


### PR DESCRIPTION
Some tiny misc fixes that improves usability.

* Make `CloseHandle` cloneable. No reason to not have it like that. The equivalent for the WS server is, so this is more consistent.
* Rename `session_metadata_extractor` to `session_meta_extractor` to be consistent with other protocol's `ServerBuilder`s
* Re-export the `NoopExtractor` which was until now unreachable.