### PR TITLE
Allow one-way bounds on trait generic parameters.

### DIFF
--- a/macros/examples/generic-trait-bounds.rs
+++ b/macros/examples/generic-trait-bounds.rs
@@ -1,12 +1,17 @@
+extern crate serde;
 extern crate jsonrpc_core;
 #[macro_use]
 extern crate jsonrpc_macros;
 
+use serde::de::DeserializeOwned;
 use jsonrpc_core::{IoHandler, Error, Result};
 use jsonrpc_core::futures::future::{self, FutureResult};
 
+// Two only requires DeserializeOwned
 build_rpc_trait! {
-	pub trait Rpc<One, Two> {
+	pub trait Rpc<One> where
+		Two: DeserializeOwned,
+	{
 		/// Get One type.
 		#[rpc(name = "getOne")]
 		fn one(&self) -> Result<One>;
@@ -18,6 +23,16 @@ build_rpc_trait! {
 		/// Performs asynchronous operation
 		#[rpc(name = "beFancy")]
 		fn call(&self, One) -> FutureResult<(One, u64), Error>;
+	}
+}
+
+build_rpc_trait! {
+	pub trait Rpc2<> where
+		Two: DeserializeOwned,
+	{
+		/// Adds two numbers and returns a result
+		#[rpc(name = "setTwo")]
+		fn set_two(&self, Two) -> Result<()>;
 	}
 }
 
@@ -38,10 +53,17 @@ impl Rpc<u64, String> for RpcImpl {
 	}
 }
 
+impl Rpc2<String> for RpcImpl {
+	fn set_two(&self, _: String) -> Result<()> {
+		unimplemented!()
+	}
+}
+
 
 fn main() {
 	let mut io = IoHandler::new();
-	let rpc = RpcImpl;
 
-	io.extend_with(rpc.to_delegate())
+	io.extend_with(Rpc::to_delegate(RpcImpl));
+	io.extend_with(Rpc2::to_delegate(RpcImpl));
 }
+

--- a/macros/examples/generic-trait.rs
+++ b/macros/examples/generic-trait.rs
@@ -17,7 +17,7 @@ build_rpc_trait! {
 
 		/// Performs asynchronous operation
 		#[rpc(name = "beFancy")]
-		fn call(&self, One) -> FutureResult<(One, u64), Error>;
+		fn call(&self, One) -> FutureResult<(One, Two), Error>;
 	}
 }
 
@@ -33,8 +33,8 @@ impl Rpc<u64, String> for RpcImpl {
 		Ok(())
 	}
 
-	fn call(&self, num: u64) -> FutureResult<(u64, u64), Error> {
-		::future::finished((num + 999, num))
+	fn call(&self, num: u64) -> FutureResult<(u64, String), Error> {
+		::future::finished((num + 999, "hello".into()))
 	}
 }
 

--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -71,17 +71,6 @@ macro_rules! metadata {
 }
 
 #[macro_export]
