### PR TITLE
fix(tcp poll): don't drop when receiver value is ready

### DIFF
--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -2,15 +2,15 @@
 #![deny(missing_docs)]
 
 use failure::{format_err, Fail};
-use futures::{future, prelude::*};
 use futures::sync::{mpsc, oneshot};
+use futures::{future, prelude::*};
 use jsonrpc_core::{Call, Error, Id, MethodCall, Output, Params, Request, Response, Version};
 use log::debug;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::collections::VecDeque;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 
 /// The errors returned by the client.
 #[derive(Debug, Fail)]
@@ -216,7 +216,7 @@ impl From<RpcChannel> for RawClient {
 
 impl RawClient {
 	/// Call RPC with raw JSON
-	pub fn call_method(&self, method: &str, params: Params) -> impl Future<Item=Value, Error=RpcError> {
+	pub fn call_method(&self, method: &str, params: Params) -> impl Future<Item = Value, Error = RpcError> {
 		let (sender, receiver) = oneshot::channel();
 		let msg = RpcMessage {
 			method: method.into(),
@@ -253,31 +253,25 @@ impl TypedClient {
 		method: &str,
 		returns: &'static str,
 		args: T,
-	) -> impl Future<Item=R, Error=RpcError> {
-		let args = serde_json::to_value(args)
-			.expect("Only types with infallible serialisation can be used for JSON-RPC");
+	) -> impl Future<Item = R, Error = RpcError> {
+		let args =
+			serde_json::to_value(args).expect("Only types with infallible serialisation can be used for JSON-RPC");
 		let params = match args {
 			Value::Array(vec) => Params::Array(vec),
 			Value::Null => Params::None,
-			_ => return future::Either::A(future::err(RpcError::Other(
-				format_err!("RPC params should serialize to a JSON array, or null")))),
+			_ => {
+				return future::Either::A(future::err(RpcError::Other(format_err!(
+					"RPC params should serialize to a JSON array, or null"
+				))))
+			}
 		};
 
-		future::Either::B(
-			self.0
-				.call_method(method, params)
-				.and_then(move |value: Value| {
-					log::debug!("response: {:?}", value);
-					let result = serde_json::from_value::<R>(value)
-						.map_err(|error| {
-							RpcError::ParseError(
-								returns.into(),
-								error.into(),
-							)
-						});
-					future::done(result)
-				})
-		)
+		future::Either::B(self.0.call_method(method, params).and_then(move |value: Value| {
+			log::debug!("response: {:?}", value);
+			let result =
+				serde_json::from_value::<R>(value).map_err(|error| RpcError::ParseError(returns.into(), error.into()));
+			future::done(result)
+		}))
 	}
 }
 
@@ -364,8 +358,8 @@ pub mod local {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::{RpcChannel, RpcError, TypedClient};
 	use jsonrpc_core::{self, IoHandler};
-	use crate::{TypedClient, RpcError, RpcChannel};
 
 	#[derive(Clone)]
 	struct AddClient(TypedClient);
@@ -377,7 +371,7 @@ mod tests {
 	}
 
 	impl AddClient {
-		fn add(&self, a: u64, b: u64) -> impl Future<Item=u64, Error=RpcError> {
+		fn add(&self, a: u64, b: u64) -> impl Future<Item = u64, Error = RpcError> {
 			self.0.call_method("add", "u64", (a, b))
 		}
 	}

--- a/derive/examples/std.rs
+++ b/derive/examples/std.rs
@@ -1,8 +1,8 @@
 //! A simple example
 #![deny(missing_docs)]
-use jsonrpc_core_client::local;
 use jsonrpc_core::futures::future::{self, Future, FutureResult};
 use jsonrpc_core::{Error, IoHandler, Result};
+use jsonrpc_core_client::local;
 use jsonrpc_derive::rpc;
 
 /// Rpc trait

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -123,9 +123,9 @@
 //!
 //! # fn main() {}
 //! ```
-//! 
+//!
 //! Client Example
-//! 
+//!
 //! ```
 //! use jsonrpc_core_client::local;
 //! use jsonrpc_core::futures::future::{self, Future, FutureResult};
@@ -174,7 +174,7 @@
 //! 	};
 //! 	fut.wait().unwrap();
 //! }
-//! 
+//!
 //! ```
 
 #![recursion_limit = "256"]

--- a/derive/tests/client.rs
+++ b/derive/tests/client.rs
@@ -1,6 +1,6 @@
 use futures::prelude::*;
-use jsonrpc_core_client::local;
 use jsonrpc_core::{IoHandler, Result};
+use jsonrpc_core_client::local;
 use jsonrpc_derive::rpc;
 
 #[rpc]

--- a/tcp/src/dispatch.rs
+++ b/tcp/src/dispatch.rs
@@ -12,7 +12,7 @@ pub type SenderChannels = Mutex<HashMap<SocketAddr, mpsc::Sender<String>>>;
 
 pub struct PeerMessageQueue<S: Stream> {
 	up: S,
-	receiver: mpsc::Receiver<String>,
+	receiver: Option<mpsc::Receiver<String>>,
 	_addr: SocketAddr,
 }
 
@@ -20,7 +20,7 @@ impl<S: Stream> PeerMessageQueue<S> {
 	pub fn new(response_stream: S, receiver: mpsc::Receiver<String>, addr: SocketAddr) -> Self {
 		PeerMessageQueue {
 			up: response_stream,
-			receiver,
+			receiver: Some(receiver),
 			_addr: addr,
 		}
 	}
@@ -82,26 +82,44 @@ impl<S: Stream<Item = String, Error = std::io::Error>> Stream for PeerMessageQue
 	type Item = String;
 	type Error = std::io::Error;
 
+	// The receiver will never return `Ok(Async::Ready(None))`
+	// Because the sender is kept in `SenderChannels` and it will never be dropped until `the stream` is resolved.
+	//
+	// Thus, that is the reason we terminate if `up_closed && receiver == Async::NotReady`.
+	//
+	// However, it is possible to have a race between `poll` and `push_work` if the connection is dropped.
+	// Therefore, the receiver is then dropped when the connection is dropped and an error is propagated when
+	// a `send` attempt is made on that channel.
 	fn poll(&mut self) -> Poll<Option<String>, std::io::Error> {
 		// check if we have response pending
-		match self.up.poll() {
-			Ok(Async::Ready(Some(val))) => {
-				return Ok(Async::Ready(Some(val)));
-			}
-			Ok(Async::Ready(None)) => {
-				// this will ensure that this polling will end when incoming i/o stream ends
-				return Ok(Async::Ready(None));
-			}
-			_ => {}
-		}
 
-		match self.receiver.poll() {
-			Ok(result) => Ok(result),
-			Err(send_err) => {
-				// not sure if it can ever happen
-				warn!("MPSC send error: {:?}", send_err);
-				Err(std::io::Error::from(std::io::ErrorKind::Other))
+		let up_closed = match self.up.poll() {
+			Ok(Async::Ready(Some(item))) => return Ok(Async::Ready(Some(item))),
+			Ok(Async::Ready(None)) => true,
+			Ok(Async::NotReady) => false,
+			err => return err,
+		};
+
+		let rx = match &mut self.receiver {
+			None => {
+				debug_assert!(up_closed);
+				return Ok(Async::Ready(None))
 			}
+			Some(rx) => rx,
+		};
+
+		match rx.poll() {
+			Ok(Async::Ready(Some(item))) => {
+				// If the other stream isn't finished yet, give them a chance to
+				// go first next time as we pulled something off `up`.
+				Ok(Async::Ready(Some(item)))
+			}
+			Ok(Async::Ready(None)) | Ok(Async::NotReady) if up_closed => {
+				self.receiver = None;
+				Ok(Async::Ready(None))
+			}
+			Ok(Async::Ready(None)) | Ok(Async::NotReady) => Ok(Async::NotReady),
+			Err(_) => Err(std::io::Error::new(std::io::ErrorKind::Other, "MPSC error")),
 		}
 	}
 }

--- a/tcp/src/dispatch.rs
+++ b/tcp/src/dispatch.rs
@@ -109,11 +109,7 @@ impl<S: Stream<Item = String, Error = std::io::Error>> Stream for PeerMessageQue
 		};
 
 		match rx.poll() {
-			Ok(Async::Ready(Some(item))) => {
-				// If the other stream isn't finished yet, give them a chance to
-				// go first next time as we pulled something off `up`.
-				Ok(Async::Ready(Some(item)))
-			}
+			Ok(Async::Ready(Some(item))) => Ok(Async::Ready(Some(item))),
 			Ok(Async::Ready(None)) | Ok(Async::NotReady) if up_closed => {
 				self.receiver = None;
 				Ok(Async::Ready(None))

--- a/tcp/src/dispatch.rs
+++ b/tcp/src/dispatch.rs
@@ -103,7 +103,7 @@ impl<S: Stream<Item = String, Error = std::io::Error>> Stream for PeerMessageQue
 		let rx = match &mut self.receiver {
 			None => {
 				debug_assert!(up_closed);
-				return Ok(Async::Ready(None))
+				return Ok(Async::Ready(None));
 			}
 			Some(rx) => rx,
 		};


### PR DESCRIPTION
Basically when `up` is polled and the result is `Ready(None)` we need to check if `receiver` has received any result which this commit fixes.

In other words the current implementation will return `early` and then drop it and some result in the `receiver` could be missed!

I tried to mimic to previous implementation to prioritize `up` and used pattern matching on both at the same time for verbosity!