### PR TITLE
Update example in IPC README

### DIFF
--- a/ipc/README.md
+++ b/ipc/README.md
@@ -15,7 +15,9 @@ jsonrpc-ipc-server = "10.0"
 `main.rs`
 
 ```rust
-use jsonrpc_ipc_server::Server;
+extern crate jsonrpc_ipc_server;
+
+use jsonrpc_ipc_server::ServerBuilder;
 use jsonrpc_ipc_server::jsonrpc_core::*;
 
 fn main() {
@@ -24,8 +26,9 @@ fn main() {
 		Ok(Value::String("hello".into()))
 	});
 
-	let server = Server::new("/tmp/json-ipc-test.ipc", io).unwrap();
-	::std::thread::spawn(move || server.run());
+	let builder = ServerBuilder::new(io);
+	let server = builder.start("/tmp/json-ipc-test.ipc").expect("Couldn't open socket");
+	server.wait();
 }
 ```
 


### PR DESCRIPTION
This addresses #272 in which the example in the IPC README is out-of-date. The updated example is copy-pasted from @gnunicorn 's reply in the thread.