### PR TITLE
Remove derive <-> core-client circular dependency

### DIFF
--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -27,7 +27,6 @@ serde = "1.0"
 serde_json = "1.0"
 
 [dev-dependencies]
-jsonrpc-derive = { version = "11.0", path = "../derive" }
 serde = "1.0"
 tokio = "0.1"
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -23,7 +23,9 @@ jsonrpc-core = { version = "11.0", path = "../core" }
 jsonrpc-core-client = { version = "11.0", path = "../core-client" }
 jsonrpc-pubsub = { version = "11.0", path = "../pubsub" }
 jsonrpc-tcp-server = { version = "11.0", path = "../tcp" }
+futures = "~0.1.6"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+tokio = "0.1"
 compiletest_rs = { version = "0.3", features = ["stable"] }

--- a/derive/tests/client.rs
+++ b/derive/tests/client.rs
@@ -1,0 +1,38 @@
+use futures::prelude::*;
+use jsonrpc_core_client::local;
+use jsonrpc_core::{IoHandler, Result};
+use jsonrpc_derive::rpc;
+
+#[rpc]
+pub trait Rpc {
+	#[rpc(name = "add")]
+	fn add(&self, a: u64, b: u64) -> Result<u64>;
+}
+
+struct RpcServer;
+
+impl Rpc for RpcServer {
+	fn add(&self, a: u64, b: u64) -> Result<u64> {
+		Ok(a + b)
+	}
+}
+
+#[test]
+fn client_server_roundtrip() {
+	let mut handler = IoHandler::new();
+	handler.extend_with(RpcServer.to_delegate());
+	let (client, rpc_client) = local::connect::<gen_client::Client, _, _>(handler);
+	let fut = client
+		.clone()
+		.add(3, 4)
+		.and_then(move |res| client.add(res, 5))
+		.join(rpc_client)
+		.map(|(res, ())| {
+			assert_eq!(res, 12);
+		})
+		.map_err(|err| {
+			eprintln!("{:?}", err);
+			assert!(false);
+		});
+	tokio::run(fut);
+}


### PR DESCRIPTION
This removes `derive` completely from `core-client` dev dependencies by using a handrolled server in the test. Breaks the `derive` <-> `core-client` circular dependency. 

I actually tested publishing this time before the PR, and `core-client` has successfully been [published](https://crates.io/crates/jsonrpc-core-client).

Also restores the original client/server roundtrip test, this time in `derive`, as suggested by @tomusdrw in #417.

