### PR TITLE
Add a way to close the http server while waiting

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -17,6 +17,6 @@ jsonrpc-server-utils = { version = "11.0", path = "../server-utils" }
 log = "0.4"
 net2 = "0.2"
 unicase = "2.0"
-
+parking_lot = "0.8.0"
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -382,7 +382,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 		let (done_tx, done_rx) = oneshot::channel();
 		let eloop = self.executor.init_with_name("http.worker0")?;
 		let req_max_size = self.max_request_body_size;
-		// First thread `Executor` is initialised differently from the others
+		// The first threads `Executor` is initialised differently from the others
 		serve(
 			(shutdown_signal, local_addr_tx, done_tx),
 			eloop.executor(),
@@ -552,9 +552,9 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 					warn!("Incoming streams error, closing sever: {:?}", e);
 				})
 				.select(shutdown_signal
-					.map_err(|e| {
-						debug!("Shutdown signaller dropped, closing server: {:?}", e);
-					}))
+				.map_err(|e| {
+					debug!("Shutdown signaller dropped, closing server: {:?}", e);
+				}))
 				.map(|_| ())
 				.map_err(|_| ())
 		})

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -448,7 +448,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 
 		Ok(Server {
 			address: local_addr?,
-			executors: Arc::new( Mutex::new(Some(executors))),
+			executors: Arc::new(Mutex::new(Some(executors))),
 			close: Arc::new(Mutex::new(Some(closers))),
 			done: Some(done_rxs),
 		})

--- a/http/src/tests.rs
+++ b/http/src/tests.rs
@@ -1409,23 +1409,16 @@ fn should_return_connection_header() {
 fn close_handle_makes_wait_return() {
 	let server = serve(id);
 	let close_handle = server.close_handle();
-	let close_handle2 = close_handle.clone();
 
 	let (tx, rx) = mpsc::channel();
 
 	thread::spawn(move || {
-		println!("[tst thr] SENDING");
 		tx.send(server.wait()).unwrap();
-		println!("[tst thr] SENT");
 	});
 
 	thread::sleep(Duration::from_secs(3));
 
-	println!("[tst] WAKING UP");
-
-	thread::spawn(move || {close_handle.close() });
-	thread::spawn(move || {close_handle2.close() });
-//	close_handle.close();
+	close_handle.close();
 
 	rx.recv_timeout(Duration::from_secs(10)).expect("Expected server to close");
 }

--- a/http/src/tests.rs
+++ b/http/src/tests.rs
@@ -4,6 +4,7 @@ use self::jsonrpc_core::{Error, ErrorCode, IoHandler, Params, Value};
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::str::Lines;
+use std::time::Duration;
 
 use self::jsonrpc_core::futures::{self, Future};
 use super::*;
@@ -52,8 +53,6 @@ fn serve_allow_headers(cors_allow_headers: cors::AccessControlAllowHeaders) -> S
 }
 
 fn io() -> IoHandler {
-	use std::{thread, time};
-
 	let mut io = IoHandler::default();
 	io.add_method("hello", |params: Params| match params.parse::<(u64,)>() {
 		Ok((num,)) => Ok(Value::String(format!("world: {}", num))),
@@ -66,7 +65,7 @@ fn io() -> IoHandler {
 	io.add_method("hello_async2", |_params: Params| {
 		let (c, p) = futures::oneshot();
 		thread::spawn(move || {
-			thread::sleep(time::Duration::from_millis(10));
+			thread::sleep(Duration::from_millis(10));
 			c.send(Value::String("world".into())).unwrap();
 		});
 		p.map_err(|_| Error::invalid_request())

--- a/ipc/src/logger.rs
+++ b/ipc/src/logger.rs
@@ -10,7 +10,7 @@ lazy_static! {
 		builder.filter(None, LevelFilter::Info);
 
 		if let Ok(log) = env::var("RUST_LOG") {
-			builder.parse(&log);
+			builder.parse_filters(&log);
 		}
 
 		if let Ok(_) = builder.try_init() {

--- a/tcp/src/logger.rs
+++ b/tcp/src/logger.rs
@@ -8,7 +8,7 @@ lazy_static! {
 		builder.filter(None, LevelFilter::Info);
 
 		if let Ok(log) = env::var("RUST_LOG") {
-			builder.parse(&log);
+			builder.parse_filters(&log);
 		}
 
 		if let Ok(_) = builder.try_init() {

--- a/ws/src/tests.rs
+++ b/ws/src/tests.rs
@@ -62,7 +62,6 @@ fn request(server: Server, request: &str) -> Response {
 
 fn serve(port: u16) -> (Server, Arc<AtomicUsize>) {
 	use crate::core::futures::sync::oneshot;
-	use std::time::Duration;
 
 	let pending = Arc::new(AtomicUsize::new(0));
 


### PR DESCRIPTION
Ref. https://github.com/paritytech/jsonrpc/pull/331

This PR implements the idea put forward by @tomusdrw to add an additional `oneshot` channel to let the `Server` know when the future is shut down, which lets us write an implementation of `Server::wait()` that can be interrupted by an external signal.

(Also includes a few fixed compiler warnings)