### PR TITLE
Fix `parity-tokio-ipc` version in `1.11` branch

### DIFF
--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -14,7 +14,6 @@ tokio-service = "0.1"
 jsonrpc-core = { version = "8.0", path = "../core" }
 jsonrpc-server-utils = { version = "8.0", path = "../server-utils" }
 parity-tokio-ipc = { git = "https://github.com/nikvolf/parity-tokio-ipc", rev = "7c9bbe3bc45d8e72a92b0951acc877da228abd50" }
-parking_lot = "0.6"
 
 [dev-dependencies]
 env_logger = "0.4"

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.3"
 tokio-service = "0.1"
 jsonrpc-core = { version = "8.0", path = "../core" }
 jsonrpc-server-utils = { version = "8.0", path = "../server-utils" }
-parity-tokio-ipc = { git = "https://github.com/nikvolf/parity-tokio-ipc" }
+parity-tokio-ipc = { git = "https://github.com/nikvolf/parity-tokio-ipc", rev = "7c9bbe3bc45d8e72a92b0951acc877da228abd50" }
 parking_lot = "0.6"
 
 [dev-dependencies]

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -14,6 +14,7 @@ tokio-service = "0.1"
 jsonrpc-core = { version = "8.0", path = "../core" }
 jsonrpc-server-utils = { version = "8.0", path = "../server-utils" }
 parity-tokio-ipc = { git = "https://github.com/nikvolf/parity-tokio-ipc" }
+parking_lot = "0.6"
 
 [dev-dependencies]
 env_logger = "0.4"

--- a/ipc/src/server.rs
+++ b/ipc/src/server.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std;
 use std::sync::Arc;
 
@@ -124,16 +126,17 @@ impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
 				}
 			}
 
-			let listener = match Endpoint::new(endpoint_addr, handle) {
-				Ok(l) => l,
+			let listener = Endpoint::new(endpoint_addr);
+
+			let remote = handle.remote().clone();
+			let connections = match listener.incoming(handle.clone()) {
+				Ok(connections) => connections,
 				Err(e) => {
 					start_signal.send(Err(e)).expect("Cannot fail since receiver never dropped before receiving");
 					return future::Either::A(future::ok(()));
 				}
 			};
 
-			let remote = handle.remote().clone();
-			let connections = listener.incoming();
 			let mut id = 0u64;
 
 			let server = connections.for_each(move |(io_stream, remote_id)| {


### PR DESCRIPTION
Fix `parity-tokio-ipc` rev right before this commit : https://github.com/NikVolf/parity-tokio-ipc/commit/1b82b8da1c3298657f38fed1e62961d5ed97f135 that introduced API changes. 