### PR TITLE
 Rename jsonrpc-client to jsonrpc-core-client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = [
 	"core",
-	"client",
+	"core-client",
 	"http",
 	"ipc",
 	"derive",

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Transport-agnostic `core` and transport servers for `http`, `ipc`, `websockets` 
 
 ## Sub-projects
 - [jsonrpc-core](./core) [![crates.io][core-image]][core-url]
+- [jsonrpc-core-client](./core-client) [![crates.io][core-client-image]][core-client-url]
 - [jsonrpc-http-server](./http) [![crates.io][http-server-image]][http-server-url]
 - [jsonrpc-ipc-server](./ipc) [![crates.io][ipc-server-image]][ipc-server-url]
 - [jsonrpc-tcp-server](./tcp) [![crates.io][tcp-server-image]][tcp-server-url]
@@ -28,6 +29,8 @@ Transport-agnostic `core` and transport servers for `http`, `ipc`, `websockets` 
 
 [core-image]: https://img.shields.io/crates/v/jsonrpc-core.svg
 [core-url]: https://crates.io/crates/jsonrpc-core
+[core-client-image]: https://img.shields.io/crates/v/jsonrpc-core-client.svg
+[core-client-url]: https://crates.io/crates/jsonrpc-core-client
 [http-server-image]: https://img.shields.io/crates/v/jsonrpc-http-server.svg
 [http-server-url]: https://crates.io/crates/jsonrpc-http-server
 [ipc-server-image]: https://img.shields.io/crates/v/jsonrpc-ipc-server.svg
@@ -101,7 +104,7 @@ fn main() {
 ### Client support
 
 ```rust
-use jsonrpc_client::local;
+use jsonrpc_core_client::local;
 use jsonrpc_core::futures::future::{self, Future, FutureResult};
 use jsonrpc_core::{Error, IoHandler, Result};
 use jsonrpc_derive::rpc;

--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Transport agnostic JSON-RPC 2.0 client implementation."
-documentation = "https://docs.rs/jsonrpc-client/"
+documentation = "https://docs.rs/jsonrpc-core-client/"
 edition = "2018"
 homepage = "https://github.com/paritytech/jsonrpc"
 keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
-name = "jsonrpc-client"
+name = "jsonrpc-core-client"
 repository = "https://github.com/paritytech/jsonrpc"
 version = "11.0.0"
 
@@ -27,7 +27,7 @@ serde_json = "1.0"
 
 [dev-dependencies]
 jsonrpc-derive = { version = "11.0", path = "../derive" }
-jsonrpc-client = { version = "11.0", path = "." }
+jsonrpc-core-client = { version = "11.0", path = "." }
 serde = "1.0"
 tokio = "0.1"
 

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -285,7 +285,7 @@ pub mod local {
 #[cfg(test)]
 mod tests {
 	use futures::prelude::*;
-	use jsonrpc_client::local;
+	use jsonrpc_core_client::local;
 	use jsonrpc_core::{IoHandler, Result};
 	use jsonrpc_derive::rpc;
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -20,7 +20,7 @@ proc-macro-crate = "0.1.3"
 
 [dev-dependencies]
 jsonrpc-core = { version = "11.0", path = "../core" }
-jsonrpc-client = { version = "11.0", path = "../client" }
+jsonrpc-core-client = { version = "11.0", path = "../core-client" }
 jsonrpc-pubsub = { version = "11.0", path = "../pubsub" }
 jsonrpc-tcp-server = { version = "11.0", path = "../tcp" }
 log = "0.4"

--- a/derive/examples/std.rs
+++ b/derive/examples/std.rs
@@ -1,6 +1,6 @@
 //! A simple example
 #![deny(missing_docs)]
-use jsonrpc_client::local;
+use jsonrpc_core_client::local;
 use jsonrpc_core::futures::future::{self, Future, FutureResult};
 use jsonrpc_core::{Error, IoHandler, Result};
 use jsonrpc_derive::rpc;

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -127,7 +127,7 @@
 //! Client Example
 //! 
 //! ```
-//! use jsonrpc_client::local;
+//! use jsonrpc_core_client::local;
 //! use jsonrpc_core::futures::future::{self, Future, FutureResult};
 //! use jsonrpc_core::{Error, IoHandler, Result};
 //! use jsonrpc_derive::rpc;

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -36,11 +36,11 @@ pub fn generate_client_module(methods: &[MethodRegistration], item_trait: &syn::
 			)
 		})
 		.unzip();
