### PR TITLE
Fix other clippy warning

### DIFF
--- a/core/src/delegates.rs
+++ b/core/src/delegates.rs
@@ -79,7 +79,7 @@ impl<T, M> IoDelegate<T, M> where
 	/// Creates new `IoDelegate`
 	pub fn new(delegate: Arc<T>) -> Self {
 		IoDelegate {
-			delegate: delegate,
+			delegate,
 			methods: HashMap::new(),
 		}
 	}

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -64,8 +64,8 @@ impl Default for Compatibility {
 }
 
 impl Compatibility {
-	fn is_version_valid(&self, version: Option<Version>) -> bool {
-		match (*self, version) {
+	fn is_version_valid(self, version: Option<Version>) -> bool {
+		match (self, version) {
 			(Compatibility::V1, None) |
 			(Compatibility::V2, Some(Version::V2)) |
 			(Compatibility::Both, _) => true,
@@ -73,8 +73,8 @@ impl Compatibility {
 		}
 	}
 
-	fn default_version(&self) -> Option<Version> {
-		match *self {
+	fn default_version(self) -> Option<Version> {
+		match self {
 			Compatibility::V1 => None,
 			Compatibility::V2 | Compatibility::Both => Some(Version::V2),
 		}

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -101,7 +101,7 @@ impl<T: Metadata> MetaIoHandler<T> {
 	/// Creates new `MetaIoHandler` compatible with specified protocol version.
 	pub fn with_compatibility(compatibility: Compatibility) -> Self {
 		MetaIoHandler {
-			compatibility: compatibility,
+			compatibility,
 			middleware: Default::default(),
 			methods: Default::default(),
 		}
@@ -113,8 +113,8 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 	/// Creates new `MetaIoHandler`
 	pub fn new(compatibility: Compatibility, middleware: S) -> Self {
 		MetaIoHandler {
-			compatibility: compatibility,
-			middleware: middleware,
+			compatibility,
+			middleware,
 			methods: Default::default(),
 		}
 	}
@@ -123,7 +123,7 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 	pub fn with_middleware(middleware: S) -> Self {
 		MetaIoHandler {
 			compatibility: Default::default(),
-			middleware: middleware,
+			middleware,
 			methods: Default::default(),
 		}
 	}

--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -94,7 +94,7 @@ impl Error {
 	pub fn new(code: ErrorCode) -> Self {
 		Error {
 			message: code.description(),
-			code: code,
+			code,
 			data: None
 		}
 	}

--- a/core/src/types/response.rs
+++ b/core/src/types/response.rs
@@ -41,14 +41,14 @@ impl Output {
 	pub fn from(result: CoreResult<Value>, id: Id, jsonrpc: Option<Version>) -> Self {
 		match result {
 			Ok(result) => Output::Success(Success {
-				id: id,
-				jsonrpc: jsonrpc,
-				result: result,
+				id,
+				jsonrpc,
+				result,
 			}),
 			Err(error) => Output::Failure(Failure {
-				id: id,
-				jsonrpc: jsonrpc,
-				error: error,
+				id,
+				jsonrpc,
+				error,
 			}),
 		}
 	}
@@ -56,8 +56,8 @@ impl Output {
 	/// Creates new failure output indicating malformed request.
 	pub fn invalid_request(id: Id, jsonrpc: Option<Version>) -> Self {
 		Output::Failure(Failure {
-			id: id,
-			jsonrpc: jsonrpc,
+			id,
+			jsonrpc,
 			error: Error::new(ErrorCode::InvalidRequest),
 		})
 	}
@@ -104,8 +104,8 @@ impl Response {
 	pub fn from(error: Error, jsonrpc: Option<Version>) -> Self {
 		Failure {
 			id: Id::Null,
-			jsonrpc: jsonrpc,
-			error: error,
+			jsonrpc,
+			error,
 		}.into()
 	}
 }

--- a/core/src/types/version.rs
+++ b/core/src/types/version.rs
@@ -14,8 +14,8 @@ pub enum Version {
 impl Serialize for Version {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where S: Serializer {
-		match self {
-			&Version::V2 => serializer.serialize_str("2.0")
+		match *self {
+			Version::V2 => serializer.serialize_str("2.0")
 		}
 	}
 }

--- a/derive/src/rpc_attr.rs
+++ b/derive/src/rpc_attr.rs
@@ -73,7 +73,7 @@ impl RpcMethodAttribute {
 									.map_or(Vec::new(), |ml| get_aliases(ml));
 								Ok(RpcMethodAttribute {
 									attr: attr.clone(),
-									name: name,
+									name,
 									aliases,
 									kind
 								})

--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -273,7 +273,7 @@ impl RpcMethod {
 		let total_args_num = param_types.len();
 		let required_args_num = total_args_num - trailing_args_num;
 
-		let switch_branches = (0..trailing_args_num+1)
+		let switch_branches = (0..=trailing_args_num)
 			.map(|passed_trailing_args_num| {
 				let passed_args_num = required_args_num + passed_trailing_args_num;
 				let passed_param_types = &param_types[..passed_args_num];

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -321,7 +321,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 
 	/// Configure the CORS `AccessControlAllowHeaders` header which are allowed.
 	pub fn cors_allow_headers(mut self, allowed_headers: cors::AccessControlAllowHeaders) -> Self {
-		self.allowed_headers = allowed_headers.into();
+		self.allowed_headers = allowed_headers;
 		self
 	}
 
@@ -583,8 +583,8 @@ impl Server {
 
 impl Drop for Server {
 	fn drop(&mut self) {
-		self.executor.take().map(|executors| {
+		if let Some(executors) = self.executor.take() {
 			for executor in executors { executor.close(); }
-		});
+		};
 	}
 }

--- a/http/src/response.rs
+++ b/http/src/response.rs
@@ -42,7 +42,7 @@ impl Response {
 		Response {
 			code: StatusCode::SERVICE_UNAVAILABLE,
 			content_type: HeaderValue::from_static("application/json; charset=utf-8"),
-			content: format!("{}", msg.into()),
+			content: msg.into(),
 		}
 	}
 

--- a/http/src/tests.rs
+++ b/http/src/tests.rs
@@ -113,9 +113,9 @@ fn request(server: Server, request: &str) -> Response {
 	let body = read_block(&mut lines);
 
 	Response {
-		status: status,
-		headers: headers,
-		body: body,
+		status,
+		headers,
+		body,
 	}
 }
 

--- a/http/src/utils.rs
+++ b/http/src/utils.rs
@@ -23,7 +23,7 @@ pub fn cors_allow_origin(
 	cors::get_cors_allow_origin(read_header(request, "origin"), read_header(request, "host"), cors_domains).map(|origin| {
 		use self::cors::AccessControlAllowOrigin::*;
 		match origin {
-			Value(ref val) => header::HeaderValue::from_str(val).unwrap_or(header::HeaderValue::from_static("null")),
+			Value(ref val) => header::HeaderValue::from_str(val).unwrap_or_else(|_| header::HeaderValue::from_static("null")),
 			Null => header::HeaderValue::from_static("null"),
 			Any => header::HeaderValue::from_static("*"),
 		}
@@ -42,12 +42,12 @@ pub fn cors_allow_headers(
 		.iter()
 		.filter_map(|val| val.to_str().ok())
 		.flat_map(|val| val.split(", "))
-		.flat_map(|val| val.split(","));
+		.flat_map(|val| val.split(','));
 
 	cors::get_cors_allow_headers(
 		headers,
 		requested_headers,
-		cors_allow_headers.into(),
+		cors_allow_headers,
 		|name| header::HeaderValue::from_str(name)
 			.unwrap_or_else(|_| header::HeaderValue::from_static("unknown"))
 	)

--- a/ipc/src/server.rs
+++ b/ipc/src/server.rs
@@ -29,7 +29,7 @@ pub struct Service<M: Metadata = (), S: Middleware<M> = middleware::Noop> {
 impl<M: Metadata, S: Middleware<M>> Service<M, S> {
 	/// Create new IPC server session with given handler and metadata.
 	pub fn new(handler: Arc<MetaIoHandler<M, S>>, meta: M) -> Self {
-		Service { handler: handler, meta: meta }
+		Service { handler, meta }
 	}
 }
 

--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -515,13 +515,11 @@ fn require_len(params: &Params, required: usize) -> Result<usize> {
 
 fn parse_trailing_param<T: DeserializeOwned>(params: Params) -> Result<(Option<T>, )> {
 	let len = try!(params_len(&params));
-	let id = match len {
+	match len {
 		0 => Ok((None,)),
 		1 => params.parse::<(T,)>().map(|(x, )| (Some(x), )),
 		_ => Err(invalid_params("Expecting only one optional parameter.", "")),
-	};
-
-	id
+	}
 }
 
 // special impl for no parameters other than block parameter.

--- a/macros/src/delegates.rs
+++ b/macros/src/delegates.rs
@@ -115,7 +115,7 @@ impl<T, M> IoDelegate<T, M> where
 	/// Creates new `IoDelegate`
 	pub fn new(delegate: Arc<T>) -> Self {
 		IoDelegate {
-			delegate: delegate,
+			delegate,
 			methods: HashMap::new(),
 		}
 	}

--- a/macros/src/pubsub.rs
+++ b/macros/src/pubsub.rs
@@ -22,7 +22,7 @@ impl<T, E> Subscriber<T, E> {
 	/// Wrap non-typed subscriber.
 	pub fn new(subscriber: pubsub::Subscriber) -> Self {
 		Subscriber {
-			subscriber: subscriber,
+			subscriber,
 			_data: PhantomData,
 		}
 	}
@@ -48,8 +48,8 @@ impl<T, E> Subscriber<T, E> {
 	pub fn assign_id(self, id: SubscriptionId) -> Result<Sink<T, E>, ()> {
 		let sink = self.subscriber.assign_id(id.clone())?;
 		Ok(Sink {
-			id: id,
-			sink: sink,
+			id,
+			sink,
 			buffered: None,
 			_data: PhantomData,
 		})

--- a/pubsub/src/handler.rs
+++ b/pubsub/src/handler.rs
@@ -57,7 +57,7 @@ impl<T: PubSubMetadata, S: core::Middleware<T>> PubSubHandler<T, S> {
 	/// Creates new `PubSubHandler`
 	pub fn new(handler: core::MetaIoHandler<T, S>) -> Self {
 		PubSubHandler {
-			handler: handler,
+			handler,
 		}
 	}
 

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -397,7 +397,7 @@ mod tests {
 		let (tx, mut rx) = oneshot::channel();
 		let subscriber = Subscriber {
 			notification: "test".into(),
-			transport: transport,
+			transport,
 			sender: tx,
 		};
 
@@ -419,7 +419,7 @@ mod tests {
 		let (tx, mut rx) = oneshot::channel();
 		let subscriber = Subscriber {
 			notification: "test".into(),
-			transport: transport,
+			transport,
 			sender: tx,
 		};
 		let error = core::Error {

--- a/pubsub/src/typed.rs
+++ b/pubsub/src/typed.rs
@@ -20,7 +20,7 @@ impl<T, E> Subscriber<T, E> {
 	/// Wrap non-typed subscriber.
 	pub fn new(subscriber: subscription::Subscriber) -> Self {
 		Subscriber {
-			subscriber: subscriber,
+			subscriber,
 			_data: PhantomData,
 		}
 	}
@@ -46,8 +46,8 @@ impl<T, E> Subscriber<T, E> {
 	pub fn assign_id(self, id: SubscriptionId) -> Result<Sink<T, E>, ()> {
 		let sink = self.subscriber.assign_id(id.clone())?;
 		Ok(Sink {
-			id: id,
-			sink: sink,
+			id,
+			sink,
 			buffered: None,
 			_data: PhantomData,
 		})

--- a/server-utils/src/cors.rs
+++ b/server-utils/src/cors.rs
@@ -239,7 +239,7 @@ pub fn get_cors_allow_headers<T: AsRef<str>, O, F: Fn(T) -> O>(
 		let are_all_allowed = headers
 			.all(|header| {
 				let name = &Ascii::new(header.as_ref());
-				only.iter().any(|h| &Ascii::new(&*h) == name) || ALWAYS_ALLOWED_HEADERS.contains(name)
+				only.iter().any(|h| Ascii::new(&*h) == name) || ALWAYS_ALLOWED_HEADERS.contains(name)
 			});
 
 		if !are_all_allowed {
@@ -259,7 +259,7 @@ pub fn get_cors_allow_headers<T: AsRef<str>, O, F: Fn(T) -> O>(
 				.filter(|header| {
 					let name = &Ascii::new(header.as_ref());
 					filtered = true;
-					only.iter().any(|h| &Ascii::new(&*h) == name) || ALWAYS_ALLOWED_HEADERS.contains(name)
+					only.iter().any(|h| Ascii::new(&*h) == name) || ALWAYS_ALLOWED_HEADERS.contains(name)
 				})
 				.map(to_result)
 				.collect();

--- a/server-utils/src/cors.rs
+++ b/server-utils/src/cors.rs
@@ -39,10 +39,10 @@ impl Origin {
 		let matcher = Matcher::new(&string);
 
 		Origin {
-			protocol: protocol,
-			host: host,
+			protocol,
+			host,
 			as_string: string,
-			matcher: matcher,
+			matcher,
 		}
 	}
 

--- a/server-utils/src/hosts.rs
+++ b/server-utils/src/hosts.rs
@@ -71,7 +71,7 @@ impl Host {
 		let host = hostname.next().expect(SPLIT_PROOF);
 		let port = match hostname.next() {
 			None => Port::None,
-			Some(port) => match port.clone().parse::<u16>().ok() {
+			Some(port) => match port.parse::<u16>().ok() {
 				Some(num) => Port::Fixed(num),
 				None => Port::Pattern(port.into()),
 			}

--- a/server-utils/src/hosts.rs
+++ b/server-utils/src/hosts.rs
@@ -56,10 +56,10 @@ impl Host {
 		let matcher = Matcher::new(&string);
 
 		Host {
-			hostname: hostname,
-			port: port,
+			hostname,
+			port,
 			as_string: string,
-			matcher: matcher,
+			matcher,
 		}
 	}
 

--- a/server-utils/src/stream_codec.rs
+++ b/server-utils/src/stream_codec.rs
@@ -35,8 +35,8 @@ impl StreamCodec {
 	/// New custom stream codec
 	pub fn new(incoming_separator: Separator, outgoing_separator: Separator) -> Self {
 		StreamCodec {
-			incoming_separator: incoming_separator,
-			outgoing_separator: outgoing_separator,
+			incoming_separator,
+			outgoing_separator,
 		}
 	}
 }

--- a/tcp/src/dispatch.rs
+++ b/tcp/src/dispatch.rs
@@ -66,11 +66,11 @@ impl Dispatcher {
 		match channels.get_mut(peer_addr) {
 			Some(channel) => {
 				// todo: maybe async here later?
-				channel.send(msg).wait().map_err(|e| PushMessageError::from(e))?;
+				channel.send(msg).wait().map_err(PushMessageError::from)?;
 				Ok(())
 			},
 			None => {
-				return Err(PushMessageError::NoSuchPeer);
+				Err(PushMessageError::NoSuchPeer)
 			}
 		}
 	}

--- a/tcp/src/dispatch.rs
+++ b/tcp/src/dispatch.rs
@@ -24,7 +24,7 @@ impl<S: Stream> PeerMessageQueue<S> {
 	) -> Self {
 		PeerMessageQueue {
 			up: response_stream,
-			receiver: receiver,
+			receiver,
 			_addr: addr,
 		}
 	}
@@ -55,7 +55,7 @@ impl Dispatcher {
 	/// Creates a new dispatcher
 	pub fn new(channels: Arc<SenderChannels>) -> Self {
 		Dispatcher {
-			channels: channels,
+			channels,
 		}
 	}
 

--- a/tcp/src/server.rs
+++ b/tcp/src/server.rs
@@ -128,12 +128,12 @@ impl<M: Metadata, S: Middleware<M> + 'static> ServerBuilder<M, S> {
 
 					let peer_message_queue = {
 						let mut channels = channels.lock();
-						channels.insert(peer_addr.clone(), sender.clone());
+						channels.insert(peer_addr, sender.clone());
 
 						PeerMessageQueue::new(
 							responses,
 							receiver,
-							peer_addr.clone(),
+							peer_addr,
 						)
 					};
 
@@ -209,6 +209,6 @@ impl Server {
 impl Drop for Server {
 	fn drop(&mut self) {
 		let _ = self.stop.take().map(|sg| sg.send(()));
-		self.executor.take().map(|executor| executor.close());
+		if let Some(executor) = self.executor.take() { executor.close() }
 	}
 }

--- a/tcp/src/server.rs
+++ b/tcp/src/server.rs
@@ -95,7 +95,7 @@ impl<M: Metadata, S: Middleware<M> + 'static> ServerBuilder<M, S> {
 					let (sender, receiver) = mpsc::channel(65536);
 
 					let context = RequestContext {
-						peer_addr: peer_addr,
+						peer_addr,
 						sender: sender.clone(),
 					};
 

--- a/tcp/src/service.rs
+++ b/tcp/src/service.rs
@@ -13,7 +13,7 @@ pub struct Service<M: Metadata = (), S: Middleware<M> = middleware::Noop> {
 
 impl<M: Metadata, S: Middleware<M>> Service<M, S> {
 	pub fn new(peer_addr: SocketAddr, handler: Arc<MetaIoHandler<M, S>>, meta: M) -> Self {
-		Service { peer_addr: peer_addr, handler: handler, meta: meta }
+		Service { peer_addr, handler, meta }
 	}
 }
 

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -43,7 +43,7 @@
 //! }
 //! ```
 
-#[warn(missing_docs)]
+#![warn(missing_docs)]
 
 extern crate jsonrpc_core as rpc;
 use serde;
@@ -67,8 +67,11 @@ pub struct Rpc {
 	pub options: Options,
 }
 
+/// Encoding format.
 pub enum Encoding {
+	/// Encodes params using `serde::to_string`.
 	Compact,
+	/// Encodes params using `serde::to_string_pretty`.
 	Pretty,
 }
 

--- a/ws/src/metadata.rs
+++ b/ws/src/metadata.rs
@@ -20,8 +20,8 @@ impl Sender {
 	/// Creates a new `Sender`.
 	pub fn new(out: ws::Sender, active: Arc<atomic::AtomicBool>) -> Self {
 		Sender {
-			out: out,
-			active: active,
+			out,
+			active,
 		}
 	}
 

--- a/ws/src/server.rs
+++ b/ws/src/server.rs
@@ -148,6 +148,6 @@ impl CloseHandle {
 	/// Closes the `Server`.
 	pub fn close(self) {
 		let _ = self.broadcaster.shutdown();
-		self.executor.lock().unwrap().take().map(|executor| executor.close());
+		if let Some(executor) = self.executor.lock().unwrap().take() { executor.close() }
 	}
 }

--- a/ws/src/server.rs
+++ b/ws/src/server.rs
@@ -103,7 +103,7 @@ impl Server {
 			addr: local_addr,
 			handle: Some(handle),
 			executor: Arc::new(Mutex::new(Some(eloop))),
-			broadcaster: broadcaster,
+			broadcaster,
 		})
 	}
 }

--- a/ws/src/session.rs
+++ b/ws/src/session.rs
@@ -152,7 +152,7 @@ pub struct Session<M: core::Metadata, S: core::Middleware<M>> {
 impl<M: core::Metadata, S: core::Middleware<M>> Drop for Session<M, S> {
 	fn drop(&mut self) {
 		self.active.store(false, atomic::Ordering::SeqCst);
-		self.stats.as_ref().map(|stats| stats.close_session(self.context.session_id));
+		if let Some(stats) = self.stats.as_ref() { stats.close_session(self.context.session_id) }
 
 		// signal to all still-live tasks that the session has been dropped.
 		for (_index, task) in self.task_slab.lock().iter_mut() {
@@ -313,7 +313,7 @@ impl<M: core::Metadata, S: core::Middleware<M>> ws::Factory for Factory<M, S> {
 
 	fn connection_made(&mut self, sender: ws::Sender) -> Self::Handler {
 		self.session_id += 1;
-		self.stats.as_ref().map(|stats| stats.open_session(self.session_id));
+		if let Some(executor) = self.stats.as_ref() { executor.open_session(self.session_id) }
 		let active = Arc::new(atomic::AtomicBool::new(true));
 
 		Session {
@@ -367,7 +367,7 @@ fn forbidden(title: &str, message: &str) -> ws::Response {
 	let mut forbidden = ws::Response::new(403, "Forbidden", format!("{}\n{}\n", title, message).into_bytes());
 	{
 		let headers = forbidden.headers_mut();
-		headers.push(("Connection".to_owned(), "close".as_bytes().to_vec()));
+		headers.push(("Connection".to_owned(), b"close".to_vec()));
 	}
 	forbidden
 }

--- a/ws/src/session.rs
+++ b/ws/src/session.rs
@@ -109,7 +109,7 @@ impl LivenessPoll {
 			(index, rx)
 		};
 
-		LivenessPoll { task_slab: task_slab, slab_handle: index, rx: rx }
+		LivenessPoll { task_slab, slab_handle: index, rx }
 	}
 }
 
@@ -297,13 +297,13 @@ impl<M: core::Metadata, S: core::Middleware<M>> Factory<M, S> {
 	) -> Self {
 		Factory {
 			session_id: 0,
-			handler: handler,
-			meta_extractor: meta_extractor,
-			allowed_origins: allowed_origins,
-			allowed_hosts: allowed_hosts,
-			request_middleware: request_middleware,
-			stats: stats,
-			executor: executor,
+			handler,
+			meta_extractor,
+			allowed_origins,
+			allowed_hosts,
+			request_middleware,
+			stats,
+			executor,
 		}
 	}
 }

--- a/ws/src/tests.rs
+++ b/ws/src/tests.rs
@@ -28,9 +28,9 @@ impl Response {
 		let body = Self::read_block(&mut lines);
 
 		Response {
-			status: status,
+			status,
 			_headers: headers,
-			body: body,
+			body,
 		}
 	}
 


### PR DESCRIPTION
What is not fixed:
* methods called `to_*` usually take self by reference; consider choosing a less ambiguous name
* very complex type used. Consider factoring parts into `type` definitions
* large size difference between variants
* this function has too many arguments