### PR TITLE
Extract client plumbing from derive, fix circular dependency

### DIFF
--- a/_automate/publish.sh
+++ b/_automate/publish.sh
@@ -2,7 +2,7 @@
 
 set -exu
 
-ORDER=(core client server-utils tcp ws ws/client http ipc stdio pubsub derive test)
+ORDER=(core core-client server-utils tcp ws ws/client http ipc stdio pubsub derive test)
 
 for crate in ${ORDER[@]}; do
 	cd $crate

--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -23,11 +23,11 @@ failure = "0.1"
 futures = "~0.1.6"
 jsonrpc-core = { version = "11.0", path = "../core" }
 log = "0.4"
+serde = "1.0"
 serde_json = "1.0"
 
 [dev-dependencies]
 jsonrpc-derive = { version = "11.0", path = "../derive" }
-jsonrpc-core-client = { version = "11.0", path = "." }
 serde = "1.0"
 tokio = "0.1"
 

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -242,6 +242,11 @@ impl From<RpcChannel> for TypedClient {
 }
 
 impl TypedClient {
+	/// Create new TypedClient
+	pub fn new(raw_cli: RawClient) -> Self {
+		TypedClient(raw_cli)
+	}
+
 	/// Call RPC with serialization of request and deserialization of response
 	pub fn call_method<T: Serialize, R: DeserializeOwned + 'static>(
 		&self,

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -69,12 +69,12 @@ impl Future for RpcFuture {
 /// the derive crate can generate a client.
 pub struct RpcMessage {
 	/// The rpc method name.
-	pub method: String,
+	method: String,
 	/// The rpc method parameters.
-	pub params: Params,
+	params: Params,
 	/// The oneshot channel to send the result of the rpc
 	/// call to.
-	pub sender: oneshot::Sender<Result<Value, Error>>,
+	sender: oneshot::Sender<Result<Value, Error>>,
 }
 
 /// A channel to a `RpcClient`.

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -393,7 +393,7 @@ mod tests {
 
 	impl AddClient {
 		fn add(&self, a: u64, b: u64) -> impl Future<Item=u64, Error=RpcError> {
-			self.0.call_method("add".into(), "u64".into(), (a, b))
+			self.0.call_method("add", "u64", (a, b))
 		}
 	}
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -23,7 +23,6 @@ jsonrpc-core = { version = "11.0", path = "../core" }
 jsonrpc-core-client = { version = "11.0", path = "../core-client" }
 jsonrpc-pubsub = { version = "11.0", path = "../pubsub" }
 jsonrpc-tcp-server = { version = "11.0", path = "../tcp" }
-log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -63,9 +63,9 @@ pub fn generate_client_module(methods: &[MethodRegistration], item_trait: &syn::
 				#(#where_clause),*
 			{
 				/// Creates a new `Client`.
-				pub fn new(inner: TypedClient) -> Self {
+				pub fn new(sender: RpcChannel) -> Self {
 					Client {
-						inner,
+						inner: sender.into(),
 						#(#markers_impl),*
 					}
 				}

--- a/derive/tests/run-pass/client_only.rs
+++ b/derive/tests/run-pass/client_only.rs
@@ -3,7 +3,6 @@ extern crate jsonrpc_core;
 extern crate jsonrpc_core_client;
 #[macro_use]
 extern crate jsonrpc_derive;
-extern crate log;
 
 use jsonrpc_core::futures::future::Future;
 use jsonrpc_core::futures::sync::mpsc;


### PR DESCRIPTION
A circular dev dependency in `core-client` was preventing the release of this crate. A test was using client `derive` which requires a dependency on `core-client`

This PR removes generated client from `derive` and uses a handrolled client. For this I extracted some code from `derive` which handles the dispatch and serialization of messages into `RawClient` and `TypedClient` helpers. 