### PR TITLE
Implement client support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,8 +9,16 @@ trim_trailing_whitespace=true
 max_line_length=120
 insert_final_newline=true
 
-[.travis.yml]
+[{.travis.yml,appveyor.yml}]
 indent_style=space
 indent_size=2
 tab_width=8
 end_of_line=lf
+
+[*.stderr]
+indent_style=none
+indent_size=none
+end_of_line=none
+charset=none
+trim_trailing_whitespace=none
+insert_final_newline=none

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ members = [
 	"tcp",
 	"test",
 	"ws",
+	"ws/client",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
 	"core",
+	"client",
 	"http",
 	"ipc",
 	"derive",

--- a/_automate/publish.sh
+++ b/_automate/publish.sh
@@ -2,7 +2,7 @@
 
 set -exu
 
-ORDER=(core server-utils tcp ws http ipc stdio pubsub macros derive test)
+ORDER=(core client server-utils tcp ws http ipc stdio pubsub macros derive test)
 
 for crate in ${ORDER[@]}; do
 	cd $crate

--- a/_automate/publish.sh
+++ b/_automate/publish.sh
@@ -2,7 +2,7 @@
 
 set -exu
 
-ORDER=(core client server-utils tcp ws http ipc stdio pubsub macros derive test)
+ORDER=(core client server-utils tcp ws ws/client http ipc stdio pubsub macros derive test)
 
 for crate in ${ORDER[@]}; do
 	cd $crate

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Transport agnostic JSON-RPC 2.0 client implementation."
-documentation = "https://docs.rs/jsonrpc-core/"
+documentation = "https://docs.rs/jsonrpc-client/"
 edition = "2018"
 homepage = "https://github.com/paritytech/jsonrpc"
 keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1.0"
 
 [dev-dependencies]
 jsonrpc-derive = { version = "10.1", path = "../derive" }
+jsonrpc-client = { version = "10.1", path = "." }
 serde = "1.0"
 tokio = "0.1"
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+authors = ["Parity Technologies <admin@parity.io>"]
+description = "Transport agnostic JSON-RPC 2.0 client implementation."
+documentation = "https://docs.rs/jsonrpc-core/"
+edition = "2018"
+homepage = "https://github.com/paritytech/jsonrpc"
+keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
+license = "MIT"
+name = "jsonrpc-client"
+repository = "https://github.com/paritytech/jsonrpc"
+version = "10.1.0"
+
+categories = [
+	"asynchronous",
+	"network-programming",
+	"web-programming::http-client",
+	"web-programming::http-server",
+	"web-programming::websocket",
+]
+
+[dependencies]
+failure = "0.1"
+futures = "~0.1.6"
+jsonrpc-core = { version = "10.1", path = "../core" }
+log = "0.4"
+serde_json = "1.0"
+
+[dev-dependencies]
+jsonrpc-derive = { version = "10.1", path = "../derive" }
+serde = "1.0"
+tokio = "0.1"
+
+[badges]
+travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -58,7 +58,7 @@ impl Future for RpcFuture {
 	type Error = RpcError;
 
 	fn poll(&mut self) -> Result<Async<Self::Item>, Self::Error> {
-		// TODO should timeout
+		// TODO should timeout (#410)
 		match self.recv.poll() {
 			Ok(Async::Ready(Ok(value))) => Ok(Async::Ready(value)),
 			Ok(Async::Ready(Err(error))) => Err(RpcError::JsonRpcError(error)),

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,0 +1,328 @@
+//! JSON-RPC client implementation.
+#![deny(missing_docs)]
+
+use jsonrpc_core::{
+	Call, Error, Id, MethodCall, Output, Params,
+	Request, Response, Version,
+};
+use futures::prelude::*;
+use futures::sync::{mpsc, oneshot};
+use failure::{Fail, format_err};
+use log::debug;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::collections::VecDeque;
+
+/// The errors returned by the client.
+#[derive(Debug, Fail)]
+pub enum RpcError {
+	/// An error returned by the server.
+	#[fail(display = "Server returned rpc error {}", _0)]
+	JsonRpcError(Error),
+	/// Failure to parse server response.
+	#[fail(display = "Failed to parse server response")]
+	ParseError,
+	/// Request timed out.
+	#[fail(display = "Request timed out")]
+	Timeout,
+	/// The server returned a response with an unknown id.
+	#[fail(display = "Server returned a response with an unknown id")]
+	UnknownId,
+	/// Not rpc specific errors.
+	#[fail(display = "{}", _0)]
+	Other(failure::Error),
+}
+
+impl From<Error> for RpcError {
+	fn from(error: Error) -> Self {
+		RpcError::JsonRpcError(error)
+	}
+}
+
+/// The future retured by the client.
+pub struct RpcFuture {
+	recv: oneshot::Receiver<Result<Value, Error>>,
+}
+
+impl RpcFuture {
+	/// Creates a new `RpcFuture`.
+	pub fn new(recv: oneshot::Receiver<Result<Value, Error>>) -> Self {
+		RpcFuture {
+			recv
+		}
+	}
+}
+
+impl Future for RpcFuture {
+	type Item = Value;
+	type Error = RpcError;
+
+	fn poll(&mut self) -> Result<Async<Self::Item>, Self::Error> {
+		// TODO should timeout
+		match self.recv.poll() {
+			Ok(Async::Ready(Ok(value))) => Ok(Async::Ready(value)),
+			Ok(Async::Ready(Err(error))) => Err(RpcError::JsonRpcError(error)),
+			Ok(Async::NotReady) => Ok(Async::NotReady),
+			Err(error) => Err(RpcError::Other(error.into())),
+		}
+	}
+}
+
+/// A message sent to the `RpcClient`. This is public so that
+/// the derive crate can generate a client.
+pub struct RpcMessage {
+	/// The rpc method name.
+	pub method: String,
+	/// The rpc method parameters.
+	pub params: Params,
+	/// The oneshot channel to send the result of the rpc
+	/// call to.
+	pub sender: oneshot::Sender<Result<Value, Error>>,
+}
+
+/// A channel to a `RpcClient`.
+pub type RpcChannel = mpsc::Sender<RpcMessage>;
+
+/// The RpcClient handles sending and receiving asynchronous
+/// messages through an underlying transport.
+pub struct RpcClient<TSink, TStream> {
+	id: u64,
+	queue: HashMap<Id, oneshot::Sender<Result<Value, Error>>>,
+	sink: TSink,
+	stream: TStream,
+	channel: Option<mpsc::Receiver<RpcMessage>>,
+	outgoing: VecDeque<String>,
+}
+
+impl<TSink, TStream> RpcClient<TSink, TStream> {
+	/// Creates a new `RpcClient`.
+	pub fn new(
+		sink: TSink,
+		stream: TStream,
+		channel: mpsc::Receiver<RpcMessage>,
+	) -> Self {
+		RpcClient {
+			id: 0,
+			queue: HashMap::new(),
+			sink,
+			stream,
+			channel: Some(channel),
+			outgoing: VecDeque::new(),
+		}
+	}
+
+	fn next_id(&mut self) -> Id {
+		let id = self.id;
+		self.id = id + 1;
+		Id::Num(id)
+	}
+}
+
+impl<TSink, TStream> Future for RpcClient<TSink, TStream>
+where
+	TSink: Sink<SinkItem=String, SinkError=RpcError>,
+	TStream: Stream<Item=String, Error=RpcError>,
+{
+	type Item = ();
+	type Error = RpcError;
+
+	fn poll(&mut self) -> Result<Async<Self::Item>, Self::Error> {
+		// Handle requests from the client.
+		loop {
+			if self.channel.is_none() {
+				break;
+			}
+			let msg = match self.channel.as_mut().unwrap().poll() {
+				Ok(Async::Ready(Some(msg))) => msg,
+				Ok(Async::Ready(None)) => {
+					// When the channel is dropped we still need to finish
+					// outstanding requests.
+					self.channel.take();
+					break;
+				},
+				Ok(Async::NotReady) => break,
+				Err(()) => continue,
+			};
+			let id = self.next_id();
+			let request = Request::Single(Call::MethodCall(MethodCall {
+				jsonrpc: Some(Version::V2),
+				method: msg.method,
+				params: msg.params,
+				id: id.clone(),
+			}));
+			self.queue.insert(id, msg.sender);
+			let request_str = serde_json::to_string(&request)
+				.map_err(|error| RpcError::Other(error.into()))?;
+			self.outgoing.push_back(request_str);
+		}
+		// Handle outgoing rpc requests.
+		loop {
+			match self.outgoing.pop_front() {
+				Some(request) => {
+					match self.sink.start_send(request)? {
+						AsyncSink::Ready => {},
+						AsyncSink::NotReady(request) => {
+							self.outgoing.push_front(request);
+							break;
+						},
+					}
+				}
+				None => break,
+			}
+		}
+		let done_sending = match self.sink.poll_complete()? {
+			Async::Ready(()) => true,
+			Async::NotReady => false,
+		};
+		// Handle incoming rpc requests.
+		loop {
+			let response_str = match self.stream.poll() {
+				Ok(Async::Ready(Some(response_str))) => response_str,
+				Ok(Async::Ready(None)) => {
+					// The websocket connection was closed so the client
+					// can be shutdown. Reopening closed connections must
+					// be handled by the transport.
+					debug!("connection closed");
+					return Ok(Async::Ready(()))
+				},
+				Ok(Async::NotReady) => break,
+				Err(err) => Err(err)?,
+			};
+			let response = serde_json::from_str::<Response>(&response_str)
+				.map_err(|error| RpcError::Other(error.into()))?;
+			let outputs: Vec<Output> = match response {
+				Response::Single(output) => vec![output],
+				Response::Batch(outputs) => outputs,
+			};
+			for output in outputs {
+				let channel = self.queue.remove(output.id());
+				let value: Result<Value, Error> = output.into();
+				match channel {
+					Some(tx) => tx.send(value)
+						.map_err(|_| {
+							RpcError::Other(format_err!("oneshot channel closed"))
+						})?,
+					None => Err(RpcError::UnknownId)?,
+				};
+			}
+		}
+		if self.channel.is_none() && self.outgoing.is_empty() && self.queue.is_empty() && done_sending {
+			debug!("client finished");
+			Ok(Async::Ready(()))
+		} else {
+			Ok(Async::NotReady)
+		}
+	}
+}
+
+/// Utilities for testing.
+pub mod test {
+	use super::*;
+	use jsonrpc_core::{IoHandler, RemoteProcedure};
+
+	/// Implements a rpc client using an `IoHandler`.
+	pub struct FakeRpc {
+		handler: IoHandler,
+		queue: VecDeque<String>,
+	}
+
+	impl FakeRpc {
+		/// Creates a new `FakeRpc`.
+		pub fn new(handler: IoHandler) -> Self {
+			FakeRpc {
+				handler,
+				queue: VecDeque::new(),
+			}
+		}
+	}
+
+	impl Stream for FakeRpc {
+		type Item = String;
+		type Error = RpcError;
+
+		fn poll(&mut self) -> Result<Async<Option<Self::Item>>, Self::Error> {
+			match self.queue.pop_front() {
+				Some(response) => Ok(Async::Ready(Some(response))),
+				None => Ok(Async::NotReady),
+			}
+		}
+	}
+
+	impl Sink for FakeRpc {
+		type SinkItem = String;
+		type SinkError = RpcError;
+
+		fn start_send(
+			&mut self,
+			request: Self::SinkItem,
+		) -> Result<AsyncSink<Self::SinkItem>, Self::SinkError> {
+			match self.handler.handle_request_sync(&request) {
+				Some(response) => self.queue.push_back(response),
+				None => {},
+			};
+			Ok(AsyncSink::Ready)
+		}
+
+		fn poll_complete(&mut self) -> Result<Async<()>, Self::SinkError> {
+			Ok(Async::Ready(()))
+		}
+	}
+
+	/// Connects to a `IoHandler`.
+	pub fn connect<TClient, TServer>(
+		server: TServer,
+	) -> (TClient, impl Future<Item=(), Error=RpcError>)
+	where
+		TClient: From<RpcChannel>,
+		TServer: Into<HashMap<String, RemoteProcedure<()>>>,
+	{
+		let mut io = IoHandler::new();
+		io.extend_with(server);
+		let (sink, stream) = test::FakeRpc::new(io).split();
+		let (sender, receiver) = mpsc::channel(0);
+		let rpc_client = RpcClient::new(sink, stream, receiver);
+		let client = TClient::from(sender);
+		(client, rpc_client)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate as jsonrpc_client;
+	use super::*;
+	use jsonrpc_core::Result;
+	use jsonrpc_derive::rpc;
+
+	#[rpc]
+	pub trait Rpc {
+		#[rpc(name = "add")]
+		fn add(&self, a: u64, b: u64) -> Result<u64>;
+	}
+
+	struct RpcServer;
+
+	impl Rpc for RpcServer {
+		fn add(&self, a: u64, b: u64) -> Result<u64> {
+			Ok(a + b)
+		}
+	}
+
+	#[test]
+	fn test_client_terminates() {
+		let (client, rpc_client) =
+			test::connect::<gen_client::Client, _>(RpcServer.to_delegate());
+		let fut = client.clone().add(3, 4)
+			.and_then(move |res| {
+				client.add(res, 5)
+			})
+			.join(rpc_client)
+			.map(|(res, ())| {
+				assert_eq!(res, 12);
+			})
+			.map_err(|err| {
+				eprintln!("{:?}", err);
+				assert!(false);
+			});
+		tokio::run(fut);
+	}
+}

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -17,8 +17,8 @@ pub enum RpcError {
 	#[fail(display = "Server returned rpc error {}", _0)]
 	JsonRpcError(Error),
 	/// Failure to parse server response.
-	#[fail(display = "Failed to parse server response")]
-	ParseError,
+	#[fail(display = "Failed to parse server response as {}: {}", _0, _1)]
+	ParseError(String, failure::Error),
 	/// Request timed out.
 	#[fail(display = "Request timed out")]
 	Timeout,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -284,8 +284,8 @@ pub mod local {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use crate as jsonrpc_client;
+	use futures::prelude::*;
+	use jsonrpc_client::local;
 	use jsonrpc_core::{IoHandler, Result};
 	use jsonrpc_derive::rpc;
 

--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -157,3 +157,11 @@ impl Error {
 		}
 	}
 }
+
+impl std::fmt::Display for Error {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		write!(f, "{}: {}", self.code.description(), self.message)
+	}
+}
+
+impl std::error::Error for Error {}

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -23,6 +23,7 @@ jsonrpc-core = { version = "10.1", path = "../core" }
 jsonrpc-client = { version = "10.1", path = "../client" }
 jsonrpc-pubsub = { version = "10.1", path = "../pubsub" }
 jsonrpc-tcp-server = { version = "10.1", path = "../tcp" }
+log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -20,6 +20,7 @@ proc-macro-crate = "0.1.3"
 
 [dev-dependencies]
 jsonrpc-core = { version = "10.1", path = "../core" }
+jsonrpc-client = { version = "10.1", path = "../client" }
 jsonrpc-pubsub = { version = "10.1", path = "../pubsub" }
 jsonrpc-tcp-server = { version = "10.1", path = "../tcp" }
 serde = "1.0"

--- a/derive/examples/generic-trait-bounds.rs
+++ b/derive/examples/generic-trait-bounds.rs
@@ -15,14 +15,14 @@ pub trait Rpc<One, Two, Three> {
 
 	/// Adds two numbers and returns a result
 	#[rpc(name = "setTwo")]
-	fn set_two(&self, _: Two) -> Result<()>;
+	fn set_two(&self, a: Two) -> Result<()>;
 
 	#[rpc(name = "getThree")]
 	fn get_three(&self) -> Result<Three>;
 
 	/// Performs asynchronous operation
 	#[rpc(name = "beFancy")]
-	fn call(&self, _: One) -> FutureResult<(One, u64), Error>;
+	fn call(&self, a: One) -> FutureResult<(One, u64), Error>;
 }
 
 struct RpcImpl;

--- a/derive/examples/generic-trait-bounds.rs
+++ b/derive/examples/generic-trait-bounds.rs
@@ -7,7 +7,7 @@ use jsonrpc_derive::rpc;
 // One is both parameter and a result so requires both Serialize and DeserializeOwned
 // Two is only a parameter so only requires DeserializeOwned
 // Three is only a result so only requires Serialize
-#[rpc]
+#[rpc(server)]
 pub trait Rpc<One, Two, Three> {
 	/// Get One type.
 	#[rpc(name = "getOne")]

--- a/derive/examples/generic-trait.rs
+++ b/derive/examples/generic-trait.rs
@@ -12,11 +12,11 @@ pub trait Rpc<One, Two> {
 
 	/// Adds two numbers and returns a result
 	#[rpc(name = "setTwo")]
-	fn set_two(&self, _: Two) -> Result<()>;
+	fn set_two(&self, a: Two) -> Result<()>;
 
 	/// Performs asynchronous operation
 	#[rpc(name = "beFancy")]
-	fn call(&self, _: One) -> FutureResult<(One, Two), Error>;
+	fn call(&self, a: One) -> FutureResult<(One, Two), Error>;
 }
 
 struct RpcImpl;

--- a/derive/examples/meta-macros.rs
+++ b/derive/examples/meta-macros.rs
@@ -18,19 +18,19 @@ pub trait Rpc<One> {
 
 	/// Adds two numbers and returns a result
 	#[rpc(name = "add")]
-	fn add(&self, _: u64, _: u64) -> Result<u64>;
+	fn add(&self, a: u64, b: u64) -> Result<u64>;
 
 	/// Multiplies two numbers. Second number is optional.
 	#[rpc(name = "mul")]
-	fn mul(&self, _: u64, _: Option<u64>) -> Result<u64>;
+	fn mul(&self, a: u64, b: Option<u64>) -> Result<u64>;
 
 	/// Performs asynchronous operation
 	#[rpc(name = "callAsync")]
-	fn call(&self, _: u64) -> FutureResult<String, Error>;
+	fn call(&self, a: u64) -> FutureResult<String, Error>;
 
 	/// Performs asynchronous operation with meta
 	#[rpc(meta, name = "callAsyncMeta", alias("callAsyncMetaAlias"))]
-	fn call_meta(&self, _: Self::Metadata, _: BTreeMap<String, Value>) -> FutureResult<String, Error>;
+	fn call_meta(&self, a: Self::Metadata, b: BTreeMap<String, Value>) -> FutureResult<String, Error>;
 }
 
 struct RpcImpl;

--- a/derive/examples/std.rs
+++ b/derive/examples/std.rs
@@ -1,7 +1,10 @@
+//! A simple example
+#![deny(missing_docs)]
 use jsonrpc_core::futures::future::{self, FutureResult};
 use jsonrpc_core::{Error, IoHandler, Result};
 use jsonrpc_derive::rpc;
 
+/// Rpc trait
 #[rpc]
 pub trait Rpc {
 	/// Returns a protocol version
@@ -10,11 +13,11 @@ pub trait Rpc {
 
 	/// Adds two numbers and returns a result
 	#[rpc(name = "add", alias("callAsyncMetaAlias"))]
-	fn add(&self, _: u64, _: u64) -> Result<u64>;
+	fn add(&self, a: u64, b: u64) -> Result<u64>;
 
 	/// Performs asynchronous operation
 	#[rpc(name = "callAsync")]
-	fn call(&self, _: u64) -> FutureResult<String, Error>;
+	fn call(&self, a: u64) -> FutureResult<String, Error>;
 }
 
 struct RpcImpl;

--- a/derive/examples/std.rs
+++ b/derive/examples/std.rs
@@ -41,12 +41,9 @@ fn main() {
 	let mut io = IoHandler::new();
 	io.extend_with(RpcImpl.to_delegate());
 
-	{
+	let fut = {
 		let (client, server) = local::connect::<gen_client::Client, _, _>(io);
-		client.add(5, 6)
-			.map(|res| println!("5 + 6 = {}", res))
-			.join(server)
-	}
-		.wait()
-		.unwrap();
+		client.add(5, 6).map(|res| println!("5 + 6 = {}", res)).join(server)
+	};
+	fut.wait().unwrap();
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -124,7 +124,7 @@
 //! # fn main() {}
 //! ```
 
-#![recursion_limit = "128"]
+#![recursion_limit = "256"]
 #![warn(missing_docs)]
 
 extern crate proc_macro;
@@ -134,6 +134,7 @@ use syn::parse_macro_input;
 
 mod rpc_attr;
 mod rpc_trait;
+mod to_client;
 mod to_delegate;
 
 /// Apply `#[rpc]` to a trait, and a `to_delegate` method is generated which

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -15,10 +15,10 @@
 //! 	fn protocol_version(&self) -> Result<String>;
 //!
 //! 	#[rpc(name = "add")]
-//! 	fn add(&self, _: u64, _: u64) -> Result<u64>;
+//! 	fn add(&self, a: u64, b: u64) -> Result<u64>;
 //!
 //! 	#[rpc(name = "callAsync")]
-//! 	fn call(&self, _: u64) -> FutureResult<String, Error>;
+//! 	fn call(&self, a: u64) -> FutureResult<String, Error>;
 //! }
 //!
 //! struct RpcImpl;

--- a/derive/src/options.rs
+++ b/derive/src/options.rs
@@ -16,7 +16,7 @@ impl DeriveOptions {
 
 	pub fn try_from(tokens: TokenStream) -> Result<Self, syn::Error> {
 		if tokens.is_empty() {
-			return Ok(Self::new(true, true))
+			return Ok(Self::new(true, true));
 		}
 		let ident: syn::Ident = syn::parse::<syn::Ident>(tokens)?;
 		let options = {

--- a/derive/src/options.rs
+++ b/derive/src/options.rs
@@ -1,0 +1,37 @@
+use proc_macro::TokenStream;
+
+#[derive(Debug)]
+pub struct DeriveOptions {
+	pub enable_client: bool,
+	pub enable_server: bool,
+}
+
+impl DeriveOptions {
+	pub fn new(enable_client: bool, enable_server: bool) -> Self {
+		DeriveOptions {
+			enable_client,
+			enable_server,
+		}
+	}
+
+	pub fn try_from(tokens: TokenStream) -> Result<Self, syn::Error> {
+		if tokens.is_empty() {
+			return Ok(Self::new(true, true))
+		}
+		let ident: syn::Ident = syn::parse::<syn::Ident>(tokens)?;
+		let options = {
+			let ident = ident.to_string();
+			if ident == "client" {
+				Some(Self::new(true, false))
+			} else if ident == "server" {
+				Some(Self::new(false, true))
+			} else {
+				None
+			}
+		};
+		match options {
+			Some(options) => Ok(options),
+			None => Err(syn::Error::new(ident.span(), "Unknown attribute.")),
+		}
+	}
+}

--- a/derive/src/rpc_attr.rs
+++ b/derive/src/rpc_attr.rs
@@ -68,8 +68,7 @@ impl RpcMethodAttribute {
 					RPC_ATTR_NAME => {
 						let has_metadata =
 							get_meta_list(meta).map_or(false, |ml| has_meta_word(METADATA_META_WORD, ml));
-						let returns = get_meta_list(meta)
-							.map_or(None, |ml| get_name_value(RETURNS_META_WORD, ml));
+						let returns = get_meta_list(meta).map_or(None, |ml| get_name_value(RETURNS_META_WORD, ml));
 						Some(Ok(AttributeKind::Rpc { has_metadata, returns }))
 					}
 					PUB_SUB_ATTR_NAME => Some(Self::parse_pubsub(meta)),

--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -2,7 +2,7 @@ use crate::options::DeriveOptions;
 use crate::rpc_attr::{AttributeKind, PubSubMethodKind, RpcMethodAttribute};
 use crate::to_client::generate_client_module;
 use crate::to_delegate::{generate_trait_item_method, MethodRegistration, RpcMethod};
-use proc_macro2::Span;
+use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use std::collections::HashMap;
 use syn::{
@@ -56,7 +56,7 @@ impl<'a> Fold for RpcTrait {
 	}
 }
 
-fn generate_rpc_item_trait(item_trait: &syn::ItemTrait) -> Result<(syn::ItemTrait, proc_macro2::TokenStream, bool)> {
+fn compute_method_registrations(item_trait: &syn::ItemTrait) -> Result<(Vec<MethodRegistration>, Vec<RpcMethod>)> {
 	let methods_result: Result<Vec<_>> = item_trait
 		.items
 		.iter()
@@ -73,13 +73,6 @@ fn generate_rpc_item_trait(item_trait: &syn::ItemTrait) -> Result<(syn::ItemTrai
 		})
 		.collect();
 	let methods = methods_result?;
-	let has_pubsub_methods = methods.iter().any(RpcMethod::is_pubsub);
-	let mut rpc_trait = RpcTrait {
-		methods: methods.clone(),
-		has_pubsub_methods,
-		has_metadata: false,
-	};
-	let mut item_trait = fold::fold_item_trait(&mut rpc_trait, item_trait.clone());
 
 	let mut pubsub_method_pairs: HashMap<String, (Option<RpcMethod>, Option<RpcMethod>)> = HashMap::new();
 	let mut method_registrations: Vec<MethodRegistration> = Vec::new();
@@ -152,27 +145,65 @@ fn generate_rpc_item_trait(item_trait: &syn::ItemTrait) -> Result<(syn::ItemTrai
 		}
 	}
 
+	Ok((method_registrations, methods))
+}
+
+fn generate_server_module(
+	method_registrations: &[MethodRegistration],
+	item_trait: &syn::ItemTrait,
+	methods: &[RpcMethod],
+) -> Result<TokenStream> {
+	let has_pubsub_methods = methods.iter().any(RpcMethod::is_pubsub);
+
+	let mut rpc_trait = RpcTrait {
+		methods: methods.to_owned(),
+		has_pubsub_methods,
+		has_metadata: false,
+	};
+	let mut rpc_server_trait = fold::fold_item_trait(&mut rpc_trait, item_trait.clone());
+
 	let to_delegate_method = generate_trait_item_method(
 		&method_registrations,
-		&item_trait,
+		&rpc_server_trait,
 		rpc_trait.has_metadata,
 		has_pubsub_methods,
 	)?;
 
-	let rpc_client_module = generate_client_module(&method_registrations, &item_trait)?;
-
-	item_trait.items.push(syn::TraitItem::Method(to_delegate_method));
+	rpc_server_trait.items.push(syn::TraitItem::Method(to_delegate_method));
 
 	let trait_bounds: Punctuated<syn::TypeParamBound, Token![+]> = parse_quote!(Sized + Send + Sync + 'static);
-	item_trait.supertraits.extend(trait_bounds);
+	rpc_server_trait.supertraits.extend(trait_bounds);
 
-	Ok((item_trait, rpc_client_module, has_pubsub_methods))
+	let optional_pubsub_import = if has_pubsub_methods {
+		crate_name("jsonrpc-pubsub").map(|pubsub_name| quote!(use #pubsub_name as _jsonrpc_pubsub;))
+	} else {
+		Ok(quote!())
+	}?;
+
+	let rpc_server_module = quote! {
+		/// The generated server module.
+		pub mod gen_server {
+			#optional_pubsub_import
+			use self::_jsonrpc_core::futures as _futures;
+			use super::*;
+
+			#rpc_server_trait
+		}
+	};
+
+	Ok(rpc_server_module)
 }
 
 fn rpc_wrapper_mod_name(rpc_trait: &syn::ItemTrait) -> syn::Ident {
 	let name = rpc_trait.ident.clone();
 	let mod_name = format!("{}{}", RPC_MOD_NAME_PREFIX, name.to_string());
 	syn::Ident::new(&mod_name, proc_macro2::Span::call_site())
+}
+
+pub fn crate_name(name: &str) -> Result<Ident> {
+	proc_macro_crate::crate_name(name)
+		.map(|name| Ident::new(&name, Span::call_site()))
+		.map_err(|e| Error::new(Span::call_site(), &e))
 }
 
 pub fn rpc_impl(input: syn::Item, options: DeriveOptions) -> Result<proc_macro2::TokenStream> {
@@ -186,46 +217,25 @@ pub fn rpc_impl(input: syn::Item, options: DeriveOptions) -> Result<proc_macro2:
 		}
 	};
 
-	let (rpc_server_trait, rpc_client_module, has_pubsub_methods) = generate_rpc_item_trait(&rpc_trait)?;
+	let (method_registrations, methods) = compute_method_registrations(&rpc_trait)?;
 
 	let name = rpc_trait.ident.clone();
 	let mod_name_ident = rpc_wrapper_mod_name(&rpc_trait);
 
-	let crate_name = |name| {
-		proc_macro_crate::crate_name(name)
-			.map(|name| Ident::new(&name, Span::call_site()))
-			.map_err(|e| Error::new(Span::call_site(), &e))
-	};
-
-	let optional_pubsub_import = if has_pubsub_methods {
-		crate_name("jsonrpc-pubsub").map(|pubsub_name| quote!(use #pubsub_name as _jsonrpc_pubsub;))
-	} else {
-		Ok(quote!())
-	}?;
-
 	let core_name = crate_name("jsonrpc-core")?;
 	let serde_name = crate_name("serde")?;
-
-	let rpc_server_module = quote! {
-		/// The generated server module.
-		pub mod gen_server {
-			#optional_pubsub_import
-			use self::_jsonrpc_core::futures as _futures;
-			use super::*;
-
-			#rpc_server_trait
-		}
-	};
 
 	let mut submodules = Vec::new();
 	let mut exports = Vec::new();
 	if options.enable_client {
+		let rpc_client_module = generate_client_module(&method_registrations, &rpc_trait)?;
 		submodules.push(rpc_client_module);
 		exports.push(quote! {
 			pub use self::#mod_name_ident::gen_client;
 		});
 	}
 	if options.enable_server {
+		let rpc_server_module = generate_server_module(&method_registrations, &rpc_trait, &methods)?;
 		submodules.push(rpc_server_module);
 		exports.push(quote! {
 			pub use self::#mod_name_ident::gen_server::#name;

--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -84,7 +84,7 @@ fn generate_rpc_item_trait(item_trait: &syn::ItemTrait) -> Result<(syn::ItemTrai
 
 	for method in methods.iter() {
 		match &method.attr().kind {
-			AttributeKind::Rpc { has_metadata } => method_registrations.push(MethodRegistration::Standard {
+			AttributeKind::Rpc { has_metadata, .. } => method_registrations.push(MethodRegistration::Standard {
 				method: method.clone(),
 				has_metadata: *has_metadata,
 			}),

--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -175,10 +175,7 @@ fn rpc_wrapper_mod_name(rpc_trait: &syn::ItemTrait) -> syn::Ident {
 	syn::Ident::new(&mod_name, proc_macro2::Span::call_site())
 }
 
-pub fn rpc_impl(
-	input: syn::Item,
-	options: DeriveOptions,
-) -> Result<proc_macro2::TokenStream> {
+pub fn rpc_impl(input: syn::Item, options: DeriveOptions) -> Result<proc_macro2::TokenStream> {
 	let rpc_trait = match input {
 		syn::Item::Trait(item_trait) => item_trait,
 		item => {
@@ -189,8 +186,7 @@ pub fn rpc_impl(
 		}
 	};
 
-	let (rpc_server_trait, rpc_client_module, has_pubsub_methods) =
-		generate_rpc_item_trait(&rpc_trait)?;
+	let (rpc_server_trait, rpc_client_module, has_pubsub_methods) = generate_rpc_item_trait(&rpc_trait)?;
 
 	let name = rpc_trait.ident.clone();
 	let mod_name_ident = rpc_wrapper_mod_name(&rpc_trait);

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -1,4 +1,5 @@
 use crate::rpc_attr::AttributeKind;
+use crate::rpc_trait::crate_name;
 use crate::to_delegate::{generate_where_clause_serialization_predicates, MethodRegistration};
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
@@ -35,9 +36,11 @@ pub fn generate_client_module(methods: &[MethodRegistration], item_trait: &syn::
 			)
 		})
 		.unzip();
+	let client_name = crate_name("jsonrpc-client")?;
 	Ok(quote! {
 		/// The generated client module.
 		pub mod gen_client {
+			use #client_name as _jsonrpc_client;
 			use super::*;
 			use _jsonrpc_core::{
 				Call, Error, ErrorCode, Id, MethodCall, Params, Request,
@@ -46,7 +49,7 @@ pub fn generate_client_module(methods: &[MethodRegistration], item_trait: &syn::
 			use _jsonrpc_core::futures::{future, Future, Sink};
 			use _jsonrpc_core::futures::sync::oneshot;
 			use _jsonrpc_core::serde_json::{self, Value};
-			use jsonrpc_client::{RpcChannel, RpcError, RpcFuture, RpcMessage};
+			use _jsonrpc_client::{RpcChannel, RpcError, RpcFuture, RpcMessage};
 
 			/// The Client.
 			#[derive(Clone)]

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -1,0 +1,316 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
+use syn::Result;
+use syn::punctuated::Punctuated;
+use crate::rpc_attr::AttributeKind;
+use crate::to_delegate::{
+	generate_where_clause_serialization_predicates,
+	MethodRegistration,
+};
+
+pub fn generate_client_module(
+	methods: &[MethodRegistration],
+	item_trait: &syn::ItemTrait,
+) -> Result<TokenStream> {
+	let client_methods = generate_client_methods(methods)?;
+	let generics = &item_trait.generics;
+	let where_clause =
+		generate_where_clause_serialization_predicates(&item_trait, true);
+	let where_clause2 = where_clause.clone();
+	let markers = generics.params.iter()
+		.filter_map(|param| {
+			match param {
+				syn::GenericParam::Type(syn::TypeParam { ident, .. }) => Some(ident),
+				_ => None,
+			}
+		})
+		.enumerate()
+		.map(|(i, ty)| {
+			let field_name = "_".to_string() + &i.to_string();
+			let field = Ident::new(&field_name, ty.span());
+			(field, ty)
+		});
+	let (markers_decl, markers_impl): (Vec<_>, Vec<_>) = markers.map(|(field, ty)| {
+		(
+			quote! {
+				#field: std::marker::PhantomData<#ty>
+			},
+			quote! {
+				#field: std::marker::PhantomData
+			}
+		)
+	}).unzip();
+	Ok(quote! {
+		/// The generated client module.
+		pub mod gen_client {
+			use super::*;
+			use _jsonrpc_core::{
+				Call, Error, ErrorCode, Id, MethodCall, Params, Request,
+				Response, Version,
+			};
+			use _jsonrpc_core::futures::{future, Future, Sink};
+			use _jsonrpc_core::futures::sync::oneshot;
+			use _jsonrpc_core::serde_json::{self, Value};
+			use jsonrpc_client::{RpcChannel, RpcError, RpcFuture, RpcMessage};
+
+			/// The Client.
+			#[derive(Clone)]
+			pub struct Client#generics {
+				sender: RpcChannel,
+				#(#markers_decl),*
+			}
+
+			impl#generics Client#generics
+			where
+				#(#where_clause),*
+			{
+				/// Creates a new `Client`.
+				pub fn new(sender: RpcChannel) -> Self {
+					Client {
+						sender,
+						#(#markers_impl),*
+					}
+				}
+
+				#(#client_methods)*
+
+				fn call_method(
+					&self,
+					method: String,
+					params: Params,
+				) -> impl Future<Item=Value, Error=RpcError> {
+					let (sender, receiver) = oneshot::channel();
+					let msg = RpcMessage {
+						method,
+						params,
+						sender,
+					};
+					self.sender
+						.to_owned()
+						.send(msg)
+						.map_err(|error| RpcError::Other(error.into()))
+						.and_then(|_| RpcFuture::new(receiver))
+				}
+			}
+
+			impl#generics From<RpcChannel> for Client#generics
+			where
+				#(#where_clause2),*
+			{
+				fn from(channel: RpcChannel) -> Self {
+					Client::new(channel)
+				}
+			}
+		}
+	})
+}
+
+fn generate_client_methods(
+	methods: &[MethodRegistration],
+) -> Result<Vec<syn::ImplItem>> {
+	let mut client_methods = vec![];
+	for method in methods {
+		match method {
+			MethodRegistration::Standard { method, .. } => {
+				let attrs = get_doc_comments(&method.trait_item.attrs);
+				let rpc_name = method.name();
+				let name = &method.trait_item.sig.ident;
+				let args = compute_args(&method.trait_item);
+				let arg_names = compute_arg_identifiers(&args)?;
+				let returns = match &method.attr.kind {
+					AttributeKind::Rpc { returns, .. } => {
+						compute_returns(&method.trait_item, returns)?
+					},
+					AttributeKind::PubSub { .. } => {
+						continue;
+					},
+				};
+				let client_method = generate_client_method(
+					&attrs,
+					rpc_name,
+					name,
+					&args,
+					&arg_names,
+					&returns,
+				);
+				client_methods.push(client_method);
+			}
+			MethodRegistration::PubSub { .. } => {
+				println!("warning: pubsub methods are currently not supported in the generated client.")
+			}
+		}
+	}
+	Ok(client_methods)
+}
+
+fn generate_client_method(
+	attrs: &[syn::Attribute],
+	rpc_name: &str,
+	name: &syn::Ident,
+	args: &Punctuated<syn::FnArg, syn::token::Comma>,
+	arg_names: &[&syn::Ident],
+	returns: &syn::Type,
+) -> syn::ImplItem {
+	syn::parse_quote! {
+		#(#attrs)*
+		pub fn #name(&self, #args) -> impl Future<Item=#returns, Error=RpcError> {
+			let args_tuple = (#(#arg_names,)*);
+			let args = serde_json::to_value(args_tuple)
+				.expect("Only types with infallible serialisation can be used for JSON-RPC");
+			let method = #rpc_name.to_owned();
+			let params = match args {
+				Value::Array(vec) => Some(Params::Array(vec)),
+				Value::Null => Some(Params::None),
+				_ => None,
+			}.expect("should never happen");
+			self.call_method(method, params)
+				.and_then(|value: Value| {
+					let result = serde_json::from_value::<#returns>(value)
+						.map_err(|error| RpcError::Other(error.into()));
+					future::done(result)
+				})
+		}
+	}
+}
+
+fn get_doc_comments(attrs: &[syn::Attribute]) -> Vec<syn::Attribute> {
+	let mut doc_comments = vec![];
+	for attr in attrs {
+		match attr {
+			syn::Attribute {
+				path: syn::Path { segments, .. },
+				..
+			} => {
+				match &segments[0] {
+					syn::PathSegment { ident, .. } => {
+						if ident.to_string() == "doc" {
+							doc_comments.push(attr.to_owned());
+						}
+					}
+				}
+			}
+		}
+	}
+	doc_comments
+}
+
+fn compute_args(
+	method: &syn::TraitItemMethod,
+) -> Punctuated<syn::FnArg, syn::token::Comma> {
+	let mut args = Punctuated::new();
+	for arg in &method.sig.decl.inputs {
+		let ty = match arg {
+			syn::FnArg::Captured(syn::ArgCaptured { ty, .. }) => ty,
+			_ => continue,
+		};
+		let segments = match ty {
+			syn::Type::Path(syn::TypePath {
+				path: syn::Path { segments, .. },
+				..
+			}) => segments,
+			_ => continue,
+		};
+		let ident = match &segments[0] {
+			syn::PathSegment { ident, .. } => ident,
+		};
+		if ident.to_string() == "Self" {
+			continue;
+		}
+		args.push(arg.to_owned());
+	}
+	args
+}
+
+fn compute_arg_identifiers(
+	args: &Punctuated<syn::FnArg, syn::token::Comma>,
+) -> Result<Vec<&syn::Ident>> {
+	let mut arg_names = vec![];
+	for arg in args {
+		let pat = match arg {
+			syn::FnArg::Captured(syn::ArgCaptured { pat, .. }) => pat,
+			_ => continue,
+		};
+		let ident = match pat {
+			syn::Pat::Ident(syn::PatIdent { ident, .. }) => ident,
+			syn::Pat::Wild(wild) => {
+				let span = wild.underscore_token.spans[0];
+				let msg = "No wildcard patterns allowed in rpc trait.";
+				return Err(syn::Error::new(span, msg))
+			},
+			_ => continue,
+		};
+		arg_names.push(ident);
+	}
+	Ok(arg_names)
+}
+
+fn compute_returns(
+	method: &syn::TraitItemMethod,
+	returns: &Option<String>,
+) -> Result<syn::Type> {
+	let returns: Option<syn::Type> = match returns {
+		Some(returns) => Some(syn::parse_str(returns)?),
+		None => None,
+	};
+	let returns = match returns {
+		None => try_infer_returns(&method.sig.decl.output),
+		_ => returns,
+	};
+	let returns = match returns {
+		Some(returns) => returns,
+		None => {
+			let span = method.attrs[0].pound_token.spans[0];
+			let msg = "Missing returns attribute.";
+			return Err(syn::Error::new(span, msg))
+		}
+	};
+	Ok(returns)
+}
+
+fn try_infer_returns(output: &syn::ReturnType) -> Option<syn::Type> {
+	match output {
+		syn::ReturnType::Type(_, ty) => {
+			match &**ty {
+				syn::Type::Path(syn::TypePath {
+					path: syn::Path { segments, .. },
+					..
+				}) => {
+					match &segments[0] {
+						syn::PathSegment {
+							ident,
+							arguments,
+							..
+						} => {
+							if ident.to_string().ends_with("Result") {
+								get_first_type_argument(arguments)
+							} else {
+								None
+							}
+						}
+					}
+				}
+				_ => None,
+			}
+		}
+		_ => None,
+	}
+}
+
+fn get_first_type_argument(args: &syn::PathArguments) -> Option<syn::Type> {
+	match args {
+		syn::PathArguments::AngleBracketed(syn::AngleBracketedGenericArguments {
+			args,
+			..
+		}) => {
+			if args.len() > 0 {
+				match &args[0] {
+					syn::GenericArgument::Type(ty) => Some(ty.to_owned()),
+					_ => None,
+				}
+			} else {
+				None
+			}
+		}
+		_ => None
+	}
+}

--- a/derive/tests/macros.rs
+++ b/derive/tests/macros.rs
@@ -19,11 +19,11 @@ pub trait Rpc {
 
 	/// Negates number and returns a result
 	#[rpc(name = "neg")]
-	fn neg(&self, _: i64) -> Result<i64>;
+	fn neg(&self, a: i64) -> Result<i64>;
 
 	/// Adds two numbers and returns a result
 	#[rpc(name = "add", alias("add_alias1", "add_alias2"))]
-	fn add(&self, _: u64, _: u64) -> Result<u64>;
+	fn add(&self, a: u64, b: u64) -> Result<u64>;
 }
 
 #[derive(Default)]

--- a/derive/tests/pubsub-macros.rs
+++ b/derive/tests/pubsub-macros.rs
@@ -24,15 +24,15 @@ pub trait Rpc {
 
 	/// Hello subscription
 	#[pubsub(subscription = "hello", subscribe, name = "hello_subscribe", alias("hello_alias"))]
-	fn subscribe(&self, _: Self::Metadata, _: Subscriber<String>, _: u32, _: Option<u64>);
+	fn subscribe(&self, a: Self::Metadata, b: Subscriber<String>, c: u32, d: Option<u64>);
 
 	/// Unsubscribe from hello subscription.
 	#[pubsub(subscription = "hello", unsubscribe, name = "hello_unsubscribe")]
-	fn unsubscribe(&self, _: Option<Self::Metadata>, _: SubscriptionId) -> Result<bool>;
+	fn unsubscribe(&self, a: Option<Self::Metadata>, b: SubscriptionId) -> Result<bool>;
 
 	/// A regular rpc method alongside pubsub
 	#[rpc(name = "add")]
-	fn add(&self, _: u64, _: u64) -> Result<u64>;
+	fn add(&self, a: u64, b: u64) -> Result<u64>;
 }
 
 #[derive(Default)]

--- a/derive/tests/run-pass/client_only.rs
+++ b/derive/tests/run-pass/client_only.rs
@@ -1,0 +1,32 @@
+extern crate serde;
+extern crate jsonrpc_core;
+extern crate jsonrpc_client;
+#[macro_use]
+extern crate jsonrpc_derive;
+extern crate log;
+
+use jsonrpc_core::futures::future::Future;
+use jsonrpc_core::futures::sync::mpsc;
+
+#[rpc(client)]
+pub trait Rpc {
+	/// Returns a protocol version
+	#[rpc(name = "protocolVersion")]
+	fn protocol_version(&self) -> Result<String>;
+
+	/// Adds two numbers and returns a result
+	#[rpc(name = "add", alias("callAsyncMetaAlias"))]
+	fn add(&self, a: u64, b: u64) -> Result<u64>;
+}
+
+fn main() {
+	let fut = {
+		let (sender, _) = mpsc::channel(0);
+		gen_client::Client::new(sender)
+			.add(5, 6)
+			.map(|res| println!("5 + 6 = {}", res))
+	};
+	fut
+		.wait()
+		.ok();
+}

--- a/derive/tests/run-pass/pubsub-dependency-not-required-for-vanilla-rpc.rs
+++ b/derive/tests/run-pass/pubsub-dependency-not-required-for-vanilla-rpc.rs
@@ -1,5 +1,6 @@
 extern crate serde;
 extern crate jsonrpc_core;
+extern crate jsonrpc_client;
 #[macro_use]
 extern crate jsonrpc_derive;
 
@@ -13,7 +14,7 @@ pub trait Rpc {
 
 	/// Adds two numbers and returns a result
 	#[rpc(name = "add", alias("callAsyncMetaAlias"))]
-	fn add(&self, _: u64, _: u64) -> Result<u64>;
+	fn add(&self, a: u64, b: u64) -> Result<u64>;
 }
 
 struct RpcImpl;

--- a/derive/tests/run-pass/pubsub-dependency-not-required-for-vanilla-rpc.rs
+++ b/derive/tests/run-pass/pubsub-dependency-not-required-for-vanilla-rpc.rs
@@ -3,6 +3,7 @@ extern crate jsonrpc_core;
 extern crate jsonrpc_client;
 #[macro_use]
 extern crate jsonrpc_derive;
+extern crate log;
 
 use jsonrpc_core::{Result, IoHandler};
 

--- a/derive/tests/run-pass/pubsub-subscription-type-without-deserialize.rs
+++ b/derive/tests/run-pass/pubsub-subscription-type-without-deserialize.rs
@@ -6,6 +6,7 @@ extern crate jsonrpc_client;
 extern crate jsonrpc_pubsub;
 #[macro_use]
 extern crate jsonrpc_derive;
+extern crate log;
 
 use std::sync::Arc;
 use jsonrpc_core::Result;

--- a/derive/tests/run-pass/pubsub-subscription-type-without-deserialize.rs
+++ b/derive/tests/run-pass/pubsub-subscription-type-without-deserialize.rs
@@ -2,6 +2,7 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate jsonrpc_core;
+extern crate jsonrpc_client;
 extern crate jsonrpc_pubsub;
 #[macro_use]
 extern crate jsonrpc_derive;
@@ -20,7 +21,7 @@ pub trait Rpc<T> {
 
 	/// Unsubscribe from hello subscription.
 	#[pubsub(subscription = "hello", unsubscribe, name = "hello_unsubscribe")]
-	fn unsubscribe(&self, _: Option<Self::Metadata>, _: SubscriptionId) -> Result<bool>;
+	fn unsubscribe(&self, a: Option<Self::Metadata>, b: SubscriptionId) -> Result<bool>;
 }
 
 // One way serialization

--- a/derive/tests/run-pass/server_only.rs
+++ b/derive/tests/run-pass/server_only.rs
@@ -1,0 +1,36 @@
+extern crate serde;
+extern crate jsonrpc_core;
+#[macro_use]
+extern crate jsonrpc_derive;
+
+use jsonrpc_core::{Result, IoHandler};
+
+#[rpc(server)]
+pub trait Rpc {
+	/// Returns a protocol version
+	#[rpc(name = "protocolVersion")]
+	fn protocol_version(&self) -> Result<String>;
+
+	/// Adds two numbers and returns a result
+	#[rpc(name = "add", alias("callAsyncMetaAlias"))]
+	fn add(&self, a: u64, b: u64) -> Result<u64>;
+}
+
+struct RpcImpl;
+
+impl Rpc for RpcImpl {
+	fn protocol_version(&self) -> Result<String> {
+		Ok("version1".into())
+	}
+
+	fn add(&self, a: u64, b: u64) -> Result<u64> {
+		Ok(a + b)
+	}
+}
+
+fn main() {
+	let mut io = IoHandler::new();
+	let rpc = RpcImpl;
+
+	io.extend_with(rpc.to_delegate())
+}

--- a/derive/tests/trailing.rs
+++ b/derive/tests/trailing.rs
@@ -6,15 +6,15 @@ use serde_json;
 pub trait Rpc {
 	/// Multiplies two numbers. Second number is optional.
 	#[rpc(name = "mul")]
-	fn mul(&self, _: u64, _: Option<u64>) -> Result<u64>;
+	fn mul(&self, a: u64, b: Option<u64>) -> Result<u64>;
 
 	/// Echos back the message, example of a single param trailing
 	#[rpc(name = "echo")]
-	fn echo(&self, _: Option<String>) -> Result<String>;
+	fn echo(&self, a: Option<String>) -> Result<String>;
 
 	/// Adds up to three numbers and returns a result
 	#[rpc(name = "add_multi")]
-	fn add_multi(&self, _: Option<u64>, _: Option<u64>, _: Option<u64>) -> Result<u64>;
+	fn add_multi(&self, a: Option<u64>, b: Option<u64>, c: Option<u64>) -> Result<u64>;
 }
 
 #[derive(Default)]

--- a/derive/tests/ui/attr-invalid-name-values.stderr
+++ b/derive/tests/ui/attr-invalid-name-values.stderr
@@ -1,4 +1,4 @@
-error: Invalid attribute parameter(s): 'Xname'. Expected 'name'
+error: Invalid attribute parameter(s): 'Xname'. Expected 'name, returns'
   --> $DIR/attr-invalid-name-values.rs:10:2
    |
 10 |       /// Returns a protocol version

--- a/derive/tests/ui/too-many-params.rs
+++ b/derive/tests/ui/too-many-params.rs
@@ -11,8 +11,8 @@ pub trait Rpc {
 	#[rpc(name = "tooManyParams")]
 	fn to_many_params(
         &self,
-        _: u64, _: u64, _: u64, _: u64, _: u64, _: u64, _: u64, _: u64, _: u64, _: u64,
-        _: u64, _: u64, _: u64, _: u64, _: u64, _: u64, _: u64,
+        a: u64, b: u64, c: u64, d: u64, e: u64, f: u64, g: u64, h: u64, i: u64, j: u64,
+        k: u64, l: u64, m: u64, n: u64, o: u64, p: u64, q: u64,
     ) -> Result<String>;
 }
 

--- a/derive/tests/ui/too-many-params.stderr
+++ b/derive/tests/ui/too-many-params.stderr
@@ -6,8 +6,8 @@ error: Maximum supported number of params is 16
 11 | |     #[rpc(name = "tooManyParams")]
 12 | |     fn to_many_params(
 13 | |         &self,
-14 | |         _: u64, _: u64, _: u64, _: u64, _: u64, _: u64, _: u64, _: u64, _: u64, _: u64,
-15 | |         _: u64, _: u64, _: u64, _: u64, _: u64, _: u64, _: u64,
+14 | |         a: u64, b: u64, c: u64, d: u64, e: u64, f: u64, g: u64, h: u64, i: u64, j: u64,
+15 | |         k: u64, l: u64, m: u64, n: u64, o: u64, p: u64, q: u64,
 16 | |     ) -> Result<String>;
    | |________________________^
 

--- a/http/src/handler.rs
+++ b/http/src/handler.rs
@@ -80,7 +80,7 @@ impl<M: Metadata, S: Middleware<M>> Service for ServerHandler<M, S> {
 
 		// Validate host
 		if should_validate_hosts && !is_host_allowed {
-			return Handler::Error(Some(Response::host_not_allowed()));
+			return Handler::Err(Some(Response::host_not_allowed()));
 		}
 
 		// Replace response with the one returned by middleware.
@@ -113,7 +113,7 @@ impl<M: Metadata, S: Middleware<M>> Service for ServerHandler<M, S> {
 
 pub enum Handler<M: Metadata, S: Middleware<M>> {
 	Rpc(RpcHandler<M, S>),
-	Error(Option<Response>),
+	Err(Option<Response>),
 	Middleware(Box<Future<Item = hyper::Response<Body>, Error = hyper::Error> + Send>),
 }
 
@@ -125,7 +125,7 @@ impl<M: Metadata, S: Middleware<M>> Future for Handler<M, S> {
 		match *self {
 			Handler::Rpc(ref mut handler) => handler.poll(),
 			Handler::Middleware(ref mut middleware) => middleware.poll(),
-			Handler::Error(ref mut response) => Ok(Async::Ready(
+			Handler::Err(ref mut response) => Ok(Async::Ready(
 				response
 					.take()
 					.expect("Response always Some initialy. Returning `Ready` so will never be polled again; qed")

--- a/ipc/src/logger.rs
+++ b/ipc/src/logger.rs
@@ -10,7 +10,7 @@ lazy_static! {
 		builder.filter(None, LevelFilter::Info);
 
 		if let Ok(log) = env::var("RUST_LOG") {
-			builder.parse(&log);
+			builder.parse_filters(&log);
 		}
 
 		if let Ok(_) = builder.try_init() {

--- a/server-utils/src/cors.rs
+++ b/server-utils/src/cors.rs
@@ -280,8 +280,8 @@ pub fn get_cors_allow_headers<T: AsRef<str>, O, F: Fn(T) -> O>(
 	}
 }
 
-/// Returns headers which are always allowed.
 lazy_static! {
+	/// Returns headers which are always allowed.
 	static ref ALWAYS_ALLOWED_HEADERS: HashSet<Ascii<&'static str>> = {
 		let mut hs = HashSet::new();
 		hs.insert(Ascii::new("Accept"));

--- a/tcp/src/logger.rs
+++ b/tcp/src/logger.rs
@@ -8,7 +8,7 @@ lazy_static! {
 		builder.filter(None, LevelFilter::Info);
 
 		if let Ok(log) = env::var("RUST_LOG") {
-			builder.parse(&log);
+			builder.parse_filters(&log);
 		}
 
 		if let Ok(_) = builder.try_init() {

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 jsonrpc-core = { path = "../core", version = "10.0" }
 jsonrpc-client = { path = "../client", version = "10.0" }
 jsonrpc-pubsub = { path = "../pubsub", version = "10.0" }
+log = "0.4"
 serde = "1.0"
 serde_json = "1.0"
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 jsonrpc-core = { path = "../core", version = "10.0" }
+jsonrpc-client = { path = "../client", version = "10.0" }
 jsonrpc-pubsub = { path = "../pubsub", version = "10.0" }
 serde = "1.0"
 serde_json = "1.0"

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -8,16 +8,16 @@
 //!
 //! #[rpc]
 //! pub trait Test {
-//! 	#[rpc(name = "rpc_some_method")]
-//!	    fn some_method(&self, _: u64) -> Result<u64>;
+//!     #[rpc(name = "rpc_some_method")]
+//!     fn some_method(&self, a: u64) -> Result<u64>;
 //! }
 //!
 //!
 //! struct Dummy;
 //! impl Test for Dummy {
-//!	  fn some_method(&self, x: u64) -> Result<u64> {
-//!     Ok(x * 2)
-//!	  }
+//!     fn some_method(&self, x: u64) -> Result<u64> {
+//!         Ok(x * 2)
+//!     }
 //! }
 //!
 //! fn main() {
@@ -31,8 +31,8 @@
 //!   let rpc = {
 //!     let mut io = IoHandler::new();
 //!     io.add_method("rpc_test_method", |_| {
-//!		  Err(Error::internal_error())
-//!		});
+//!         Err(Error::internal_error())
+//!     });
 //!     test::Rpc::from(io)
 //!   };
 //!

--- a/ws/client/Cargo.toml
+++ b/ws/client/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+authors = ["Parity Technologies <admin@parity.io>"]
+description = "JSON-RPC 2.0 websocket client implementation."
+documentation = "https://docs.rs/jsonrpc-core/"
+edition = "2018"
+homepage = "https://github.com/paritytech/jsonrpc"
+keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
+license = "MIT"
+name = "jsonrpc-ws-client"
+repository = "https://github.com/paritytech/jsonrpc"
+version = "10.1.0"
+
+categories = [
+	"asynchronous",
+	"network-programming",
+	"web-programming::http-client",
+	"web-programming::http-server",
+	"web-programming::websocket",
+]
+
+[dependencies]
+failure = "0.1"
+futures = "0.1"
+jsonrpc-core = { version = "10.1", path = "../../core" }
+jsonrpc-client = { version = "10.1", path = "../../client" }
+log = "0.4"
+tokio = "0.1"
+websocket = "0.22"
+
+[badges]
+travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/ws/client/Cargo.toml
+++ b/ws/client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "JSON-RPC 2.0 websocket client implementation."
-documentation = "https://docs.rs/jsonrpc-core/"
+documentation = "https://docs.rs/jsonrpc-ws-client/"
 edition = "2018"
 homepage = "https://github.com/paritytech/jsonrpc"
 keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]

--- a/ws/client/src/lib.rs
+++ b/ws/client/src/lib.rs
@@ -1,0 +1,122 @@
+//! JSON-RPC websocket client implementation.
+#![deny(missing_docs)]
+use failure::Error;
+use futures::prelude::*;
+use futures::sync::mpsc;
+use jsonrpc_client::{RpcClient, RpcChannel, RpcError};
+use log::info;
+use std::collections::VecDeque;
+use websocket::{ClientBuilder, OwnedMessage};
+
+/// Connect to a JSON-RPC websocket server.
+///
+/// Uses an unbuffered channel to queue outgoing rpc messages.
+pub fn connect<T>(url: &str) -> Result<impl Future<Item=T, Error=RpcError>, Error>
+where
+	T: From<RpcChannel>,
+{
+	let client = ClientBuilder::new(url)?
+		.async_connect(None)
+		.map(|(client, _)| {
+			let (sink, stream) = client.split();
+			let (sink, stream) = WebsocketClient::new(sink, stream).split();
+			let (sender, receiver) = mpsc::channel(0);
+			let rpc_client = RpcClient::new(sink, stream, receiver)
+				.map_err(|error| eprintln!("{:?}", error));
+			tokio::spawn(rpc_client);
+			sender.into()
+		})
+		.map_err(|error| RpcError::Other(error.into()));
+	Ok(client)
+}
+
+struct WebsocketClient<TSink, TStream> {
+	sink: TSink,
+	stream: TStream,
+	queue: VecDeque<OwnedMessage>,
+}
+
+impl<TSink, TStream, TError> WebsocketClient<TSink, TStream>
+where
+	TSink: Sink<SinkItem=OwnedMessage, SinkError=TError>,
+	TStream: Stream<Item=OwnedMessage, Error=TError>,
+	TError: Into<Error>,
+{
+	pub fn new(sink: TSink, stream: TStream) -> Self {
+		Self {
+			sink,
+			stream,
+			queue: VecDeque::new(),
+		}
+	}
+}
+
+impl<TSink, TStream, TError> Sink for WebsocketClient<TSink, TStream>
+where
+	TSink: Sink<SinkItem=OwnedMessage, SinkError=TError>,
+	TStream: Stream<Item=OwnedMessage, Error=TError>,
+	TError: Into<Error>,
+{
+	type SinkItem = String;
+	type SinkError = RpcError;
+
+	fn start_send(
+		&mut self,
+		request: Self::SinkItem,
+	) -> Result<AsyncSink<Self::SinkItem>, Self::SinkError> {
+		self.queue.push_back(OwnedMessage::Text(request));
+		Ok(AsyncSink::Ready)
+	}
+
+	fn poll_complete(&mut self) -> Result<Async<()>, Self::SinkError> {
+		loop {
+			match self.queue.pop_front() {
+				Some(request) => {
+					match self.sink.start_send(request) {
+						Ok(AsyncSink::Ready) => continue,
+						Ok(AsyncSink::NotReady(request)) => {
+							self.queue.push_front(request);
+							break;
+						}
+						Err(error) => return Err(RpcError::Other(error.into()))
+					}
+				}
+				None => break,
+			}
+		}
+		self.sink.poll_complete()
+			.map_err(|error| RpcError::Other(error.into()))
+	}
+}
+
+impl<TSink, TStream, TError> Stream for WebsocketClient<TSink, TStream>
+where
+	TSink: Sink<SinkItem=OwnedMessage, SinkError=TError>,
+	TStream: Stream<Item=OwnedMessage, Error=TError>,
+	TError: Into<Error>,
+{
+	type Item = String;
+	type Error = RpcError;
+
+	fn poll(&mut self) -> Result<Async<Option<Self::Item>>, Self::Error> {
+		loop {
+			match self.stream.poll() {
+				Ok(Async::Ready(Some(message))) => {
+					match message {
+						OwnedMessage::Text(data) => return Ok(Async::Ready(Some(data))),
+						OwnedMessage::Binary(data) => info!("server sent binary data {:?}", data),
+						OwnedMessage::Ping(p) => self.queue.push_front(OwnedMessage::Pong(p)),
+						OwnedMessage::Pong(_) => {}
+						OwnedMessage::Close(c) => self.queue.push_front(OwnedMessage::Close(c)),
+					}
+				}
+				Ok(Async::Ready(None)) => {
+					// TODO try to reconnect (#411).
+					return Ok(Async::Ready(None))
+				},
+				Ok(Async::NotReady) => return Ok(Async::NotReady),
+				Err(error) => return Err(RpcError::Other(error.into()))
+			}
+		}
+	}
+}

--- a/ws/client/src/lib.rs
+++ b/ws/client/src/lib.rs
@@ -3,7 +3,7 @@
 use failure::Error;
 use futures::prelude::*;
 use futures::sync::mpsc;
-use jsonrpc_client::{RpcClient, RpcChannel, RpcError};
+use jsonrpc_client::{RpcChannel, RpcClient, RpcError};
 use log::info;
 use std::collections::VecDeque;
 use websocket::{ClientBuilder, OwnedMessage};
@@ -11,7 +11,7 @@ use websocket::{ClientBuilder, OwnedMessage};
 /// Connect to a JSON-RPC websocket server.
 ///
 /// Uses an unbuffered channel to queue outgoing rpc messages.
-pub fn connect<T>(url: &str) -> Result<impl Future<Item=T, Error=RpcError>, Error>
+pub fn connect<T>(url: &str) -> Result<impl Future<Item = T, Error = RpcError>, Error>
 where
 	T: From<RpcChannel>,
 {
@@ -21,8 +21,7 @@ where
 			let (sink, stream) = client.split();
 			let (sink, stream) = WebsocketClient::new(sink, stream).split();
 			let (sender, receiver) = mpsc::channel(0);
-			let rpc_client = RpcClient::new(sink, stream, receiver)
-				.map_err(|error| eprintln!("{:?}", error));
+			let rpc_client = RpcClient::new(sink, stream, receiver).map_err(|error| eprintln!("{:?}", error));
 			tokio::spawn(rpc_client);
 			sender.into()
 		})
@@ -38,8 +37,8 @@ struct WebsocketClient<TSink, TStream> {
 
 impl<TSink, TStream, TError> WebsocketClient<TSink, TStream>
 where
-	TSink: Sink<SinkItem=OwnedMessage, SinkError=TError>,
-	TStream: Stream<Item=OwnedMessage, Error=TError>,
+	TSink: Sink<SinkItem = OwnedMessage, SinkError = TError>,
+	TStream: Stream<Item = OwnedMessage, Error = TError>,
 	TError: Into<Error>,
 {
 	pub fn new(sink: TSink, stream: TStream) -> Self {
@@ -53,17 +52,14 @@ where
 
 impl<TSink, TStream, TError> Sink for WebsocketClient<TSink, TStream>
 where
-	TSink: Sink<SinkItem=OwnedMessage, SinkError=TError>,
-	TStream: Stream<Item=OwnedMessage, Error=TError>,
+	TSink: Sink<SinkItem = OwnedMessage, SinkError = TError>,
+	TStream: Stream<Item = OwnedMessage, Error = TError>,
 	TError: Into<Error>,
 {
 	type SinkItem = String;
 	type SinkError = RpcError;
 
-	fn start_send(
-		&mut self,
-		request: Self::SinkItem,
-	) -> Result<AsyncSink<Self::SinkItem>, Self::SinkError> {
+	fn start_send(&mut self, request: Self::SinkItem) -> Result<AsyncSink<Self::SinkItem>, Self::SinkError> {
 		self.queue.push_back(OwnedMessage::Text(request));
 		Ok(AsyncSink::Ready)
 	}
@@ -71,28 +67,25 @@ where
 	fn poll_complete(&mut self) -> Result<Async<()>, Self::SinkError> {
 		loop {
 			match self.queue.pop_front() {
-				Some(request) => {
-					match self.sink.start_send(request) {
-						Ok(AsyncSink::Ready) => continue,
-						Ok(AsyncSink::NotReady(request)) => {
-							self.queue.push_front(request);
-							break;
-						}
-						Err(error) => return Err(RpcError::Other(error.into()))
+				Some(request) => match self.sink.start_send(request) {
+					Ok(AsyncSink::Ready) => continue,
+					Ok(AsyncSink::NotReady(request)) => {
+						self.queue.push_front(request);
+						break;
 					}
-				}
+					Err(error) => return Err(RpcError::Other(error.into())),
+				},
 				None => break,
 			}
 		}
-		self.sink.poll_complete()
-			.map_err(|error| RpcError::Other(error.into()))
+		self.sink.poll_complete().map_err(|error| RpcError::Other(error.into()))
 	}
 }
 
 impl<TSink, TStream, TError> Stream for WebsocketClient<TSink, TStream>
 where
-	TSink: Sink<SinkItem=OwnedMessage, SinkError=TError>,
-	TStream: Stream<Item=OwnedMessage, Error=TError>,
+	TSink: Sink<SinkItem = OwnedMessage, SinkError = TError>,
+	TStream: Stream<Item = OwnedMessage, Error = TError>,
 	TError: Into<Error>,
 {
 	type Item = String;
@@ -101,21 +94,19 @@ where
 	fn poll(&mut self) -> Result<Async<Option<Self::Item>>, Self::Error> {
 		loop {
 			match self.stream.poll() {
-				Ok(Async::Ready(Some(message))) => {
-					match message {
-						OwnedMessage::Text(data) => return Ok(Async::Ready(Some(data))),
-						OwnedMessage::Binary(data) => info!("server sent binary data {:?}", data),
-						OwnedMessage::Ping(p) => self.queue.push_front(OwnedMessage::Pong(p)),
-						OwnedMessage::Pong(_) => {}
-						OwnedMessage::Close(c) => self.queue.push_front(OwnedMessage::Close(c)),
-					}
-				}
+				Ok(Async::Ready(Some(message))) => match message {
+					OwnedMessage::Text(data) => return Ok(Async::Ready(Some(data))),
+					OwnedMessage::Binary(data) => info!("server sent binary data {:?}", data),
+					OwnedMessage::Ping(p) => self.queue.push_front(OwnedMessage::Pong(p)),
+					OwnedMessage::Pong(_) => {}
+					OwnedMessage::Close(c) => self.queue.push_front(OwnedMessage::Close(c)),
+				},
 				Ok(Async::Ready(None)) => {
 					// TODO try to reconnect (#411).
-					return Ok(Async::Ready(None))
-				},
+					return Ok(Async::Ready(None));
+				}
 				Ok(Async::NotReady) => return Ok(Async::NotReady),
-				Err(error) => return Err(RpcError::Other(error.into()))
+				Err(error) => return Err(RpcError::Other(error.into())),
 			}
 		}
 	}

--- a/ws/client/src/lib.rs
+++ b/ws/client/src/lib.rs
@@ -3,7 +3,8 @@
 use failure::Error;
 use futures::prelude::*;
 use futures::sync::mpsc;
-use jsonrpc_client::{RpcChannel, RpcClient, RpcError};
+use jsonrpc_client::RpcClient;
+pub use jsonrpc_client::{RpcChannel, RpcError};
 use log::info;
 use std::collections::VecDeque;
 use websocket::{ClientBuilder, OwnedMessage};


### PR DESCRIPTION
Requirements for generating a client are:
- rpc trait methods need to name their arguments
- pubsub methods are ignored

closes #253 and #381 