-macro_rules! print_generics {
-	(
-		$(
-			$generics:ident
-		),*
-	) => {
-		$( $generics: Send + Sync + 'static ),*
-	};
-}
-
-#[macro_export]
 macro_rules! build_rpc_trait {
 	(
 		$(#[$t_attr: meta])*

--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -71,11 +71,53 @@ macro_rules! metadata {
 }
 
 #[macro_export]
+macro_rules! print_generics {
+	(
+		$(
+			$generics:ident
+		),*
+	) => {
+		$( $generics: Send + Sync + 'static ),*
+	};
+}
+
+#[macro_export]
 macro_rules! build_rpc_trait {
-	// entry-point. todo: make another for traits w/ bounds.
 	(
 		$(#[$t_attr: meta])*
-		pub trait $name: ident $(<$($generics:ident),*>)* {
+		pub trait $name:ident $(<$( $generics:ident ),*>
+		$(
+			where
+				$( $generics2:ident : $bounds:tt $( + $morebounds:tt )* ,)+
+		)* )*
+		{
+			$( $rest: tt )+
+		}
+	) => {
+		build_rpc_trait! {
+			@WITH_BOUNDS
+			$(#[$t_attr])*
+			pub trait $name $(<
+				// first generic parameters with both bounds
+				$( $generics ,)*
+				@BOUNDS
+				// then specialised ones
+				$( $( $generics2 : $bounds $( + $morebounds )* )* )*
+			> )* {
+				$( $rest )+
+			}
+		}
+	};
+
+	// entry-point. todo: make another for traits w/ bounds.
+	(
+		@WITH_BOUNDS
+		$(#[$t_attr: meta])*
+		pub trait $name:ident $(<
+			$( $simple_generics:ident ,)*
+			@BOUNDS
+			$( $generics:ident $(: $bounds:tt $( + $morebounds:tt )* )* ),*
+		>)* {
 			$(
 				$( #[doc=$m_doc:expr] )*
 				#[ rpc( $($t:tt)* ) ]
@@ -84,7 +126,7 @@ macro_rules! build_rpc_trait {
 		}
 	) => {
 		$(#[$t_attr])*
-		pub trait $name $(<$($generics,)*>)* : Sized + Send + Sync + 'static {
+		pub trait $name $(<$( $simple_generics ,)* $( $generics , )*>)* : Sized + Send + Sync + 'static {
 			$(
 				$(#[doc=$m_doc])*
 				fn $m_name ( $($p)* ) -> $result<$out $(, $error)* > ;
@@ -93,7 +135,10 @@ macro_rules! build_rpc_trait {
 			/// Transform this into an `IoDelegate`, automatically wrapping
 			/// the parameters.
 			fn to_delegate<M: $crate::jsonrpc_core::Metadata>(self) -> $crate::IoDelegate<Self, M>
-				where $($($generics: Send + Sync + 'static + $crate::Serialize + $crate::DeserializeOwned),*)*
+				where $(
+					$($simple_generics: Send + Sync + 'static + $crate::Serialize + $crate::DeserializeOwned ,)*
+					$($generics: Send + Sync + 'static $( + $bounds $( + $morebounds )* )* ),*
+				)*
 			{
 				let mut del = $crate::IoDelegate::new(self.into());
 				$(
@@ -109,8 +154,13 @@ macro_rules! build_rpc_trait {
 
 	// entry-point for trait with metadata methods
 	(
+		@WITH_BOUNDS
 		$(#[$t_attr: meta])*
-		pub trait $name: ident $(<$($generics:ident),*>)* {
+		pub trait $name: ident $(<
+			$( $simple_generics:ident ,)*
+			@BOUNDS
+			$($generics:ident $( : $bounds:tt $( + $morebounds:tt )* )* ),*
+		>)* {
 			type Metadata;
 
 			$(
@@ -133,7 +183,7 @@ macro_rules! build_rpc_trait {
 		}
 	) => {
 		$(#[$t_attr])*
-		pub trait $name $(<$($generics,)*>)* : Sized + Send + Sync + 'static {
+		pub trait $name $(<$( $simple_generics ,)* $( $generics , )* >)* : Sized + Send + Sync + 'static {
 			// Metadata bound differs for traits with subscription methods.
 			metadata! (
 				$( $sub_name )*
@@ -154,7 +204,10 @@ macro_rules! build_rpc_trait {
 			/// Transform this into an `IoDelegate`, automatically wrapping
 			/// the parameters.
 			fn to_delegate(self) -> $crate::IoDelegate<Self, Self::Metadata>
-				where $($($generics: Send + Sync + 'static + $crate::Serialize + $crate::DeserializeOwned),*)*
+				where $(
+					$($simple_generics: Send + Sync + 'static + $crate::Serialize + $crate::DeserializeOwned ),*
+					$($generics: Send + Sync + 'static $( + $bounds $( + $morebounds )* )* ),*
+				)*
 			{
 				let mut del = $crate::IoDelegate::new(self.into());
 				$(


### PR DESCRIPTION
Implemented to maintain backward compatibility.
In the future we should just rewrite the macro #66 

Related https://github.com/paritytech/substrate/issues/1098