### PR TITLE
derive: don't require pubsub dependency if no pubsub methods

### DIFF
--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -149,7 +149,7 @@ fn rpc_wrapper_mod_name(rpc_trait: &syn::ItemTrait) -> syn::Ident {
 pub fn rpc_impl(input: syn::Item) -> Result<proc_macro2::TokenStream> {
 	let rpc_trait = match input {
 		syn::Item::Trait(item_trait) => item_trait,
-		item @ _ => return Err(syn::Error::new_spanned(item, "rpc_api trait only works with trait declarations")),
+		item @ _ => return Err(syn::Error::new_spanned(item, "The #[rpc] custom attribute only works with trait declarations")),
 	};
 
 	let rpc_trait = generate_rpc_item_trait(&rpc_trait)?;

--- a/derive/tests/run-pass/pubsub-dependency-not-required-for-vanilla-rpc.rs
+++ b/derive/tests/run-pass/pubsub-dependency-not-required-for-vanilla-rpc.rs
@@ -1,0 +1,36 @@
+extern crate serde;
+extern crate jsonrpc_core;
+#[macro_use]
+extern crate jsonrpc_derive;
+
+use jsonrpc_core::{Result, IoHandler};
+
+#[rpc]
+pub trait Rpc {
+	/// Returns a protocol version
+	#[rpc(name = "protocolVersion")]
+	fn protocol_version(&self) -> Result<String>;
+
+	/// Adds two numbers and returns a result
+	#[rpc(name = "add", alias("callAsyncMetaAlias"))]
+	fn add(&self, _: u64, _: u64) -> Result<u64>;
+}
+
+struct RpcImpl;
+
+impl Rpc for RpcImpl {
+	fn protocol_version(&self) -> Result<String> {
+		Ok("version1".into())
+	}
+
+	fn add(&self, a: u64, b: u64) -> Result<u64> {
+		Ok(a + b)
+	}
+}
+
+fn main() {
+	let mut io = IoHandler::new();
+	let rpc = RpcImpl;
+
+	io.extend_with(rpc.to_delegate())
+}


### PR DESCRIPTION
Fixes #369 