### PR TITLE
ws: replace error-chain with vanilla Error impl

### DIFF
--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/paritytech/jsonrpc"
 version = "10.1.0"
 
 [dependencies]
-error-chain = "0.12"
 jsonrpc-core = { version = "10.1", path = "../core" }
 jsonrpc-server-utils = { version = "10.1", path = "../server-utils" }
 log = "0.4"

--- a/ws/src/error.rs
+++ b/ws/src/error.rs
@@ -1,28 +1,49 @@
 #![allow(missing_docs)]
 
-use std::io;
+use std::{io, error, fmt, result};
 
 use crate::ws;
 
-error_chain! {
-	foreign_links {
-		Io(io::Error);
-	}
+#[derive(Debug)]
+pub enum Error {
+	Io(io::Error),
+	WsError(ws::Error),
+	ConnectionClosed,
+}
 
-	errors {
-		/// Attempted action on closed connection.
-		ConnectionClosed {
-			description("connection is closed"),
-			display("Action on closed connection."),
+pub type Result<T> = result::Result<T, Error>;
+
+impl fmt::Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
+		match self {
+			Error::ConnectionClosed => write!(f, "Action on closed connection."),
+			Error::WsError(err) => write!(f, "WebSockets Error: {}", err),
+			Error::Io(err) => write!(f, "Io Error: {}", err),
 		}
+	}
+}
+
+impl error::Error for Error {
+	fn source(&self) -> Option<&(error::Error + 'static)> {
+		match self {
+			Error::Io(io) => Some(io),
+			Error::WsError(ws) => Some(ws),
+			Error::ConnectionClosed => None,
+		}
+	}
+}
+
+impl From<io::Error> for Error {
+	fn from(err: io::Error) -> Self {
+		Error::Io(err)
 	}
 }
 
 impl From<ws::Error> for Error {
 	fn from(err: ws::Error) -> Self {
 		match err.kind {
-			ws::ErrorKind::Io(e) => e.into(),
-			_ => Error::with_chain(err, "WebSockets Error"),
+			ws::ErrorKind::Io(err) => Error::Io(err),
+			_ => Error::WsError(err),
 		}
 	}
 }

--- a/ws/src/error.rs
+++ b/ws/src/error.rs
@@ -1,16 +1,19 @@
-#![allow(missing_docs)]
-
 use std::{io, error, fmt, result};
 
 use crate::ws;
 
+/// WebSockets Server Error
 #[derive(Debug)]
 pub enum Error {
+	/// Io Error
 	Io(io::Error),
+	/// WebSockets Error
 	WsError(ws::Error),
+	/// Connection Closed
 	ConnectionClosed,
 }
 
+/// WebSockets Server Result
 pub type Result<T> = result::Result<T, Error>;
 
 impl fmt::Display for Error {

--- a/ws/src/lib.rs
+++ b/ws/src/lib.rs
@@ -8,8 +8,6 @@ pub use ws;
 pub use jsonrpc_core;
 
 #[macro_use]
-extern crate error_chain;
-#[macro_use]
 extern crate log;
 
 mod error;
@@ -22,7 +20,7 @@ mod tests;
 
 use jsonrpc_core as core;
 
-pub use self::error::{Error, ErrorKind, Result};
+pub use self::error::{Error, Result};
 pub use self::metadata::{RequestContext, MetaExtractor, NoopExtractor};
 pub use self::session::{RequestMiddleware, MiddlewareAction};
 pub use self::server::{CloseHandle, Server};

--- a/ws/src/metadata.rs
+++ b/ws/src/metadata.rs
@@ -29,7 +29,7 @@ impl Sender {
 		if self.active.load(atomic::Ordering::SeqCst) {
 			Ok(())
 		} else {
-			bail!(error::ErrorKind::ConnectionClosed)
+			Err(error::Error::ConnectionClosed)
 		}
 	}
 

--- a/ws/src/session.rs
+++ b/ws/src/session.rs
@@ -254,7 +254,7 @@ impl<M: core::Metadata, S: core::Middleware<M>> ws::Handler for Session<M, S> {
 				if let Some(result) = response {
 					let res = out.send(result);
 					match res {
-						Err(error::Error(error::ErrorKind::ConnectionClosed, _)) => {
+						Err(error::Error::ConnectionClosed) => {
 							active_lock.store(false, atomic::Ordering::SeqCst);
 						},
 						Err(e) => {


### PR DESCRIPTION
Just did this quickly to see what it is like converting an `error-chain` to vanilla Error impl. (because of `Error::cause` being deprecated in Rust 1.33)

This is one option to consider for https://github.com/paritytech/parity-ethereum/issues/10302 and https://github.com/paritytech/substrate/issues/1547

