### PR TITLE
Http CloseHandle for closing while waiting

### DIFF
--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -577,17 +577,17 @@ impl Server {
 	}
 
 	/// Returns a handle to the server that can be used to close it while another thread is
-    /// blocking in `wait`.
-    pub fn close_handle(&mut self) -> CloseHandle {
+	/// blocking in `wait`.
+	pub fn close_handle(&mut self) -> CloseHandle {
 		let executor_close: Option<Vec<_>> = self.executor.as_mut().map(|executors| {
 			executors.iter_mut().map(|executor| executor.close_handle()).collect()
 		});
 
-        CloseHandle {
-            executor_close,
-            close: self.close.clone(),
-        }
-    }
+		CloseHandle {
+			executor_close,
+			close: self.close.clone(),
+		}
+	}
 }
 
 impl Drop for Server {
@@ -598,8 +598,8 @@ impl Drop for Server {
 
 /// A handle that allows closing of a server even if it owned by a thread blocked in `wait`.
 pub struct CloseHandle {
-    close: Arc<Mutex<Option<Vec<oneshot::Sender<()>>>>>,
-    executor_close: Option<Vec<Option<futures::Complete<()>>>>,
+	close: Arc<Mutex<Option<Vec<oneshot::Sender<()>>>>>,
+	executor_close: Option<Vec<Option<futures::Complete<()>>>>,
 }
 
 impl CloseHandle {

--- a/server-utils/src/reactor.rs
+++ b/server-utils/src/reactor.rs
@@ -62,6 +62,14 @@ impl Executor {
 		self.executor().spawn(future)
 	}
 
+	pub fn close_handle(&mut self) -> Option<futures::Complete<()>> {
+		if let Executor::Spawned(ref mut eloop) = self {
+			eloop.close_handle()
+		} else {
+			None
+		}
+	}
+
 	/// Closes underlying event loop (if any!).
 	pub fn close(self) {
 		if let Executor::Spawned(eloop) = self {
@@ -162,5 +170,9 @@ impl RpcEventLoop {
 		let _ = self.close.take().expect("Close is always set before self is consumed.").send(()).map_err(|e| {
 			warn!("Event Loop is already finished. {:?}", e);
 		});
+	}
+
+	pub fn close_handle(&mut self) -> Option<futures::Complete<()>>{
+		self.close.take()
 	}
 }

--- a/server-utils/src/reactor.rs
+++ b/server-utils/src/reactor.rs
@@ -62,6 +62,7 @@ impl Executor {
 		self.executor().spawn(future)
 	}
 
+	/// Returns a handle to close the underlying event loop
 	pub fn close_handle(&mut self) -> Option<futures::Complete<()>> {
 		if let Executor::Spawned(ref mut eloop) = self {
 			eloop.close_handle()
@@ -172,6 +173,8 @@ impl RpcEventLoop {
 		});
 	}
 
+	/// Returns the close signal that can be used to close the event loop even while
+	/// another thread is blocked on the event loop in "wait"
 	pub fn close_handle(&mut self) -> Option<futures::Complete<()>>{
 		self.close.take()
 	}


### PR DESCRIPTION
Add CloseHandle to Json Http server to allow a different thread to close() after calling wait() on main server thread. Based on similar work for websockets: https://github.com/paritytech/jsonrpc/pull/151/files