### PR TITLE
Optional metadata for unsubscribe.

### DIFF
--- a/macros/examples/pubsub-macros.rs
+++ b/macros/examples/pubsub-macros.rs
@@ -29,7 +29,7 @@ build_rpc_trait! {
 
 			/// Unsubscribe from hello subscription.
 			#[rpc(name = "hello_unsubscribe")]
-			fn unsubscribe(&self, Self::Metadata, SubscriptionId) -> Result<bool>;
+			fn unsubscribe(&self, Option<Self::Metadata>, SubscriptionId) -> Result<bool>;
 		}
 	}
 }
@@ -62,7 +62,7 @@ impl Rpc for RpcImpl {
 		self.active.write().unwrap().insert(sub_id, sink);
 	}
 
-	fn unsubscribe(&self, _meta: Self::Metadata, id: SubscriptionId) -> Result<bool> {
+	fn unsubscribe(&self, _meta: Option<Self::Metadata>, id: SubscriptionId) -> Result<bool> {
 		let removed = self.active.write().unwrap().remove(&id);
 		if removed.is_some() {
 			Ok(true)

--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -48,7 +48,7 @@ use util::{invalid_params, expect_no_params, to_value};
 ///	  #[rpc(name = "hello_subscribe")]
 ///	  fn subscribe(&self, Self::Metadata, pubsub::Subscriber<String>, u64);
 ///	  #[rpc(name = "hello_unsubscribe")]
-///	  fn unsubscribe(&self, Self::Metadata, SubscriptionId) -> Result<bool>;
+///	  fn unsubscribe(&self, Option<Self::Metadata>, SubscriptionId) -> Result<bool>;
 ///	}
 ///	```
 ///
@@ -257,7 +257,7 @@ macro_rules! build_rpc_trait {
 		subscribe: (name = $subscribe: expr $(, alias = [ $( $sub_alias: expr, )+ ])*)
 		fn $sub_method: ident (&self, Self::Metadata $(, $sub_p: ty)+);
 		unsubscribe: (name = $unsubscribe: expr $(, alias = [ $( $unsub_alias: expr, )+ ])*)
-		fn $unsub_method: ident (&self, Self::Metadata $(, $unsub_p: ty)+) -> $result: tt <$out: ty $(, $error_unsub: ty)* >;
+		fn $unsub_method: ident (&self, Option < Self::Metadata > $(, $unsub_p: ty)+) -> $result: tt <$out: ty $(, $error_unsub: ty)* >;
 	) => {
 		$del.add_subscription(
 			$name,

--- a/macros/src/delegates.rs
+++ b/macros/src/delegates.rs
@@ -86,14 +86,14 @@ struct DelegateUnsubscribe<T, F> {
 
 impl<M, T, F, I> jsonrpc_pubsub::UnsubscribeRpcMethod<M> for DelegateUnsubscribe<T, F> where
 	M: PubSubMetadata,
-	F: Fn(&T, SubscriptionId, M) -> I,
+	F: Fn(&T, SubscriptionId, Option<M>) -> I,
 	I: IntoFuture<Item = Value, Error = Error>,
 	T: Send + Sync + 'static,
 	F: Send + Sync + 'static,
 	I::Future: Send + 'static,
 {
 	type Out = I::Future;
-	fn call(&self, id: SubscriptionId, meta: M) -> Self::Out {
+	fn call(&self, id: SubscriptionId, meta: Option<M>) -> Self::Out {
 		let closure = &self.closure;
 		closure(&self.delegate, id, meta).into_future()
 	}
@@ -183,7 +183,7 @@ impl<T, M> IoDelegate<T, M> where
 	) where
 		Sub: Fn(&T, Params, M, Subscriber),
 		Sub: Send + Sync + 'static,
-		Unsub: Fn(&T, SubscriptionId, M) -> I,
+		Unsub: Fn(&T, SubscriptionId, Option<M>) -> I,
 		I: IntoFuture<Item = Value, Error = Error>,
 		Unsub: Send + Sync + 'static,
 		I::Future: Send + 'static,

--- a/macros/tests/pubsub-macros.rs
+++ b/macros/tests/pubsub-macros.rs
@@ -29,7 +29,7 @@ build_rpc_trait! {
 
 			/// Unsubscribe from hello subscription.
 			#[rpc(name = "hello_unsubscribe")]
-			fn unsubscribe(&self, Self::Metadata, SubscriptionId) -> Result<bool>;
+			fn unsubscribe(&self, Option<Self::Metadata>, SubscriptionId) -> Result<bool>;
 		}
 	}
 }
@@ -44,7 +44,7 @@ impl Rpc for RpcImpl {
 		let _sink = subscriber.assign_id(SubscriptionId::Number(5));
 	}
 
-	fn unsubscribe(&self, _meta: Self::Metadata, _id: SubscriptionId) -> Result<bool> {
+	fn unsubscribe(&self, _meta: Option<Self::Metadata>, _id: SubscriptionId) -> Result<bool> {
 		Ok(true)
 	}
 }

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -244,7 +244,7 @@ impl<M, F, G> core::RpcMethod<M> for Subscribe<F, G> where
 					transport: session.sender(),
 					sender: tx,
 				};
-				self.subscribe.call(params, meta.clone(), subscriber);
+				self.subscribe.call(params, meta, subscriber);
 
 				let unsub = self.unsubscribe.clone();
 				let notification = self.notification.clone();
@@ -254,7 +254,7 @@ impl<M, F, G> core::RpcMethod<M> for Subscribe<F, G> where
 						futures::done(match result {
 							Ok(id) => {
 								session.add_subscription(&notification, &id, move |id| {
-									let _ = unsub.call(id, meta.clone()).wait();
+									let _ = unsub.call(id, None).wait();
 								});
 								Ok(id.into())
 							},
@@ -288,7 +288,7 @@ impl<M, G> core::RpcMethod<M> for Unsubscribe<G> where
 		match (meta.session(), id) {
 			(Some(session), Some(id)) => {
 				session.remove_subscription(&self.notification, &id);
-				Box::new(self.unsubscribe.call(id, meta))
+				Box::new(self.unsubscribe.call(id, Some(meta)))
 			},
 			(Some(_), None) => Box::new(future::err(core::Error::invalid_params("Expected subscription id."))),
 			_ => Box::new(future::err(subscriptions_unavailable())),

--- a/pubsub/src/types.rs
+++ b/pubsub/src/types.rs
@@ -12,6 +12,10 @@ pub type TransportError = mpsc::SendError<String>;
 pub type SinkResult = core::futures::sink::Send<TransportSender>;
 
 /// Metadata extension for pub-sub method handling.
+///
+/// NOTE storing `PubSubMetadata` (or rather storing `Arc<Session>`) in
+/// any other place outside of the handler will prevent `unsubscribe` methods
+/// to be called in case the `Session` is dropped (i.e. transport connection is closed).
 pub trait PubSubMetadata: core::Metadata {
 	/// Returns session object associated with given request/client.
 	/// `None` indicates that sessions are not supported on the used transport.


### PR DESCRIPTION
A change in #344 caused an issue with unsubscribe whenever transport connection is closed (we had a test for this, but it was incorrect - fixed in this PR as well).

The assumption was that `Arc<Session>` (within `Metadata`) is held only by the underlying transport, so whenever the connection is closed `Metadata` is dropped.
By passing a clone of `Metadata` to the closure that is supposed to be called whenever `Session` is dropped I've caused a cyclic dependency, which in turn prevented the `Session` to be dropped at all.
This in turn prevents any `unsubscribe` handlers to be called on closed connection.

This PR changes the unsubscribe handler so that `Metadata` is only available when the method is explicitly called. In case of closed connection you get `None`.