### PR TITLE
Solve more issues with commas.

### DIFF
--- a/macros/examples/generic-trait-bounds.rs
+++ b/macros/examples/generic-trait-bounds.rs
@@ -9,10 +9,14 @@ use jsonrpc_core::futures::future::{self, FutureResult};
 
 // Two only requires DeserializeOwned
 build_rpc_trait! {
-	pub trait Rpc<One> where
+	pub trait Rpc<Zero, One> where
 		Two: DeserializeOwned,
 		Three: Serialize,
 	{
+		/// Get Zero type.
+		#[rpc(name = "getOne")]
+		fn zero(&self) -> Result<Zero>;
+
 		/// Get One type.
 		#[rpc(name = "getOne")]
 		fn one(&self) -> Result<One>;
@@ -41,11 +45,44 @@ build_rpc_trait! {
 	}
 }
 
+build_rpc_trait! {
+	pub trait Rpc3<Zero, One> where
+		Two: DeserializeOwned,
+		Three: Serialize,
+	{
+		type Metadata;
+
+		/// Get Zero type.
+		#[rpc(name = "getOne")]
+		fn zero(&self) -> Result<Zero>;
+
+		/// Get One type.
+		#[rpc(name = "getOne")]
+		fn one(&self) -> Result<One>;
+
+		/// Adds two numbers and returns a result
+		#[rpc(name = "setTwo")]
+		fn set_two(&self, Two) -> Result<()>;
+
+		/// Adds two numbers and returns a result
+		#[rpc(name = "getThree")]
+		fn three(&self) -> Result<Three>;
+
+		/// Performs asynchronous operation
+		#[rpc(name = "beFancy")]
+		fn call(&self, One) -> FutureResult<(One, u64), Error>;
+	}
+}
+
 struct RpcImpl;
 
-impl Rpc<u64, String, u32> for RpcImpl {
+impl Rpc<u8, u64, String, u32> for RpcImpl {
+	fn zero(&self) -> Result<u8> {
+		Ok(0)
+	}
+
 	fn one(&self) -> Result<u64> {
-		Ok(100)
+		Ok(1)
 	}
 
 	fn set_two(&self, x: String) -> Result<()> {
@@ -68,6 +105,30 @@ impl Rpc2<String> for RpcImpl {
 	}
 }
 
+impl Rpc3<u8, u64, String, u32> for RpcImpl {
+	type Metadata = ();
+
+	fn zero(&self) -> Result<u8> {
+		Ok(0)
+	}
+
+	fn one(&self) -> Result<u64> {
+		Ok(1)
+	}
+
+	fn set_two(&self, x: String) -> Result<()> {
+		println!("{}", x);
+		Ok(())
+	}
+
+	fn three(&self) -> Result<u32> {
+		Ok(3)
+	}
+
+	fn call(&self, num: u64) -> FutureResult<(u64, u64), Error> {
+		::future::finished((num + 999, num))
+	}
+}
 
 fn main() {
 	let mut io = IoHandler::new();

--- a/macros/examples/generic-trait-bounds.rs
+++ b/macros/examples/generic-trait-bounds.rs
@@ -14,7 +14,7 @@ build_rpc_trait! {
 		Three: Serialize,
 	{
 		/// Get Zero type.
-		#[rpc(name = "getOne")]
+		#[rpc(name = "getZero")]
 		fn zero(&self) -> Result<Zero>;
 
 		/// Get One type.
@@ -53,7 +53,7 @@ build_rpc_trait! {
 		type Metadata;
 
 		/// Get Zero type.
-		#[rpc(name = "getOne")]
+		#[rpc(name = "getZero")]
 		fn zero(&self) -> Result<Zero>;
 
 		/// Get One type.

--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -75,10 +75,11 @@ macro_rules! build_rpc_trait {
 	(
 		$(#[$t_attr: meta])*
 		pub trait $name:ident $(<$( $generics:ident ),*>
-		$(
-			where
-				$( $generics2:ident : $bounds:tt $( + $morebounds:tt )* ,)+
-		)* )*
+			$(
+				where
+					$( $generics2:ident : $bounds:tt $( + $morebounds:tt )* ,)+
+			)*
+		)*
 		{
 			$( $rest: tt )+
 		}
@@ -91,21 +92,19 @@ macro_rules! build_rpc_trait {
 				$( $generics ,)*
 				@BOUNDS
 				// then specialised ones
-				$( $( $generics2 : $bounds $( + $morebounds )* ),* )*
+				$( $( $generics2 : $bounds $( + $morebounds )* ,)* )*
 			> )* {
 				$( $rest )+
 			}
 		}
 	};
-
-	// entry-point. todo: make another for traits w/ bounds.
 	(
 		@WITH_BOUNDS
 		$(#[$t_attr: meta])*
 		pub trait $name:ident $(<
 			$( $simple_generics:ident ,)*
 			@BOUNDS
-			$( $generics:ident $(: $bounds:tt $( + $morebounds:tt )* )* ),*
+			$( $generics:ident : $bounds:tt $( + $morebounds:tt )* ,)*
 		>)* {
 			$(
 				$( #[doc=$m_doc:expr] )*
@@ -129,7 +128,7 @@ macro_rules! build_rpc_trait {
 			fn to_delegate<M: $crate::jsonrpc_core::Metadata>(self) -> $crate::IoDelegate<Self, M>
 				where $(
 					$($simple_generics: Send + Sync + 'static + $crate::Serialize + $crate::DeserializeOwned ,)*
-					$($generics: Send + Sync + 'static $( + $bounds $( + $morebounds )* )* ),*
+					$($generics: Send + Sync + 'static + $bounds $( + $morebounds )* ,)*
 				)*
 			{
 				let mut del = $crate::IoDelegate::new(self.into());
@@ -151,7 +150,7 @@ macro_rules! build_rpc_trait {
 		pub trait $name: ident $(<
 			$( $simple_generics:ident ,)*
 			@BOUNDS
-			$($generics:ident $( : $bounds:tt $( + $morebounds:tt )* )* ),*
+			$( $generics:ident : $bounds:tt $( + $morebounds:tt )* ,)*
 		>)* {
 			type Metadata;
 
@@ -201,8 +200,8 @@ macro_rules! build_rpc_trait {
 			/// the parameters.
 			fn to_delegate(self) -> $crate::IoDelegate<Self, Self::Metadata>
 				where $(
-					$($simple_generics: Send + Sync + 'static + $crate::Serialize + $crate::DeserializeOwned ),*
-					$($generics: Send + Sync + 'static $( + $bounds $( + $morebounds )* )* ),*
+					$($simple_generics: Send + Sync + 'static + $crate::Serialize + $crate::DeserializeOwned ,)*
+					$($generics: Send + Sync + 'static + $bounds $( + $morebounds )* , )*
 				)*
 			{
 				let mut del = $crate::IoDelegate::new(self.into());


### PR DESCRIPTION
Follow up on #355 there was even more commas misplaced.
Now we don't require trailing commas only in the initial parsing (before adding `@*` tokens) - after that the commas are required after every element.

I've added a test case with Metadata as well, cause it's parsed separately.