### PR TITLE
Update hyper to version 0.12.

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://github.com/paritytech/jsonrpc"
 repository = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-core"
-version = "8.0.2"
+version = "9.0.0"
 authors = ["debris <marek.kotewicz@gmail.com>"]
 keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 documentation = "https://paritytech.github.io/jsonrpc/jsonrpc_core/index.html"
@@ -19,7 +19,7 @@ categories = [
 
 [dependencies]
 log = "0.4"
-futures = "0.1.6"
+futures = "~0.1.6"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/core/src/calls.rs
+++ b/core/src/calls.rs
@@ -5,7 +5,7 @@ use futures::{Future, IntoFuture};
 use BoxFuture;
 
 /// Metadata trait
-pub trait Metadata: Clone + Send + 'static {}
+pub trait Metadata: Clone + Send + Sync + 'static {}
 impl Metadata for () {}
 impl<T: Metadata> Metadata for Option<T> {}
 impl<T: Metadata> Metadata for Box<T> {}

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -11,7 +11,7 @@ use types::{Error, ErrorCode, Version};
 use types::{Request, Response, Call, Output};
 
 /// A type representing middleware or RPC response before serialization.
-pub type FutureResponse = Box<Future<Item=Option<Response>, Error=()> + Send>;
+pub type FutureResponse = Box<Future<Item=Option<Response>, Error=()> + Send + 'static>;
 
 /// A type representing future string response.
 pub type FutureResult<F> = future::Map<

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -4,15 +4,15 @@ homepage = "https://github.com/paritytech/jsonrpc"
 repository = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-http-server"
-version = "8.0.1"
+version = "9.0.0"
 authors = ["debris <marek.kotewicz@gmail.com>"]
 keywords = ["jsonrpc", "json-rpc", "json", "rpc", "server"]
 documentation = "https://paritytech.github.io/jsonrpc/jsonrpc_http_server/index.html"
 
 [dependencies]
-hyper = "0.11"
-jsonrpc-core = { version = "8.0", path = "../core" }
-jsonrpc-server-utils = { version = "8.0", path = "../server-utils" }
+hyper = "0.12"
+jsonrpc-core = { version = "9.0", path = "../core" }
+jsonrpc-server-utils = { version = "9.0", path = "../server-utils" }
 log = "0.4"
 net2 = "0.2"
 unicase = "2.0"

--- a/http/examples/http_meta.rs
+++ b/http/examples/http_meta.rs
@@ -3,7 +3,6 @@ extern crate unicase;
 
 use jsonrpc_http_server::{ServerBuilder, hyper, RestApi, AccessControlAllowHeaders};
 use jsonrpc_http_server::jsonrpc_core::*;
-use self::hyper::header;
 
 #[derive(Default, Clone)]
 struct Meta {
@@ -27,15 +26,14 @@ fn main() {
 	let server = ServerBuilder::new(io)
 		.cors_allow_headers(AccessControlAllowHeaders::Only(
 			vec![
-				"Authorization",
+				hyper::header::HeaderName::from_static("Authorization"),
 			])
 		)
 		.rest_api(RestApi::Unsecure)
 		// You can also implement `MetaExtractor` trait and pass a struct here.
-		.meta_extractor(|req: &hyper::Request| {
-			let auth = req.headers()
-				.get::<header::Authorization<header::Bearer>>();
-			let auth = auth.map(|h| h.token.clone());
+		.meta_extractor(|req: &hyper::Request<hyper::Body>| {
+			let auth = req.headers().get(hyper::header::AUTHORIZATION)
+				.map(|h| h.to_str().expect("Invalid authorization value").to_owned());
 
 			Meta { auth }
 		})

--- a/http/examples/http_middleware.rs
+++ b/http/examples/http_middleware.rs
@@ -14,8 +14,8 @@ fn main() {
 
 	let server = ServerBuilder::new(io)
 		.cors(DomainsValidation::AllowOnly(vec![AccessControlAllowOrigin::Null]))
-		.request_middleware(|request: hyper::server::Request| {
-			if request.path() == "/status" {
+		.request_middleware(|request: hyper::Request<hyper::Body>| {
+			if request.uri() == "/status" {
 				Response::ok("Server running OK.").into()
 			} else {
 				request.into()

--- a/http/src/handler.rs
+++ b/http/src/handler.rs
@@ -3,9 +3,8 @@ use Rpc;
 use std::{fmt, mem, str};
 use std::sync::Arc;
 
-use hyper::{self, mime, server, Method};
-use hyper::header::{self, Headers};
-use unicase::Ascii;
+use hyper::{self, service::Service, Body, Method};
+use hyper::header::{self, HeaderMap, HeaderValue};
 
 use jsonrpc::{self as core, FutureResult, Metadata, Middleware, NoopMiddleware};
 use jsonrpc::futures::{Future, Poll, Async, Stream, future};
@@ -56,13 +55,13 @@ impl<M: Metadata, S: Middleware<M>> ServerHandler<M, S> {
 	}
 }
 
-impl<M: Metadata, S: Middleware<M>> server::Service for ServerHandler<M, S> {
-	type Request = server::Request;
-	type Response = server::Response;
+impl<M: Metadata, S: Middleware<M>> Service for ServerHandler<M, S> {
+	type ReqBody = Body;
+	type ResBody = Body;
 	type Error = hyper::Error;
 	type Future = Handler<M, S>;
 
-	fn call(&self, request: Self::Request) -> Self::Future {
+	fn call(&mut self, request: hyper::Request<Self::ReqBody>) -> Self::Future {
 		let is_host_allowed = utils::is_host_allowed(&request, &self.allowed_hosts);
 		let action = self.middleware.on_request(request);
 
@@ -108,11 +107,11 @@ impl<M: Metadata, S: Middleware<M>> server::Service for ServerHandler<M, S> {
 pub enum Handler<M: Metadata, S: Middleware<M>> {
 	Rpc(RpcHandler<M, S>),
 	Error(Option<Response>),
-	Middleware(Box<Future<Item=server::Response, Error=hyper::Error> + Send>),
+	Middleware(Box<Future<Item = hyper::Response<Body>, Error = hyper::Error> + Send>),
 }
 
 impl<M: Metadata, S: Middleware<M>> Future for Handler<M, S> {
-	type Item = server::Response;
+	type Item = hyper::Response<Body>;
 	type Error = hyper::Error;
 
 	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
@@ -155,7 +154,7 @@ enum RpcHandlerState<M, F> where
 	F: Future<Item = Option<core::Response>, Error = ()>,
 {
 	ReadingHeaders {
-		request: server::Request,
+		request: hyper::Request<Body>,
 		cors_domains: CorsDomains,
 		continue_on_invalid_cors: bool,
 	},
@@ -202,9 +201,9 @@ pub struct RpcHandler<M: Metadata, S: Middleware<M>> {
 	jsonrpc_handler: Rpc<M, S>,
 	state: RpcHandlerState<M, S::Future>,
 	is_options: bool,
-	cors_allow_origin: cors::AllowOrigin<header::AccessControlAllowOrigin>,
+	cors_allow_origin: cors::AllowOrigin<header::HeaderValue>,
 	cors_max_age: Option<u32>,
-	cors_allow_headers: cors::AllowHeaders<header::AccessControlAllowHeaders>,
+	cors_allow_headers: cors::AllowHeaders<header::HeaderMap>,
 	allowed_headers: cors::AccessControlAllowHeadersUnicase,
 	rest_api: RestApi,
 	health_api: Option<(String, String)>,
@@ -212,7 +211,7 @@ pub struct RpcHandler<M: Metadata, S: Middleware<M>> {
 }
 
 impl<M: Metadata, S: Middleware<M>> Future for RpcHandler<M, S> {
-	type Item = server::Response;
+	type Item = hyper::Response<Body>;
 	type Error = hyper::Error;
 
 	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
@@ -223,7 +222,7 @@ impl<M: Metadata, S: Middleware<M>> Future for RpcHandler<M, S> {
 				// Read cors header
 				self.cors_allow_origin = utils::cors_allow_origin(&request, &cors_domains);
 				self.cors_allow_headers = utils::cors_allow_headers(&request, &allowed_headers);
-				self.is_options = *request.method() == Method::Options;
+				self.is_options = *request.method() == Method::OPTIONS;
 				// Read other headers
 				RpcPollState::Ready(self.read_headers(request, continue_on_invalid_cors))
 			},
@@ -279,10 +278,9 @@ impl<M: Metadata, S: Middleware<M>> Future for RpcHandler<M, S> {
 		let (new_state, is_ready) = new_state.decompose();
 		match new_state {
 			RpcHandlerState::Writing(res) => {
-				let mut response: server::Response = res.into();
+				let mut response: hyper::Response<Body> = res.into();
 				let cors_allow_origin = mem::replace(&mut self.cors_allow_origin, cors::AllowOrigin::Invalid);
 				let cors_allow_headers = mem::replace(&mut self.cors_allow_headers, cors::AllowHeaders::Invalid);
-
 				Self::set_response_headers(
 					response.headers_mut(),
 					self.is_options,
@@ -305,7 +303,7 @@ impl<M: Metadata, S: Middleware<M>> Future for RpcHandler<M, S> {
 }
 
 // Intermediate and internal error type to better distinguish
-// error cases occuring during request body processing.
+// error cases occurring during request body processing.
 enum BodyError {
 	Hyper(hyper::Error),
 	Utf8(str::Utf8Error),
@@ -321,7 +319,7 @@ impl From<hyper::Error> for BodyError {
 impl<M: Metadata, S: Middleware<M>> RpcHandler<M, S> {
 	fn read_headers(
 		&self,
-		request: server::Request,
+		request: hyper::Request<Body>,
 		continue_on_invalid_cors: bool,
 	) -> RpcHandlerState<M, S::Future> {
 		if self.cors_allow_origin == cors::AllowOrigin::Invalid && !continue_on_invalid_cors {
@@ -335,34 +333,34 @@ impl<M: Metadata, S: Middleware<M>> RpcHandler<M, S> {
 		let metadata = self.jsonrpc_handler.extractor.read_metadata(&request);
 
 		// Proceed
-		match *request.method() {
+		match request.method().clone() {
 			// Validate the ContentType header
 			// to prevent Cross-Origin XHRs with text/plain
-			Method::Post if Self::is_json(request.headers().get::<header::ContentType>()) => {
+			Method::POST if Self::is_json(request.headers().get("content-type")) => {
 				let uri = if self.rest_api != RestApi::Disabled { Some(request.uri().clone()) } else { None };
 				RpcHandlerState::ReadingBody {
 					metadata,
 					request: Default::default(),
 					uri,
-					body: request.body(),
+					body: request.into_body(),
 				}
 			},
-			Method::Post if self.rest_api == RestApi::Unsecure && request.uri().path().split('/').count() > 2 => {
+			Method::POST if self.rest_api == RestApi::Unsecure && request.uri().path().split('/').count() > 2 => {
 				RpcHandlerState::ProcessRest {
 					metadata,
 					uri: request.uri().clone(),
 				}
 			},
 			// Just return error for unsupported content type
-			Method::Post => {
+			Method::POST => {
 				RpcHandlerState::Writing(Response::unsupported_content_type())
 			},
 			// Don't validate content type on options
-			Method::Options => {
+			Method::OPTIONS => {
 				RpcHandlerState::Writing(Response::empty())
 			},
 			// Respond to health API request if there is one configured.
-			Method::Get if self.health_api.as_ref().map(|x| &*x.0) == Some(request.uri().path()) => {
+			Method::GET if self.health_api.as_ref().map(|x| &*x.0) == Some(request.uri().path()) => {
 				RpcHandlerState::ProcessHealth {
 					metadata,
 					method: self.health_api.as_ref()
@@ -497,51 +495,53 @@ impl<M: Metadata, S: Middleware<M>> RpcHandler<M, S> {
 	}
 
 	fn set_response_headers(
-		headers: &mut Headers,
+		headers: &mut HeaderMap,
 		is_options: bool,
-		cors_allow_origin: Option<header::AccessControlAllowOrigin>,
+		cors_allow_origin: Option<HeaderValue>,
 		cors_max_age: Option<u32>,
-		cors_allow_headers: AllowHeaders<header::AccessControlAllowHeaders>,
+		cors_allow_headers: AllowHeaders<header::HeaderMap>,
 	) {
 		if is_options {
-			headers.set(header::Allow(vec![
-				Method::Options,
-				Method::Post,
-			]));
-			headers.set(header::Accept(vec![
-				header::qitem(mime::APPLICATION_JSON)
-			]));
+			headers.append(header::ALLOW, Method::OPTIONS.as_str().parse().expect("`Method` will always parse; qed"));
+			headers.append(header::ALLOW, Method::POST.as_str().parse().expect("`Method` will always parse; qed"));
+
+			headers.append(header::ACCEPT, HeaderValue::from_static("application/json"));
+
 		}
 
 		if let Some(cors_domain) = cors_allow_origin {
-			headers.set(header::AccessControlAllowMethods(vec![
-				Method::Options,
-				Method::Post
-			]));
+			headers.append(header::ACCESS_CONTROL_ALLOW_METHODS, Method::OPTIONS.as_str().parse()
+				.expect("`Method` will always parse; qed"));
+			headers.append(header::ACCESS_CONTROL_ALLOW_METHODS, Method::POST.as_str().parse()
+				.expect("`Method` will always parse; qed"));
 
 			if let AllowHeaders::Ok(cors_allow_headers) = cors_allow_headers {
-				if !cors_allow_headers.is_empty() {
-					headers.set(cors_allow_headers);
-				}
+				headers.extend(cors_allow_headers);
 			}
 
-			if let Some(cors_max_age) = cors_max_age {
-				headers.set(header::AccessControlMaxAge(cors_max_age));
+			if let Some(cma) = cors_max_age {
+				headers.append(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_str(&cma.to_string())
+					.expect("`u32` will always parse; qed"));
 			}
-			headers.set(cors_domain);
-			headers.set(header::Vary::Items(vec![
-				Ascii::new("origin".to_owned())
-			]));
+
+			headers.append(header::ACCESS_CONTROL_ALLOW_ORIGIN, cors_domain);
+			headers.append(header::VARY, HeaderValue::from_static("origin"));
 		}
 	}
 
-	fn is_json(content_type: Option<&header::ContentType>) -> bool {
-		const APPLICATION_JSON_UTF_8: &str = "application/json; charset=utf-8";
-
+	/// Returns true if the `content_type` header indicates a valid JSON
+	/// message.
+	fn is_json(content_type: Option<&header::HeaderValue>) -> bool {
 		match content_type {
-			Some(&header::ContentType(ref mime))
-				if *mime == mime::APPLICATION_JSON || *mime == APPLICATION_JSON_UTF_8 => true,
-			_ => false
+			Some(header_val) => {
+				match header_val.to_str() {
+					Ok(header_str) => {
+						header_str == "application/json" || header_str == "application/json; charset=utf-8"
+					},
+					Err(_) => false,
+				}
+			}
+			_ => false,
 		}
 	}
 }

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -52,7 +52,7 @@ use jsonrpc::futures::sync::oneshot;
 use server_utils::reactor::{Executor, UninitializedExecutor};
 
 pub use server_utils::hosts::{Host, DomainsValidation};
-pub use server_utils::cors::{self, AccessControlAllowOrigin, Origin};
+pub use server_utils::cors::{self, AccessControlAllowOrigin, Origin, AllowCors};
 pub use server_utils::tokio;
 pub use handler::ServerHandler;
 pub use utils::{is_host_allowed, cors_allow_origin, cors_allow_headers};

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -44,17 +44,16 @@ use std::sync::{mpsc, Arc};
 use std::net::SocketAddr;
 use std::thread;
 
-use hyper::server;
+use hyper::{server, Body};
 use jsonrpc_core as jsonrpc;
 use jsonrpc::MetaIoHandler;
-use jsonrpc::futures::{self, Future, Stream};
+use jsonrpc::futures::{self, Future, Stream, future};
 use jsonrpc::futures::sync::oneshot;
-use server_utils::reactor::{Remote, UninitializedRemote};
+use server_utils::reactor::{Executor, UninitializedExecutor};
 
 pub use server_utils::hosts::{Host, DomainsValidation};
-pub use server_utils::cors::{AccessControlAllowOrigin, Origin, AccessControlAllowHeaders};
-pub use server_utils::cors;
-pub use server_utils::tokio_core;
+pub use server_utils::cors::{self, AccessControlAllowOrigin, AccessControlAllowHeaders, Origin};
+pub use server_utils::tokio;
 pub use handler::ServerHandler;
 pub use utils::{is_host_allowed, cors_allow_origin, AllowOrigin};
 pub use response::Response;
@@ -67,14 +66,14 @@ pub enum RequestMiddlewareAction {
 		/// This allows for side effects to take place.
 		should_continue_on_invalid_cors: bool,
 		/// The request object returned
-		request: server::Request,
+		request: hyper::Request<Body>,
 	},
 	/// Intercept the request and respond differently.
 	Respond {
 		/// Should standard hosts validation be performed?
 		should_validate_hosts: bool,
 		/// a future for server response
-		response: Box<Future<Item=server::Response, Error=hyper::Error> + Send>,
+		response: Box<Future<Item=hyper::Response<Body>, Error=hyper::Error> + Send>,
 	}
 }
 
@@ -87,8 +86,8 @@ impl From<Response> for RequestMiddlewareAction {
 	}
 }
 
-impl From<server::Response> for RequestMiddlewareAction {
-	fn from(response: server::Response) -> Self {
+impl From<hyper::Response<Body>> for RequestMiddlewareAction {
+	fn from(response: hyper::Response<Body>) -> Self {
 		RequestMiddlewareAction::Respond {
 			should_validate_hosts: true,
 			response: Box::new(futures::future::ok(response)),
@@ -96,8 +95,8 @@ impl From<server::Response> for RequestMiddlewareAction {
 	}
 }
 
-impl From<server::Request> for RequestMiddlewareAction {
-	fn from(request: server::Request) -> Self {
+impl From<hyper::Request<Body>> for RequestMiddlewareAction {
+	fn from(request: hyper::Request<Body>) -> Self {
 		RequestMiddlewareAction::Proceed {
 			should_continue_on_invalid_cors: false,
 			request,
@@ -108,13 +107,13 @@ impl From<server::Request> for RequestMiddlewareAction {
 /// Allows to intercept request and handle it differently.
 pub trait RequestMiddleware: Send + Sync + 'static {
 	/// Takes a request and decides how to proceed with it.
-	fn on_request(&self, request: server::Request) -> RequestMiddlewareAction;
+	fn on_request(&self, request: hyper::Request<hyper::Body>) -> RequestMiddlewareAction;
 }
 
 impl<F> RequestMiddleware for F where
-	F: Fn(server::Request) -> RequestMiddlewareAction + Sync + Send + 'static,
+	F: Fn(hyper::Request<Body>) -> RequestMiddlewareAction + Sync + Send + 'static,
 {
-	fn on_request(&self, request: server::Request) -> RequestMiddlewareAction {
+	fn on_request(&self, request: hyper::Request<hyper::Body>) -> RequestMiddlewareAction {
 		(*self)(request)
 	}
 }
@@ -122,7 +121,7 @@ impl<F> RequestMiddleware for F where
 #[derive(Default)]
 struct NoopRequestMiddleware;
 impl RequestMiddleware for NoopRequestMiddleware {
-	fn on_request(&self, request: server::Request) -> RequestMiddlewareAction {
+	fn on_request(&self, request: hyper::Request<Body>) -> RequestMiddlewareAction {
 		RequestMiddlewareAction::Proceed {
 			should_continue_on_invalid_cors: false,
 			request,
@@ -133,14 +132,14 @@ impl RequestMiddleware for NoopRequestMiddleware {
 /// Extracts metadata from the HTTP request.
 pub trait MetaExtractor<M: jsonrpc::Metadata>: Sync + Send + 'static {
 	/// Read the metadata from the request
-	fn read_metadata(&self, _: &server::Request) -> M;
+	fn read_metadata(&self, _: &hyper::Request<Body>) -> M;
 }
 
 impl<M, F> MetaExtractor<M> for F where
 	M: jsonrpc::Metadata,
-	F: Fn(&server::Request) -> M + Sync + Send + 'static,
+	F: Fn(&hyper::Request<Body>) -> M + Sync + Send + 'static,
 {
-	fn read_metadata(&self, req: &server::Request) -> M {
+	fn read_metadata(&self, req: &hyper::Request<Body>) -> M {
 		(*self)(req)
 	}
 }
@@ -148,7 +147,7 @@ impl<M, F> MetaExtractor<M> for F where
 #[derive(Default)]
 struct NoopExtractor;
 impl<M: jsonrpc::Metadata + Default> MetaExtractor<M> for NoopExtractor {
-	fn read_metadata(&self, _: &server::Request) -> M {
+	fn read_metadata(&self, _: &hyper::Request<Body>) -> M {
 		M::default()
 	}
 }
@@ -194,7 +193,7 @@ pub enum RestApi {
 /// Convenient JSON-RPC HTTP Server builder.
 pub struct ServerBuilder<M: jsonrpc::Metadata = (), S: jsonrpc::Middleware<M> = jsonrpc::NoopMiddleware> {
 	handler: Arc<MetaIoHandler<M, S>>,
-	remote: UninitializedRemote,
+	executor: UninitializedExecutor,
 	meta_extractor: Arc<MetaExtractor<M>>,
 	request_middleware: Arc<RequestMiddleware>,
 	cors_domains: CorsDomains,
@@ -233,7 +232,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 	{
 		ServerBuilder {
 			handler: Arc::new(handler.into()),
-			remote: UninitializedRemote::Unspawned,
+			executor: UninitializedExecutor::Unspawned,
 			meta_extractor: Arc::new(extractor),
 			request_middleware: Arc::new(NoopRequestMiddleware::default()),
 			cors_domains: None,
@@ -248,11 +247,11 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 		}
 	}
 
-	/// Utilize existing event loop remote to poll RPC results.
+	/// Utilize existing event loop executor to poll RPC results.
 	///
 	/// Applies only to 1 of the threads. Other threads will spawn their own Event Loops.
-	pub fn event_loop_remote(mut self, remote: tokio_core::reactor::Remote) -> Self {
-		self.remote = UninitializedRemote::Shared(remote);
+	pub fn event_loop_executor(mut self, executor: tokio::runtime::TaskExecutor) -> Self {
+		self.executor = UninitializedExecutor::Shared(executor);
 		self
 	}
 
@@ -377,11 +376,11 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 
 		let (local_addr_tx, local_addr_rx) = mpsc::channel();
 		let (close, shutdown_signal) = oneshot::channel();
-		let eloop = self.remote.init_with_name("http.worker0")?;
+		let eloop = self.executor.init_with_name("http.worker0")?;
 		let req_max_size = self.max_request_body_size;
 		serve(
 			(shutdown_signal, local_addr_tx),
-			eloop.remote(),
+			eloop.executor(),
 			addr.to_owned(),
 			cors_domains.clone(),
 			cors_max_age,
@@ -398,10 +397,10 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 		let handles = (0..self.threads - 1).map(|i| {
 			let (local_addr_tx, local_addr_rx) = mpsc::channel();
 			let (close, shutdown_signal) = oneshot::channel();
-			let eloop = UninitializedRemote::Unspawned.init_with_name(format!("http.worker{}", i + 1))?;
+			let eloop = UninitializedExecutor::Unspawned.init_with_name(format!("http.worker{}", i + 1))?;
 			serve(
 				(shutdown_signal, local_addr_tx),
-				eloop.remote(),
+				eloop.executor(),
 				addr.to_owned(),
 				cors_domains.clone(),
 				cors_max_age,
@@ -426,11 +425,11 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 			Ok((eloop, close))
 		}).collect::<io::Result<(Vec<_>)>>()?;
 		handles.push((eloop, close));
-		let (remotes, close) = handles.into_iter().unzip();
+		let (executors, close) = handles.into_iter().unzip();
 
 		Ok(Server {
 			address: local_addr?,
-			remote: Some(remotes),
+			executor: Some(executors),
 			close: Some(close),
 		})
 	}
@@ -444,7 +443,7 @@ fn recv_address(local_addr_rx: mpsc::Receiver<io::Result<SocketAddr>>) -> io::Re
 
 fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 	signals: (oneshot::Receiver<()>, mpsc::Sender<io::Result<SocketAddr>>),
-	remote: tokio_core::reactor::Remote,
+	executor: tokio::runtime::TaskExecutor,
 	addr: SocketAddr,
 	cors_domains: CorsDomains,
 	cors_max_age: Option<u32>,
@@ -459,8 +458,9 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 	max_request_body_size: usize,
 ) {
 	let (shutdown_signal, local_addr_tx) = signals;
-	remote.spawn(move |handle| {
-		let handle1 = handle.clone();
+	executor.spawn(future::lazy(move || {
+		let handle = tokio::reactor::Handle::current();
+
 		let bind = move || {
 			let listener = match addr {
 				SocketAddr::V4(_) => net2::TcpBuilder::new_v4()?,
@@ -470,7 +470,7 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 			listener.reuse_address(true)?;
 			listener.bind(&addr)?;
 			let listener = listener.listen(1024)?;
-			let listener = tokio_core::net::TcpListener::from_listener(listener, &addr, &handle1)?;
+			let listener = tokio::net::TcpListener::from_std(listener, &handle)?;
 			// Add current host to allowed headers.
 			// NOTE: we need to use `l.local_addr()` instead of `addr`
 			// it might be different!
@@ -498,19 +498,15 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 			}
 		};
 
-		let handle = handle.clone();
 		bind_result.and_then(move |(listener, local_addr)| {
 			let allowed_hosts = server_utils::hosts::update(allowed_hosts, &local_addr);
 
-			let http = {
-				let mut http = server::Http::new();
-				http.keep_alive(keep_alive);
-				http.sleep_on_errors(true);
-				http
-			};
+			let mut http = server::conn::Http::new();
+			http.keep_alive(keep_alive);
+
 			listener.incoming()
-				.for_each(move |(socket, addr)| {
-					http.bind_connection(&handle, socket, addr, ServerHandler::new(
+				.for_each(move |socket| {
+					let service = ServerHandler::new(
 						jsonrpc_handler.clone(),
 						cors_domains.clone(),
 						cors_max_age,
@@ -520,7 +516,9 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 						rest_api,
 						health_api.clone(),
 						max_request_body_size,
-					));
+					);
+					tokio::spawn(http.serve_connection(socket, service)
+						.map_err(|e| error!("Error serving connection: {:?}", e)));
 					Ok(())
 				})
 				.map_err(|e| {
@@ -532,7 +530,7 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 				.map(|_| ())
 				.map_err(|_| ())
 		})
-	});
+	}));
 }
 
 #[cfg(unix)]
@@ -554,7 +552,7 @@ fn configure_port(_reuse: bool, _tcp: &net2::TcpBuilder) -> io::Result<()> {
 /// jsonrpc http server instance
 pub struct Server {
 	address: SocketAddr,
-	remote: Option<Vec<Remote>>,
+	executor: Option<Vec<Executor>>,
 	close: Option<Vec<oneshot::Sender<()>>>,
 }
 
@@ -571,23 +569,23 @@ impl Server {
 			let _ = close.send(());
 		}
 
-		for remote in self.remote.take().expect(PROOF) {
-			remote.close();
+		for executor in self.executor.take().expect(PROOF) {
+			executor.close();
 		}
 	}
 
 	/// Will block, waiting for the server to finish.
 	pub fn wait(mut self) {
-		for remote in self.remote.take().expect(PROOF) {
-			remote.wait();
+		for executor in self.executor.take().expect(PROOF) {
+			executor.wait();
 		}
 	}
 }
 
 impl Drop for Server {
 	fn drop(&mut self) {
-		self.remote.take().map(|remotes| {
-			for remote in remotes { remote.close(); }
+		self.executor.take().map(|executors| {
+			for executor in executors { executor.close(); }
 		});
 	}
 }

--- a/http/src/response.rs
+++ b/http/src/response.rs
@@ -1,8 +1,6 @@
 //! Basic Request/Response structures used internally.
 
-use hyper::server;
-
-pub use hyper::{header, Method, StatusCode};
+pub use hyper::{self, Method, Body, StatusCode, header::HeaderValue};
 
 /// Simple server response structure
 #[derive(Debug)]
@@ -10,7 +8,7 @@ pub struct Response {
 	/// Response code
 	pub code: StatusCode,
 	/// Response content type
-	pub content_type: header::ContentType,
+	pub content_type: HeaderValue,
 	/// Response body
 	pub content: String,
 }
@@ -24,8 +22,8 @@ impl Response {
 	/// Create a response with given body and 200 OK status code.
 	pub fn ok<T: Into<String>>(response: T) -> Self {
 		Response {
-			code: StatusCode::Ok,
-			content_type: header::ContentType::json(),
+			code: StatusCode::OK,
+			content_type: HeaderValue::from_static("application/json"),
 			content: response.into(),
 		}
 	}
@@ -33,8 +31,8 @@ impl Response {
 	/// Create a response for plaintext internal error.
 	pub fn internal_error<T: Into<String>>(msg: T) -> Self {
 		Response {
-			code: StatusCode::InternalServerError,
-			content_type: header::ContentType::plaintext(),
+			code: StatusCode::INTERNAL_SERVER_ERROR,
+			content_type: HeaderValue::from_static("text/plain; charset=utf-8"),
 			content: format!("Internal Server Error: {}", msg.into()),
 		}
 	}
@@ -42,17 +40,17 @@ impl Response {
 	/// Create a json response for service unavailable.
 	pub fn service_unavailable<T: Into<String>>(msg: T) -> Self {
 		Response {
-			code: StatusCode::ServiceUnavailable,
-			content_type: header::ContentType::json(),
-			content: msg.into(),
+			code: StatusCode::SERVICE_UNAVAILABLE,
+			content_type: HeaderValue::from_static("application/json"),
+			content: format!("Service Unavailable: {}", msg.into()),
 		}
 	}
 
 	/// Create a response for not allowed hosts.
 	pub fn host_not_allowed() -> Self {
 		Response {
-			code: StatusCode::Forbidden,
-			content_type: header::ContentType::plaintext(),
+			code: StatusCode::FORBIDDEN,
+			content_type: HeaderValue::from_static("text/plain; charset=utf-8"),
 			content: "Provided Host header is not whitelisted.\n".to_owned(),
 		}
 	}
@@ -60,8 +58,8 @@ impl Response {
 	/// Create a response for unsupported content type.
 	pub fn unsupported_content_type() -> Self {
 		Response {
-			code: StatusCode::UnsupportedMediaType,
-			content_type: header::ContentType::plaintext(),
+			code: StatusCode::UNSUPPORTED_MEDIA_TYPE,
+			content_type: HeaderValue::from_static("text/plain; charset=utf-8"),
 			content: "Supplied content type is not allowed. Content-Type: application/json is required\n".to_owned(),
 		}
 	}
@@ -69,8 +67,8 @@ impl Response {
 	/// Create a response for disallowed method used.
 	pub fn method_not_allowed() -> Self {
 		Response {
-			code: StatusCode::MethodNotAllowed,
-			content_type: header::ContentType::plaintext(),
+			code: StatusCode::METHOD_NOT_ALLOWED,
+			content_type: HeaderValue::from_static("text/plain; charset=utf-8"),
 			content: "Used HTTP Method is not allowed. POST or OPTIONS is required\n".to_owned(),
 		}
 	}
@@ -78,8 +76,8 @@ impl Response {
 	/// CORS invalid
 	pub fn invalid_allow_origin() -> Self {
 		Response {
-			code: StatusCode::Forbidden,
-			content_type: header::ContentType::plaintext(),
+			code: StatusCode::FORBIDDEN,
+			content_type: HeaderValue::from_static("text/plain; charset=utf-8"),
 			content: "Origin of the request is not whitelisted. CORS headers would not be sent and any side-effects were cancelled as well.\n".to_owned(),
 		}
 	}
@@ -87,8 +85,8 @@ impl Response {
 	/// CORS header invalid
 	pub fn invalid_allow_headers() -> Self {
 		Response {
-			code: StatusCode::Forbidden,
-			content_type: header::ContentType::plaintext(),
+			code: StatusCode::FORBIDDEN,
+			content_type: HeaderValue::from_static("text/plain; charset=utf-8"),
 			content: "Header field is not allowed.\n".to_owned(),
 		}
 	}
@@ -96,8 +94,8 @@ impl Response {
 	/// Create a response for bad request
 	pub fn bad_request<S: Into<String>>(msg: S) -> Self {
 		Response {
-			code: StatusCode::BadRequest,
-			content_type: header::ContentType::plaintext(),
+			code: StatusCode::BAD_REQUEST,
+			content_type: HeaderValue::from_static("text/plain; charset=utf-8"),
 			content: msg.into()
 		}
 	}
@@ -105,18 +103,29 @@ impl Response {
 	/// Create a response for too large (413)
 	pub fn too_large<S: Into<String>>(msg: S) -> Self {
 		Response {
-			code: StatusCode::PayloadTooLarge,
-			content_type: header::ContentType::plaintext(),
+			code: StatusCode::PAYLOAD_TOO_LARGE,
+			content_type: HeaderValue::from_static("text/plain; charset=utf-8"),
 			content: msg.into()
 		}
 	}
 }
 
-impl Into<server::Response> for Response {
-	fn into(self) -> server::Response {
-		server::Response::new()
-			.with_status(self.code)
-			.with_header(self.content_type)
-			.with_body(self.content)
+// TODO: Consider switching to a `TryFrom` conversion once it stabilizes.
+impl From<Response> for hyper::Response<Body> {
+	/// Converts from a jsonrpc `Response` to a `hyper::Response`
+	///
+	/// ## Panics
+	///
+	/// Panics if the response cannot be converted due to failure to parse
+	/// body content.
+	///
+	fn from(res: Response) -> hyper::Response<Body> {
+		hyper::Response::builder()
+			.status(res.code)
+			.header("content-type", res.content_type)
+			.body(res.content.into())
+			// Parsing `StatusCode` and `HeaderValue` is infalliable but
+			// parsing body content is not.
+			.expect("Unable to parse response body for type conversion")
 	}
 }

--- a/http/src/utils.rs
+++ b/http/src/utils.rs
@@ -1,21 +1,16 @@
-use hyper::{header, server};
+use hyper::{self, header};
 
 use server_utils::{cors, hosts};
 pub use server_utils::cors::{AllowOrigin, AllowHeaders, AccessControlAllowHeaders};
 
 /// Extracts string value of a single header in request.
-fn read_header<'a>(req: &'a server::Request, header: &str) -> Option<&'a str> {
-	match req.headers().get_raw(header) {
-		Some(ref v) if v.len() == 1 => {
-			::std::str::from_utf8(&v[0]).ok()
-		},
-		_ => None
-	}
+fn read_header<'a>(req: &'a hyper::Request<hyper::Body>, header_name: &str) -> Option<&'a str> {
+	req.headers().get(header_name).and_then(|v| v.to_str().ok())
 }
 
 /// Returns `true` if Host header in request matches a list of allowed hosts.
 pub fn is_host_allowed(
-	request: &server::Request,
+	request: &hyper::Request<hyper::Body>,
 	allowed_hosts: &Option<Vec<hosts::Host>>,
 ) -> bool {
 	hosts::is_host_valid(read_header(request, "host"), allowed_hosts)
@@ -23,23 +18,23 @@ pub fn is_host_allowed(
 
 /// Returns a CORS header that should be returned with that request.
 pub fn cors_allow_origin(
-	request: &server::Request,
+	request: &hyper::Request<hyper::Body>,
 	cors_domains: &Option<Vec<cors::AccessControlAllowOrigin>>
-) -> AllowOrigin<header::AccessControlAllowOrigin> {
+) -> AllowOrigin<header::HeaderValue> {
 	cors::get_cors_allow_origin(read_header(request, "origin"), read_header(request, "host"), cors_domains).map(|origin| {
 		use self::cors::AccessControlAllowOrigin::*;
 		match origin {
-			Value(val) => header::AccessControlAllowOrigin::Value((*val).to_owned()),
-			Null => header::AccessControlAllowOrigin::Null,
-			Any => header::AccessControlAllowOrigin::Any,
+			Value(ref val) => header::HeaderValue::from_str(val).unwrap_or(header::HeaderValue::from_static("null")),
+			Null => header::HeaderValue::from_static("null"),
+			Any => header::HeaderValue::from_static("*"),
 		}
 	})
 }
 
 /// Returns the CORS header that should be returned with that request.
 pub fn cors_allow_headers(
-	request: &server::Request,
+	request: &hyper::Request<hyper::Body>,
 	cors_allow_headers: &cors::AccessControlAllowHeadersUnicase
-) -> AllowHeaders<header::AccessControlAllowHeaders> {
+) -> AllowHeaders {
 	cors::get_cors_allow_headers(request.headers(), cors_allow_headers.into())
 }

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsonrpc-ipc-server"
 description = "IPC server for JSON-RPC"
-version = "8.0.1"
+version = "9.0.0"
 authors = ["Nikolay Volf <nikvolf@gmail.com>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/jsonrpc"
@@ -11,9 +11,9 @@ documentation = "https://paritytech.github.io/jsonrpc/json_ipc_server/index.html
 [dependencies]
 log = "0.4"
 tokio-service = "0.1"
-jsonrpc-core = { version = "8.0", path = "../core" }
-jsonrpc-server-utils = { version = "8.0", path = "../server-utils" }
-parity-tokio-ipc = { git = "https://github.com/nikvolf/parity-tokio-ipc", branch = "stable" }
+jsonrpc-core = { version = "9.0", path = "../core" }
+jsonrpc-server-utils = { version = "9.0", path = "../server-utils" }
+parity-tokio-ipc = { git = "https://github.com/NikVolf/parity-tokio-ipc", rev = "306ea3e" }
 parking_lot = "0.6"
 
 [dev-dependencies]

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -24,5 +24,5 @@ use jsonrpc_core as jsonrpc;
 pub use meta::{MetaExtractor, NoopExtractor, RequestContext};
 pub use server::{Server, ServerBuilder, CloseHandle,SecurityAttributes};
 
-pub use self::server_utils::tokio_core;
+pub use self::server_utils::tokio;
 pub use self::server_utils::session::{SessionStats, SessionId};

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -4,19 +4,19 @@ homepage = "https://github.com/paritytech/jsonrpc"
 repository = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-macros"
-version = "8.0.1"
+version = "9.0.0"
 authors = ["rphmeier <robert@parity.io>"]
 keywords = ["jsonrpc", "json-rpc", "json", "rpc", "macros"]
 documentation = "https://paritytech.github.io/jsonrpc/jsonrpc_macros/index.html"
 
 [dependencies]
 serde = "1.0"
-jsonrpc-core = { version = "8.0", path = "../core" }
-jsonrpc-pubsub = { version = "8.0", path = "../pubsub" }
+jsonrpc-core = { version = "9.0", path = "../core" }
+jsonrpc-pubsub = { version = "9.0", path = "../pubsub" }
 
 [dev-dependencies]
 serde_json = "1.0"
-jsonrpc-tcp-server = { version = "8.0", path = "../tcp" }
+jsonrpc-tcp-server = { version = "9.0", path = "../tcp" }
 
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/minihttp/Cargo.toml
+++ b/minihttp/Cargo.toml
@@ -4,15 +4,15 @@ homepage = "https://github.com/paritytech/jsonrpc"
 repository = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-minihttp-server"
-version = "8.0.1"
+version = "9.0.0"
 authors = ["tomusdrw <tomasz@parity.io>"]
 keywords = ["jsonrpc", "json-rpc", "json", "rpc", "server"]
 documentation = "https://paritytech.github.io/jsonrpc/jsonrpc_minihttp_server/index.html"
 
 [dependencies]
 bytes = "0.4"
-jsonrpc-core = { version = "8.0", path = "../core" }
-jsonrpc-server-utils = { version = "8.0", path = "../server-utils" }
+jsonrpc-core = { version = "9.0", path = "../core" }
+jsonrpc-server-utils = { version = "9.0", path = "../server-utils" }
 log = "0.4"
 parking_lot = "0.6"
 tokio-minihttp = { git = "https://github.com/tomusdrw/tokio-minihttp" }

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "https://github.com/paritytech/jsonrpc"
 repository = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-pubsub"
-version = "8.0.1"
+version = "9.0.0"
 authors = ["tomusdrw <tomasz@parity.io>"]
 keywords = ["jsonrpc", "json-rpc", "json", "rpc", "macros"]
 documentation = "https://paritytech.github.io/jsonrpc/jsonrpc_pubsub/index.html"
@@ -12,10 +12,10 @@ documentation = "https://paritytech.github.io/jsonrpc/jsonrpc_pubsub/index.html"
 [dependencies]
 log = "0.4"
 parking_lot = "0.6"
-jsonrpc-core = { version = "8.0", path = "../core" }
+jsonrpc-core = { version = "9.0", path = "../core" }
 
 [dev-dependencies]
-jsonrpc-tcp-server = { version = "8.0", path = "../tcp" }
+jsonrpc-tcp-server = { version = "9.0", path = "../tcp" }
 
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/pubsub/more-examples/Cargo.toml
+++ b/pubsub/more-examples/Cargo.toml
@@ -3,12 +3,12 @@ name = "jsonrpc-pubsub-examples"
 description = "Examples of Publish-Subscribe extension for jsonrpc."
 homepage = "https://github.com/paritytech/jsonrpc"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "8.0.0"
+version = "9.0.0"
 authors = ["tomusdrw <tomasz@parity.io>"]
 license = "MIT"
 
 [dependencies]
-jsonrpc-core = { version = "8.0", path = "../../core" }
-jsonrpc-pubsub = { version = "8.0", path = "../" }
-jsonrpc-ws-server = { version = "8.0", path = "../../ws" }
-jsonrpc-ipc-server = { version = "8.0", path = "../../ipc" }
+jsonrpc-core = { version = "9.0", path = "../../core" }
+jsonrpc-pubsub = { version = "9.0", path = "../" }
+jsonrpc-ws-server = { version = "9.0", path = "../../ws" }
+jsonrpc-ipc-server = { version = "9.0", path = "../../ipc" }

--- a/server-utils/Cargo.toml
+++ b/server-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Server utils for jsonrpc-core crate."
 name = "jsonrpc-server-utils"
-version = "8.0.1"
+version = "9.0.0"
 authors = ["tomusdrw <tomasz@parity.io>"]
 license = "MIT"
 keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
@@ -12,13 +12,14 @@ repository = "https://github.com/paritytech/jsonrpc"
 [dependencies]
 globset = "0.4"
 log = "0.4"
-jsonrpc-core = { version = "8.0", path = "../core" }
-tokio-core = { version = "0.1" }
-tokio-io = { version = "0.1" }
+jsonrpc-core = { version = "9.0", path = "../core" }
+tokio = { version = "0.1" }
+tokio-codec = { version = "0.1" }
 bytes = "0.4"
-hyper = "0.11"
+hyper = "0.12"
 unicase = "2.0"
 lazy_static = "1.1.0"
+num_cpus = "~1.8"
 
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/server-utils/src/lib.rs
+++ b/server-utils/src/lib.rs
@@ -11,9 +11,10 @@ extern crate lazy_static;
 extern crate globset;
 extern crate jsonrpc_core as core;
 extern crate bytes;
+extern crate num_cpus;
 
-pub extern crate tokio_core;
-pub extern crate tokio_io;
+pub extern crate tokio;
+pub extern crate tokio_codec;
 
 pub mod cors;
 pub mod hosts;

--- a/server-utils/src/reactor.rs
+++ b/server-utils/src/reactor.rs
@@ -1,68 +1,77 @@
-//! Event Loop Remote
+//! Event Loop Executor
 //! Either spawns a new event loop, or re-uses provided one.
 
 use std::{io, thread};
 use std::sync::mpsc;
-use tokio_core;
+use tokio;
+use num_cpus;
 
 use core::futures::{self, Future};
 
-/// Possibly uninitialized event loop remote.
+/// Possibly uninitialized event loop executor.
 #[derive(Debug)]
-pub enum UninitializedRemote {
-	/// Shared instance of remote.
-	Shared(tokio_core::reactor::Remote),
+pub enum UninitializedExecutor {
+	/// Shared instance of executor.
+	Shared(tokio::runtime::TaskExecutor),
 	/// Event Loop should be spawned by the transport.
 	Unspawned,
 }
 
-impl UninitializedRemote {
-	/// Initializes remote.
-	/// In case there is no shared remote, will spawn a new event loop.
-	/// Dropping `Remote` closes the loop.
-	pub fn initialize(self) -> io::Result<Remote> {
+impl UninitializedExecutor {
+	/// Initializes executor.
+	/// In case there is no shared executor, will spawn a new event loop.
+	/// Dropping `Executor` closes the loop.
+	pub fn initialize(self) -> io::Result<Executor> {
 		self.init_with_name("event.loop")
 	}
 
-	/// Initializes remote.
-	/// In case there is no shared remote, will spawn a new event loop.
-	/// Dropping `Remote` closes the loop.
-	pub fn init_with_name<T: Into<String>>(self, name: T) -> io::Result<Remote> {
+	/// Initializes executor.
+	/// In case there is no shared executor, will spawn a new event loop.
+	/// Dropping `Executor` closes the loop.
+	pub fn init_with_name<T: Into<String>>(self, name: T) -> io::Result<Executor> {
 		match self {
-			UninitializedRemote::Shared(remote) => Ok(Remote::Shared(remote)),
-			UninitializedRemote::Unspawned => RpcEventLoop::with_name(Some(name.into())).map(Remote::Spawned),
+			UninitializedExecutor::Shared(executor) => Ok(Executor::Shared(executor)),
+			UninitializedExecutor::Unspawned => RpcEventLoop::with_name(Some(name.into())).map(Executor::Spawned),
 		}
 	}
 }
 
-/// Initialized Remote
+/// Initialized Executor
 #[derive(Debug)]
-pub enum Remote {
+pub enum Executor {
 	/// Shared instance
-	Shared(tokio_core::reactor::Remote),
+	Shared(tokio::runtime::TaskExecutor),
 	/// Spawned Event Loop
 	Spawned(RpcEventLoop),
 }
 
-impl Remote {
-	/// Get remote associated with this event loop.
-	pub fn remote(&self) -> tokio_core::reactor::Remote {
+impl Executor {
+	/// Get tokio executor associated with this event loop.
+	pub fn executor(&self) -> tokio::runtime::TaskExecutor {
 		match *self {
-			Remote::Shared(ref remote) => remote.clone(),
-			Remote::Spawned(ref eloop) => eloop.remote(),
+			Executor::Shared(ref executor) => executor.clone(),
+			Executor::Spawned(ref eloop) => eloop.executor(),
 		}
+	}
+
+	/// Spawn a future onto the Tokio runtime.
+	pub fn spawn<F>(&self, future: F)
+	where
+		F: Future<Item = (), Error = ()> + Send + 'static,
+	{
+		self.executor().spawn(future)
 	}
 
 	/// Closes underlying event loop (if any!).
 	pub fn close(self) {
-		if let Remote::Spawned(eloop) = self {
+		if let Executor::Spawned(eloop) = self {
 			eloop.close()
 		}
 	}
 
 	/// Wait for underlying event loop to finish (if any!).
 	pub fn wait(self) {
-		if let Remote::Spawned(eloop) = self {
+		if let Executor::Spawned(eloop) = self {
 			let _ = eloop.wait();
 		}
 	}
@@ -71,7 +80,7 @@ impl Remote {
 /// A handle to running event loop. Dropping the handle will cause event loop to finish.
 #[derive(Debug)]
 pub struct RpcEventLoop {
-	remote: tokio_core::reactor::Remote,
+	executor: tokio::runtime::TaskExecutor,
 	close: Option<futures::Complete<()>>,
 	handle: Option<thread::JoinHandle<()>>,
 }
@@ -96,30 +105,52 @@ impl RpcEventLoop {
 		if let Some(name) = name {
 			tb = tb.name(name);
 		}
+
 		let handle = tb.spawn(move || {
-			let el = tokio_core::reactor::Core::new();
-			match el {
-				Ok(mut el) => {
-					tx.send(Ok(el.remote())).expect("Rx is blocking upper thread.");
-					let _ = el.run(futures::empty().select(stopped));
+			let mut tp_builder = tokio::executor::thread_pool::Builder::new();
+
+			let pool_size = match num_cpus::get_physical() {
+				1 => 1,
+				2...4 => 2,
+				_ => 3,
+			};
+
+			tp_builder
+				.pool_size(pool_size)
+				.name_prefix("jsonrpc-eventloop-");
+
+			let runtime = tokio::runtime::Builder::new()
+				.threadpool_builder(tp_builder)
+				.build();
+
+			match runtime {
+				Ok(mut runtime) => {
+					tx.send(Ok(runtime.executor())).expect("Rx is blocking upper thread.");
+					let terminate = futures::empty().select(stopped)
+						.map(|_| ())
+						.map_err(|_| ());
+					runtime.spawn(terminate);
+					runtime.shutdown_on_idle().wait().unwrap();
+					println!("Server has shut down.");
 				},
 				Err(err) => {
 					tx.send(Err(err)).expect("Rx is blocking upper thread.");
 				}
 			}
 		}).expect("Couldn't spawn a thread.");
-		let remote = rx.recv().expect("tx is transfered to a newly spawned thread.");
 
-		remote.map(|remote| RpcEventLoop {
-			remote: remote,
+		let exec = rx.recv().expect("tx is transfered to a newly spawned thread.");
+
+		exec.map(|executor| RpcEventLoop {
+			executor,
 			close: Some(stop),
 			handle: Some(handle),
 		})
 	}
 
-	/// Get remote for this event loop.
-	pub fn remote(&self) -> tokio_core::reactor::Remote {
-		self.remote.clone()
+	/// Get executor for this event loop.
+	pub fn executor(&self) -> tokio::runtime::TaskExecutor {
+		self.executor.clone()
 	}
 
 	/// Blocks current thread and waits until the event loop is finished.

--- a/server-utils/src/stream_codec.rs
+++ b/server-utils/src/stream_codec.rs
@@ -1,5 +1,5 @@
 use std::{io, str};
-use tokio_io::codec::{Decoder, Encoder};
+use tokio_codec::{Decoder, Encoder};
 use bytes::BytesMut;
 
 /// Separator for enveloping messages in streaming codecs
@@ -64,7 +64,7 @@ impl Decoder for StreamCodec {
 				}
 			} else {
 				Ok(None)
-			}			
+			}
 		} else {
 			let mut depth = 0;
 			let mut in_str = false;
@@ -112,7 +112,7 @@ impl Decoder for StreamCodec {
 impl Encoder for StreamCodec {
 	type Item = String;
 	type Error = io::Error;
-	
+
 	fn encode(&mut self, msg: String, buf: &mut BytesMut) -> io::Result<()> {
 		let mut payload = msg.into_bytes();
 		if let Separator::Byte(separator) = self.outgoing_separator {
@@ -127,7 +127,7 @@ impl Encoder for StreamCodec {
 mod tests {
 
 	use super::StreamCodec;
-	use tokio_io::codec::Decoder;
+	use tokio_codec::Decoder;
 	use bytes::{BytesMut, BufMut};
 
 	#[test]
@@ -269,5 +269,5 @@ mod tests {
 
 		assert_eq!(request, "{ test: 1 }");
 		assert_eq!(request2, "{ test: 2 }");
-	}	
+	}
 }

--- a/stdio/Cargo.toml
+++ b/stdio/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://paritytech.github.io/jsonrpc/jsonrpc_stdio_server/index
 
 [dependencies]
 futures = "0.1.23"
-jsonrpc-core = { version = "8.0", path = "../core" }
+jsonrpc-core = { version = "9.0", path = "../core" }
 log = "0.4"
 tokio = "0.1.7"
 tokio-codec = "0.1.0"

--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsonrpc-tcp-server"
 description = "TCP/IP server for JSON-RPC"
-version = "8.0.1"
+version = "9.0.0"
 authors = ["NikVolf <nikvolf@gmail.com>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/jsonrpc"
@@ -12,8 +12,8 @@ documentation = "https://paritytech.github.io/jsonrpc/jsonrpc_tcp_server/index.h
 log = "0.4"
 parking_lot = "0.6"
 tokio-service = "0.1"
-jsonrpc-core = { version = "8.0", path = "../core" }
-jsonrpc-server-utils = { version = "8.0", path = "../server-utils" }
+jsonrpc-core = { version = "9.0", path = "../core" }
+jsonrpc-server-utils = { version = "9.0", path = "../server-utils" }
 
 [dev-dependencies]
 lazy_static = "1.0"

--- a/tcp/src/lib.rs
+++ b/tcp/src/lib.rs
@@ -46,4 +46,4 @@ use jsonrpc_core as jsonrpc;
 pub use dispatch::{Dispatcher, PushMessageError};
 pub use meta::{MetaExtractor, RequestContext};
 pub use server::{ServerBuilder, Server};
-pub use self::server_utils::tokio_core;
+pub use self::server_utils::tokio;

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsonrpc-test"
 description = "Simple test framework for JSON-RPC."
-version = "8.0.1"
+version = "9.0.0"
 authors = ["Tomasz Drwięga <tomasz@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/jsonrpc"
@@ -9,9 +9,9 @@ repository = "https://github.com/paritytech/jsonrpc"
 documentation = "https://paritytech.github.io/jsonrpc/jsonrpc_test/index.html"
 
 [dependencies]
-jsonrpc-core = { path = "../core", version = "8.0" }
+jsonrpc-core = { path = "../core", version = "9.0" }
 serde = "1.0"
 serde_json = "1.0"
 
 [dev-dependencies]
-jsonrpc-macros = { path = "../macros", version = "8.0" }
+jsonrpc-macros = { path = "../macros", version = "9.0" }

--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsonrpc-ws-server"
 description = "WebSockets server for JSON-RPC"
-version = "8.0.0"
+version = "9.0.0"
 authors = ["tomusdrw <tomasz@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/jsonrpc"
@@ -10,8 +10,8 @@ documentation = "https://paritytech.github.io/jsonrpc/json_ws_server/index.html"
 
 [dependencies]
 error-chain = "0.12"
-jsonrpc-core = { version = "8.0", path = "../core" }
-jsonrpc-server-utils = { version = "8.0", path = "../server-utils" }
+jsonrpc-core = { version = "9.0", path = "../core" }
+jsonrpc-server-utils = { version = "9.0", path = "../server-utils" }
 log = "0.4"
 parking_lot = "0.6"
 slab = "0.4"

--- a/ws/src/lib.rs
+++ b/ws/src/lib.rs
@@ -31,5 +31,5 @@ pub use self::server::{CloseHandle, Server};
 pub use self::server_builder::ServerBuilder;
 pub use self::server_utils::cors::Origin;
 pub use self::server_utils::hosts::{Host, DomainsValidation};
-pub use self::server_utils::tokio_core;
+pub use self::server_utils::tokio;
 pub use self::server_utils::session::{SessionId, SessionStats};

--- a/ws/src/metadata.rs
+++ b/ws/src/metadata.rs
@@ -3,8 +3,7 @@ use std::sync::{atomic, Arc};
 
 use core::{self, futures};
 use core::futures::sync::mpsc;
-use server_utils::tokio_core::reactor::Remote;
-use server_utils::session;
+use server_utils::{session, tokio::runtime::TaskExecutor};
 use ws;
 
 use error;
@@ -74,7 +73,7 @@ pub struct RequestContext {
 	/// Direct channel to send messages to a client.
 	pub out: Sender,
 	/// Remote to underlying event loop.
-	pub remote: Remote,
+	pub executor: TaskExecutor,
 }
 
 impl RequestContext {
@@ -83,7 +82,7 @@ impl RequestContext {
 	pub fn sender(&self) -> mpsc::Sender<String> {
 		let out = self.out.clone();
 		let (sender, receiver) = mpsc::channel(1);
-		self.remote.spawn(move |_| SenderFuture(out, receiver));
+		self.executor.spawn(SenderFuture(out, receiver));
 		sender
 	}
 }

--- a/ws/src/server_builder.rs
+++ b/ws/src/server_builder.rs
@@ -5,7 +5,7 @@ use core;
 use server_utils;
 use server_utils::cors::Origin;
 use server_utils::hosts::{Host, DomainsValidation};
-use server_utils::reactor::UninitializedRemote;
+use server_utils::reactor::UninitializedExecutor;
 use server_utils::session::SessionStats;
 
 use error::Result;
@@ -21,7 +21,7 @@ pub struct ServerBuilder<M: core::Metadata, S: core::Middleware<M>> {
 	allowed_hosts: Option<Vec<Host>>,
 	request_middleware: Option<Arc<session::RequestMiddleware>>,
 	session_stats: Option<Arc<SessionStats>>,
-	remote: UninitializedRemote,
+	executor: UninitializedExecutor,
 	max_connections: usize,
 }
 
@@ -47,14 +47,14 @@ impl<M: core::Metadata, S: core::Middleware<M>> ServerBuilder<M, S> {
 			allowed_hosts: None,
 			request_middleware: None,
 			session_stats: None,
-			remote: UninitializedRemote::Unspawned,
+			executor: UninitializedExecutor::Unspawned,
 			max_connections: 100,
 		}
 	}
 
-	/// Utilize existing event loop remote to poll RPC results.
-	pub fn event_loop_remote(mut self, remote: server_utils::tokio_core::reactor::Remote) -> Self {
-		self.remote = UninitializedRemote::Shared(remote);
+	/// Utilize existing event loop executor to poll RPC results.
+	pub fn event_loop_executor(mut self, executor: server_utils::tokio::runtime::TaskExecutor) -> Self {
+		self.executor = UninitializedExecutor::Shared(executor);
 		self
 	}
 
@@ -107,7 +107,7 @@ impl<M: core::Metadata, S: core::Middleware<M>> ServerBuilder<M, S> {
 			self.allowed_hosts,
 			self.request_middleware,
 			self.session_stats,
-			self.remote,
+			self.executor,
 			self.max_connections,
 		)
 	}


### PR DESCRIPTION
* Replace `tokio_core` with `tokio`.

* `server_utils::reactor::Remote` has been renamed to `Executor`.
  The `Shared` variant now contains a `tokio::runtime::TaskExecutor`.
  This may need to be changed to a trait object (of
  `tokio::executor::Executor`) or be otherwise abstracted to conceal the
  type in the public API.
* Bump crate versions to 0.9

Eventually, I'll be updating Parity to use these new changes and to remove `tokio_core` etc. You *may* want to consider holding off on merging until I'm done, to ensure everything works properly. I don't have an estimate on when that will be.

Closes https://github.com/paritytech/jsonrpc/issues/298