### PR TITLE
Add stdio server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 	"pubsub",
 	"pubsub/more-examples",
 	"server-utils",
+	"stdio",
 	"tcp",
 	"test",
 	"ws",

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Transport-agnostic `core` and transport servers for `http`, `ipc`, `websockets` 
 - [jsonrpc-ipc-server](./ipc)
 - [jsonrpc-tcp-server](./tcp) [![crates.io][tcp-server-image]][tcp-server-url]
 - [jsonrpc-ws-server](./ws)
+- [jsonrpc-stdio-server](./stdio)
 - [jsonrpc-macros](./macros) [![crates.io][macros-image]][macros-url]
 - [jsonrpc-server-utils](./server-utils) [![crates.io][server-utils-image]][server-utils-url]
 - [jsonrpc-pubsub](./pubsub) [![crates.io][pubsub-image]][pubsub-url]

--- a/stdio/Cargo.toml
+++ b/stdio/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "jsonrpc-stdio-server"
+description = "STDIN/STDOUT server for JSON-RPC"
+version = "0.1.0"
+authors = ["cmichi <mich@elmueller.net>"]
+license = "MIT"
+homepage = "https://github.com/paritytech/jsonrpc"
+repository = "https://github.com/paritytech/jsonrpc"
+documentation = "https://paritytech.github.io/jsonrpc/jsonrpc_stdio_server/index.html"
+
+[dependencies]
+futures = "0.1.23"
+jsonrpc-core = { version = "8.0", path = "../core" }
+log = "0.4"
+tokio = "0.1.7"
+tokio-codec = "0.1.0"
+tokio-io = "0.1.7"
+tokio-stdin-stdout = "0.1.4"
+
+[dev-dependencies]
+lazy_static = "1.0"
+env_logger = "0.5"
+
+[badges]
+travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/stdio/README.md
+++ b/stdio/README.md
@@ -1,0 +1,32 @@
+# jsonrpc-stdio-server
+STDIN/STDOUT server for JSON-RPC 2.0.
+Takes one request per line and outputs each response on a new line.
+
+[Documentation](http://paritytech.github.io/jsonrpc/jsonrpc_stdio_server/index.html)
+
+## Example
+
+`Cargo.toml`
+
+```
+[dependencies]
+jsonrpc-stdio-server = { git = "https://github.com/paritytech/jsonrpc" }
+```
+
+`main.rs`
+
+```rust
+extern crate jsonrpc_stdio_server;
+
+use jsonrpc_stdio_server::server;
+use jsonrpc_stdio_server::jsonrpc_core::*;
+
+fn main() {
+	let mut io = IoHandler::default();
+	io.add_method("say_hello", |_params| {
+		Ok(Value::String("hello".to_owned()))
+	});
+
+	ServerBuilder::new(io).build();
+}
+```

--- a/stdio/examples/stdio.rs
+++ b/stdio/examples/stdio.rs
@@ -1,0 +1,13 @@
+extern crate jsonrpc_stdio_server;
+
+use jsonrpc_stdio_server::ServerBuilder;
+use jsonrpc_stdio_server::jsonrpc_core::*;
+
+fn main() {
+	let mut io = IoHandler::default();
+	io.add_method("say_hello", |_params| {
+		Ok(Value::String("hello".to_owned()))
+	});
+
+	ServerBuilder::new(io).build();
+}

--- a/stdio/src/lib.rs
+++ b/stdio/src/lib.rs
@@ -1,0 +1,76 @@
+//! jsonrpc server using stdin/stdout
+//!
+//! ```no_run
+//! extern crate jsonrpc_stdio_server;
+//!
+//! use jsonrpc_stdio_server::ServerBuilder;
+//! use jsonrpc_stdio_server::jsonrpc_core::*;
+//!
+//! fn main() {
+//! 	let mut io = IoHandler::default();
+//! 	io.add_method("say_hello", |_params| {
+//! 		Ok(Value::String("hello".to_owned()))
+//! 	});
+//!
+//! 	ServerBuilder::new(io).build();
+//! }
+//! ```
+
+#![warn(missing_docs)]
+
+extern crate futures;
+extern crate tokio;
+extern crate tokio_codec;
+extern crate tokio_io;
+extern crate tokio_stdin_stdout;
+#[macro_use] extern crate log;
+
+pub extern crate jsonrpc_core;
+
+use std::sync::Arc;
+use tokio::prelude::{Future, Stream};
+use tokio_codec::{FramedRead, FramedWrite, LinesCodec};
+use jsonrpc_core::{IoHandler};
+
+/// Stdio server builder
+pub struct ServerBuilder {
+	handler: Arc<IoHandler>,
+}
+
+impl ServerBuilder {
+	/// Returns a new server instance
+	pub fn new<T>(handler: T) -> Self where T: Into<IoHandler> {
+		ServerBuilder { handler: Arc::new(handler.into()) }
+	}
+
+	/// Will block until EOF is read or until an error occurs.
+	/// The server reads from STDIN line-by-line, one request is taken
+	/// per line and each response is written to STDOUT on a new line.
+	pub fn build(&self) {
+		let stdin = tokio_stdin_stdout::stdin(0);
+		let stdout = tokio_stdin_stdout::stdout(0).make_sendable();
+
+		let framed_stdin = FramedRead::new(stdin, LinesCodec::new());
+		let framed_stdout = FramedWrite::new(stdout, LinesCodec::new());
+
+		let handler = self.handler.clone();
+		let future = framed_stdin
+			.and_then(move |line| process(&handler, line).map_err(|_| unreachable!()))
+			.forward(framed_stdout)
+			.map(|_| ())
+			.map_err(|e| panic!("{:?}", e));
+
+		tokio::run(future);
+	}
+}
+
+/// Process a request asynchronously
+fn process(io: &Arc<IoHandler>, input: String) -> impl Future<Item = String, Error = ()> + Send {
+	io.handle_request(&input).map(move |result| match result {
+		Some(res) => res,
+		None => {
+			info!("JSON RPC request produced no response: {:?}", input);
+			String::from("")
+		}
+	})
+}

--- a/tcp/src/server.rs
+++ b/tcp/src/server.rs
@@ -25,7 +25,7 @@ pub struct ServerBuilder<M: Metadata = (), S: Middleware<M> = NoopMiddleware> {
 }
 
 impl<M: Metadata + Default, S: Middleware<M> + 'static> ServerBuilder<M, S> {
-	/// Creates new `SeverBuilder` wih given `IoHandler`
+	/// Creates new `ServerBuilder` wih given `IoHandler`
 	pub fn new<T>(handler: T) -> Self where
 		T: Into<MetaIoHandler<M, S>>,
 	{
@@ -34,7 +34,7 @@ impl<M: Metadata + Default, S: Middleware<M> + 'static> ServerBuilder<M, S> {
 }
 
 impl<M: Metadata, S: Middleware<M> + 'static> ServerBuilder<M, S> {
-	/// Creates new `SeverBuilder` wih given `IoHandler`
+	/// Creates new `ServerBuilder` wih given `IoHandler`
 	pub fn with_meta_extractor<T, E>(handler: T, extractor: E) -> Self where
 		T: Into<MetaIoHandler<M, S>>,
 		E: MetaExtractor<M> + 'static,


### PR DESCRIPTION
Hi @tomusdrw,

this is the current status of #194.

It's clear to me that this is most probably not the version we want to merge. I think of it more as a draft to get feedback on and since I'm new to Rust I would much appreciate any feedback!                                                                                                                                                 

It works and you can test it e.g. by

```
yes '{"jsonrpc":"2.0","id":1,"method":"say_hello","params":[]}' | head -n25 | cargo run --example stdin-stdout -p jsonrpc-stdin-stdout-server                      
```

I decided to use https://github.com/vi/tokio-stdin-stdout/ instead of the two libs you had mentioned, because it looked more elaborate and maintained to me.       

Some things:

1. There is currently no test for the server and I am unsure how to implement one. The thing is that all these stdin/stdout libs read from `::std::io::stdin();`, which I think is a problem. As I understand it Rust tests are executed in parallel and hence concurrent writes to `stdin` by different tests can occur. So different tests which use stdin would probably interfere with each other.    
<br/>I guess one option could be to spawn the whole stdin-stdout server as a separate process, but from what I have seen so far this seems a bit unusual.

2. The instantiation currently differs from the other servers, for which you use an API like this:                                                                 

```
let server = ServerBuilder::new(io)
  .start().unwrap())
  .expect("Unable to start RPC server");

server.wait().unwrap()
```

What do you think would be a good way to align the instantiation?

3. Regarding the `Make request processing log optional` commit: I'm not that happy with this solution, since it changes behavior for all the other servers too. What do you think? Maybe it also makes sense to persist  somewhere in the readme's that one needs to explicitly set the `info` flag to still get this output.                                      

Thanks!