### PR TITLE
derive: use proc_macro_crate to handle import renames

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro = true
 syn = { version = "^0.15.22", features = ["full", "extra-traits", "visit", "fold"] }
 proc-macro2 = "0.4"
 quote = "0.6"
+proc-macro-crate = "0.1.3"
 
 [dev-dependencies]
 jsonrpc-core = { version = "10.1", path = "../core" }


### PR DESCRIPTION
Use @bkchr's [proc-macro-crate](https://crates.io/crates/proc-macro-crate) to handle when the user renames one of the crates imported by `derive`.