### PR TITLE
Be forward compatible with rust-lang/rust#59928

### DIFF
--- a/http/src/handler.rs
+++ b/http/src/handler.rs
@@ -121,7 +121,7 @@ impl<M: Metadata, S: Middleware<M>> Future for Handler<M, S> {
 	type Item = hyper::Response<Body>;
 	type Error = hyper::Error;
 
-	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+	fn poll(&mut self) -> Poll<Self::Item, hyper::Error> {
 		match *self {
 			Handler::Rpc(ref mut handler) => handler.poll(),
 			Handler::Middleware(ref mut middleware) => middleware.poll(),


### PR DESCRIPTION
Hello! In https://github.com/rust-lang/rust/pull/59928 we are making https://github.com/rust-lang/rust/issues/57644 a deny-by-default lint. To be forward compatible with that, here's a simple fix. Thank you for you understanding!