### PR TITLE
access to websocket broadcaster

### DIFF
--- a/ws/src/lib.rs
+++ b/ws/src/lib.rs
@@ -22,7 +22,7 @@ use jsonrpc_core as core;
 
 pub use self::error::{Error, Result};
 pub use self::metadata::{MetaExtractor, NoopExtractor, RequestContext};
-pub use self::server::{CloseHandle, Server};
+pub use self::server::{Broadcaster, CloseHandle, Server};
 pub use self::server_builder::ServerBuilder;
 pub use self::server_utils::cors::Origin;
 pub use self::server_utils::hosts::{DomainsValidation, Host};


### PR DESCRIPTION
 Im sending out a broadcaster object holding the ws::sender in order to not leak ws stuff which seems to work, but for now Im only accepting vec u8 for send, instead of From Message Any thoughts on how to implement that from without reexporting Message?