-	let client_name = crate_name("jsonrpc-client")?;
+	let client_name = crate_name("jsonrpc-core-client")?;
 	Ok(quote! {
 		/// The generated client module.
 		pub mod gen_client {
-			use #client_name as _jsonrpc_client;
+			use #client_name as _jsonrpc_core_client;
 			use super::*;
 			use _jsonrpc_core::{
 				Call, Error, ErrorCode, Id, MethodCall, Params, Request,
@@ -49,7 +49,7 @@ pub fn generate_client_module(methods: &[MethodRegistration], item_trait: &syn::
 			use _jsonrpc_core::futures::{future, Future, Sink};
 			use _jsonrpc_core::futures::sync::oneshot;
 			use _jsonrpc_core::serde_json::{self, Value};
-			use _jsonrpc_client::{RpcChannel, RpcError, RpcFuture, RpcMessage};
+			use _jsonrpc_core_client::{RpcChannel, RpcError, RpcFuture, RpcMessage};
 
 			/// The Client.
 			#[derive(Clone)]

--- a/derive/tests/run-pass/client_only.rs
+++ b/derive/tests/run-pass/client_only.rs
@@ -1,6 +1,6 @@
 extern crate serde;
 extern crate jsonrpc_core;
-extern crate jsonrpc_client;
+extern crate jsonrpc_core_client;
 #[macro_use]
 extern crate jsonrpc_derive;
 extern crate log;

--- a/derive/tests/run-pass/pubsub-dependency-not-required-for-vanilla-rpc.rs
+++ b/derive/tests/run-pass/pubsub-dependency-not-required-for-vanilla-rpc.rs
@@ -1,6 +1,6 @@
 extern crate serde;
 extern crate jsonrpc_core;
-extern crate jsonrpc_client;
+extern crate jsonrpc_core_client;
 #[macro_use]
 extern crate jsonrpc_derive;
 extern crate log;

--- a/derive/tests/run-pass/pubsub-subscription-type-without-deserialize.rs
+++ b/derive/tests/run-pass/pubsub-subscription-type-without-deserialize.rs
@@ -2,7 +2,7 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate jsonrpc_core;
-extern crate jsonrpc_client;
+extern crate jsonrpc_core_client;
 extern crate jsonrpc_pubsub;
 #[macro_use]
 extern crate jsonrpc_derive;

--- a/ipc/src/logger.rs
+++ b/ipc/src/logger.rs
@@ -10,7 +10,7 @@ lazy_static! {
 		builder.filter(None, LevelFilter::Info);
 
 		if let Ok(log) = env::var("RUST_LOG") {
-			builder.parse_filters(&log);
+			builder.parse(&log);
 		}
 
 		if let Ok(_) = builder.try_init() {

--- a/tcp/src/logger.rs
+++ b/tcp/src/logger.rs
@@ -8,7 +8,7 @@ lazy_static! {
 		builder.filter(None, LevelFilter::Info);
 
 		if let Ok(log) = env::var("RUST_LOG") {
-			builder.parse_filters(&log);
+			builder.parse(&log);
 		}
 
 		if let Ok(_) = builder.try_init() {

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 jsonrpc-core = { path = "../core", version = "11.0" }
-jsonrpc-client = { path = "../client", version = "11.0" }
+jsonrpc-core-client = { path = "../core-client", version = "11.0" }
 jsonrpc-pubsub = { path = "../pubsub", version = "11.0" }
 log = "0.4"
 serde = "1.0"

--- a/ws/client/Cargo.toml
+++ b/ws/client/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 failure = "0.1"
 futures = "0.1"
 jsonrpc-core = { version = "11.0", path = "../../core" }
-jsonrpc-client = { version = "11.0", path = "../../client" }
+jsonrpc-core-client = { version = "11.0", path = "../../core-client" }
 log = "0.4"
 tokio = "0.1"
 websocket = "0.22"

--- a/ws/client/src/lib.rs
+++ b/ws/client/src/lib.rs
@@ -3,8 +3,8 @@
 use failure::Error;
 use futures::prelude::*;
 use futures::sync::mpsc;
-use jsonrpc_client::RpcClient;
-pub use jsonrpc_client::{RpcChannel, RpcError};
+use jsonrpc_core_client::RpcClient;
+pub use jsonrpc_core_client::{RpcChannel, RpcError};
 use log::info;
 use std::collections::VecDeque;
 use websocket::{ClientBuilder, OwnedMessage};


### PR DESCRIPTION
There's already a crate [jsonrpc_client](https://crates.io/crates/jsonrpc-client) which collides because crates.io considers `_` and `-` equivalent. 

https://www.reddit.com/r/rust/comments/7x2ls9/consistentify_hyphen_usage_on_cratesio/