### PR TITLE
Handle keep-alive correctly

### DIFF
--- a/http/src/handler.rs
+++ b/http/src/handler.rs
@@ -102,7 +102,7 @@ impl<M: Metadata, S: Middleware<M>> Service for ServerHandler<M, S> {
 					health_api: self.health_api.clone(),
 					max_request_body_size: self.max_request_body_size,
 					// initial value, overwritten when reading client headers
-					keep_alive: None,
+					keep_alive: true,
 				})
 			}
 		}
@@ -214,7 +214,7 @@ pub struct RpcHandler<M: Metadata, S: Middleware<M>> {
 	rest_api: RestApi,
 	health_api: Option<(String, String)>,
 	max_request_body_size: usize,
-	keep_alive: Option<bool>,
+	keep_alive: bool,
 }
 
 impl<M: Metadata, S: Middleware<M>> Future for RpcHandler<M, S> {
@@ -510,7 +510,7 @@ impl<M: Metadata, S: Middleware<M>> RpcHandler<M, S> {
 		cors_max_age: Option<u32>,
 		cors_allow_origin: Option<HeaderValue>,
 		cors_allow_headers: Option<Vec<HeaderValue>>,
-		keep_alive: Option<bool>,
+		keep_alive: bool,
 	) {
 		let as_header = |m: Method| m.as_str().parse().expect("`Method` will always parse; qed");
 		let concat = |headers: &[HeaderValue]| {
@@ -550,12 +550,8 @@ impl<M: Metadata, S: Middleware<M>> RpcHandler<M, S> {
 			}
 		}
 
-		if let Some(keep_alive) = keep_alive {
-			headers.append(header::CONNECTION, if keep_alive {
-				HeaderValue::from_static("keep-alive")
-			} else {
-				HeaderValue::from_static("close")
-			});
+		if !keep_alive {
+			headers.append(header::CONNECTION, HeaderValue::from_static("close"));
 		}
 	}
 

--- a/http/src/handler.rs
+++ b/http/src/handler.rs
@@ -25,6 +25,7 @@ pub struct ServerHandler<M: Metadata = (), S: Middleware<M> = NoopMiddleware> {
 	rest_api: RestApi,
 	health_api: Option<(String, String)>,
 	max_request_body_size: usize,
+	keep_alive: bool,
 }
 
 impl<M: Metadata, S: Middleware<M>> ServerHandler<M, S> {
@@ -39,6 +40,7 @@ impl<M: Metadata, S: Middleware<M>> ServerHandler<M, S> {
 		rest_api: RestApi,
 		health_api: Option<(String, String)>,
 		max_request_body_size: usize,
+		keep_alive: bool,
 	) -> Self {
 		ServerHandler {
 			jsonrpc_handler,
@@ -50,6 +52,7 @@ impl<M: Metadata, S: Middleware<M>> ServerHandler<M, S> {
 			rest_api,
 			health_api,
 			max_request_body_size,
+			keep_alive,
 		}
 	}
 }
@@ -89,6 +92,7 @@ impl<M: Metadata, S: Middleware<M>> Service for ServerHandler<M, S> {
 						cors_domains: self.cors_domains.clone(),
 						cors_headers: self.cors_allowed_headers.clone(),
 						continue_on_invalid_cors: should_continue_on_invalid_cors,
+						keep_alive: self.keep_alive,
 					},
 					is_options: false,
 					cors_max_age: self.cors_max_age,
@@ -97,6 +101,8 @@ impl<M: Metadata, S: Middleware<M>> Service for ServerHandler<M, S> {
 					rest_api: self.rest_api,
 					health_api: self.health_api.clone(),
 					max_request_body_size: self.max_request_body_size,
+					// initial value, overwritten when reading client headers
+					keep_alive: None,
 				})
 			}
 		}
@@ -157,6 +163,7 @@ enum RpcHandlerState<M, F> where
 		cors_domains: CorsDomains,
 		cors_headers: cors::AccessControlAllowHeaders,
 		continue_on_invalid_cors: bool,
