### PR TITLE
Support multiple trailing arguments

### DIFF
--- a/derive/tests/compiletests.rs
+++ b/derive/tests/compiletests.rs
@@ -7,7 +7,7 @@ fn run_mode(mode: &'static str) {
 
 	config.mode = mode.parse().expect("Invalid mode");
 	config.src_base = PathBuf::from(format!("tests/{}", mode));
-	config.link_deps(); // Populate config.target_rustcflags with dependencies on the path
+	config.target_rustcflags = Some("-L ../target/debug/ -L ../target/debug/deps/".to_owned());
 	config.clean_rmeta(); // If your tests import the parent crate, this helps with E0464
 
 	compiletest::run_tests(&config);

--- a/derive/tests/trailing.rs
+++ b/derive/tests/trailing.rs
@@ -11,6 +11,10 @@ pub trait Rpc {
 	/// Echos back the message, example of a single param trailing
 	#[rpc(name = "echo")]
 	fn echo(&self, _: Option<String>) -> Result<String>;
+
+	/// Adds up to three numbers and returns a result
+	#[rpc(name = "add_multi")]
+	fn add_multi(&self, _: Option<u64>, _: Option<u64>, _: Option<u64>) -> Result<u64>;
 }
 
 #[derive(Default)]
@@ -23,6 +27,10 @@ impl Rpc for RpcImpl {
 
 	fn echo(&self, x: Option<String>) -> Result<String> {
 		Ok(x.unwrap_or("".into()))
+	}
+
+	fn add_multi(&self, a: Option<u64>, b: Option<u64>, c: Option<u64>) -> Result<u64> {
+		Ok(a.unwrap_or_default() + b.unwrap_or_default() + c.unwrap_or_default())
 	}
 }
 
@@ -89,6 +97,53 @@ fn should_accept_single_trailing_param() {
 	assert_eq!(result2, serde_json::from_str(r#"{
 		"jsonrpc": "2.0",
 		"result": "",
+		"id": 1
+	}"#).unwrap());
+}
+
+#[test]
+fn should_accept_multiple_trailing_params() {
+	let mut io = IoHandler::new();
+	let rpc = RpcImpl::default();
+	io.extend_with(rpc.to_delegate());
+
+	// when
+	let req1 = r#"{"jsonrpc":"2.0","id":1,"method":"add_multi","params":[]}"#;
+	let req2 = r#"{"jsonrpc":"2.0","id":1,"method":"add_multi","params":[1]}"#;
+	let req3 = r#"{"jsonrpc":"2.0","id":1,"method":"add_multi","params":[1, 2]}"#;
+	let req4 = r#"{"jsonrpc":"2.0","id":1,"method":"add_multi","params":[1, 2, 3]}"#;
+
+	let res1 = io.handle_request_sync(req1);
+	let res2 = io.handle_request_sync(req2);
+	let res3 = io.handle_request_sync(req3);
+	let res4 = io.handle_request_sync(req4);
+
+	// then
+	let result1: Response = serde_json::from_str(&res1.unwrap()).unwrap();
+	assert_eq!(result1, serde_json::from_str(r#"{
+		"jsonrpc": "2.0",
+		"result": 0,
+		"id": 1
+	}"#).unwrap());
+
+	let result2: Response = serde_json::from_str(&res2.unwrap()).unwrap();
+	assert_eq!(result2, serde_json::from_str(r#"{
+		"jsonrpc": "2.0",
+		"result": 1,
+		"id": 1
+	}"#).unwrap());
+
+	let result3: Response = serde_json::from_str(&res3.unwrap()).unwrap();
+	assert_eq!(result3, serde_json::from_str(r#"{
+		"jsonrpc": "2.0",
+		"result": 3,
+		"id": 1
+	}"#).unwrap());
+
+	let result4: Response = serde_json::from_str(&res4.unwrap()).unwrap();
+	assert_eq!(result4, serde_json::from_str(r#"{
+		"jsonrpc": "2.0",
+		"result": 6,
 		"id": 1
 	}"#).unwrap());
 }


### PR DESCRIPTION
The rules are exactly as in C++: if you need to pass value of some optional argument, you must also pass values for all previous optional arguments. So there's no ambiguities with that.

This PR supersedes the `pzec_dependency_multiple_trailing_args` branch, but please do not delete it - we'll need to update parity-zcash once/if this PR is merged. I'll delete it by myself later.