+		keep_alive: bool,
 	},
 	ReadingBody {
 		body: hyper::Body,
@@ -207,6 +214,7 @@ pub struct RpcHandler<M: Metadata, S: Middleware<M>> {
 	rest_api: RestApi,
 	health_api: Option<(String, String)>,
 	max_request_body_size: usize,
+	keep_alive: Option<bool>,
 }
 
 impl<M: Metadata, S: Middleware<M>> Future for RpcHandler<M, S> {
@@ -215,10 +223,13 @@ impl<M: Metadata, S: Middleware<M>> Future for RpcHandler<M, S> {
 
 	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
 		let new_state = match mem::replace(&mut self.state, RpcHandlerState::Done) {
-			RpcHandlerState::ReadingHeaders { request, cors_domains, cors_headers, continue_on_invalid_cors, } => {
+			RpcHandlerState::ReadingHeaders {
+				request, cors_domains, cors_headers, continue_on_invalid_cors, keep_alive,
+			} => {
 				// Read cors header
 				self.cors_allow_origin = utils::cors_allow_origin(&request, &cors_domains);
 				self.cors_allow_headers = utils::cors_allow_headers(&request, &cors_headers);
+				self.keep_alive = utils::keep_alive(&request, keep_alive);
 				self.is_options = *request.method() == Method::OPTIONS;
 				// Read other headers
 				RpcPollState::Ready(self.read_headers(request, continue_on_invalid_cors))
@@ -285,6 +296,7 @@ impl<M: Metadata, S: Middleware<M>> Future for RpcHandler<M, S> {
 					self.cors_max_age,
 					cors_allow_origin.into(),
 					cors_allow_headers.into(),
+					self.keep_alive,
 				);
 				Ok(Async::Ready(response))
 			},
@@ -498,6 +510,7 @@ impl<M: Metadata, S: Middleware<M>> RpcHandler<M, S> {
 		cors_max_age: Option<u32>,
 		cors_allow_origin: Option<HeaderValue>,
 		cors_allow_headers: Option<Vec<HeaderValue>>,
+		keep_alive: Option<bool>,
 	) {
 		let as_header = |m: Method| m.as_str().parse().expect("`Method` will always parse; qed");
 		let concat = |headers: &[HeaderValue]| {
@@ -535,6 +548,14 @@ impl<M: Metadata, S: Middleware<M>> RpcHandler<M, S> {
 					headers.append(header::ACCESS_CONTROL_ALLOW_HEADERS, concat(&cors_allow_headers));
 				}
 			}
+		}
+
+		if let Some(keep_alive) = keep_alive {
+			headers.append(header::CONNECTION, if keep_alive {
+				HeaderValue::from_static("keep-alive")
+			} else {
+				HeaderValue::from_static("close")
+			});
 		}
 	}
 

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -517,6 +517,7 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 						rest_api,
 						health_api.clone(),
 						max_request_body_size,
+						keep_alive,
 					);
 					tokio::spawn(http.serve_connection(socket, service)
 						.map_err(|e| error!("Error serving connection: {:?}", e)));

--- a/http/src/tests.rs
+++ b/http/src/tests.rs
@@ -1185,8 +1185,8 @@ fn should_close_connection_without_keep_alive() {
 	);
 
 	// then
-	assert!(!response.headers.contains("connection:"),
-		"Header present in {}", response.headers);
+	assert!(response.headers.contains("connection: close"),
+		"Header missing in {}", response.headers);
 	assert_eq!(response.status, "HTTP/1.1 200 OK".to_owned());
 	assert_eq!(response.body, world_batch());
 }

--- a/http/src/utils.rs
+++ b/http/src/utils.rs
@@ -52,3 +52,18 @@ pub fn cors_allow_headers(
 			.unwrap_or_else(|_| header::HeaderValue::from_static("unknown"))
 	)
 }
+
+/// Returns an optional value of `Connection` header that should be included in the response.
+/// The second parameter defines if server is configured with keep-alive option.
+/// Return value of `Some(true)` indicates that `Connection: keep-alive` should be included,
+/// `Some(false)` indicates `Connection: close` and `None` doesn't include the header at all.
+pub fn keep_alive(
+	request: &hyper::Request<hyper::Body>,
+	keep_alive: bool,
+) -> Option<bool> {
+	read_header(request, "connection")
+		.map(|val| match (keep_alive, val) {
+			(true, "keep-alive") => true,
+			_ => false,
+		})
+}

--- a/tcp/src/tests.rs
+++ b/tcp/src/tests.rs
@@ -215,9 +215,8 @@ fn peer_meta() {
 	println!("{}", result);
 
 	// contains random port, so just smoky comparing response length
-	assert_eq!(
-		if cfg!(windows) { 58 } else { 59 },
-		result.len()
+	assert!(
+		result.len() == 58 || result.len() == 59
 	);
 }
 


### PR DESCRIPTION
It seems that hyper setting only affects the underlying TPC stream, but doesn't add any headers to the response to inform the client.

This PR changes the way we handle `keep_alive` in the builder, so that correct `Connection` headers are added to the response.