### PR TITLE
Add client transport features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,10 @@ before_script:
   - rustup component add rustfmt
 
 script:
-  - cargo build --all --features "$JSONRPC_CLIENT_FEATURES"
-  - cargo test --all --features "$JSONRPC_CLIENT_FEATURES"
+  - cargo build --all
+  - cargo test --all
+  - cargo build --manifest-path=core-client/Cargo.toml --features "$JSONRPC_CLIENT_FEATURES"
+  - cargo test --manifest-path=core-client/Cargo.toml --features "$JSONRPC_CLIENT_FEATURES"
   - |
     ([ $TRAVIS_RUST_VERSION = stable ] && cargo fmt --all -- --check) || true
 
@@ -52,4 +54,6 @@ env:
   - secure: "QA4Rw78VSsP1vH2Yve1eAVpjG32HH9DZZ79xrhxZXp34wKoemp+aGqaFN/8uXPfsXshlYxtMCTT6M9OiWTTLvku5tI5kBsDneu8mLut7eBZHVniYSp2SbKpTeqfpGMDHoCR0WD9AlWDn9Elm6txbghXjrxhCMg8gkhhsLGnQt/ARFF1wRHnXT0TjJg8fQtd+/OK0TaRfknx1RptruaznxfUi3DBwzDdzaMMZfd3VjWR1hPFRpDSL0mM+l6OjNrLbCeiR//k3lV4rpIhedsz0ODjfW2Hdk63qCaLJsXCkG1Bcuf/FYbYC+osm5SrHhGA1j2EgazWcLA6Wkzt15KPOR/HirNj+PCiS0YbGKM5Ac5LT6m6q0iYSF/pq1+jDurcSwBwYrTOY6X2FZCZQBfTP/4qnSjWgGPOkzBSMS6BNEBDQZgdc3xCASXadj7waF4Y4UGD0bDPuBtXopI4ppKLqSa7CsvKz6TX2yW0UVgUuQ5/jz/S+fkcz74o016d5x027yjaxAu/Z8fQFLSaBtiFU8sBzA+MDU3apFgjsYXiaGYZ8gDrp7WjbfHNYfBAMEHHKY4toywB5Vi8zJxF+Wn1n4hkvb/kDqSV9giFmWEg321U+pAGNAH4yY25tIJqS8gT89cz4oQJp7aWjA3Ke01e104yqqZU+N+CSyZHEeksdPt8="
   matrix:
   - JSONRPC_CLIENT_FEATURES=''
-  - JSONRPC_CLIENT_FEATURES='tls'
+  - JSONRPC_CLIENT_FEATURES='http, tls'
+  - JSONRPC_CLIENT_FEATURES='ws'
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,9 @@ before_script:
 script:
   - cargo build --all
   - cargo test --all
-  - cargo build --manifest-path=core-client/Cargo.toml --features "$JSONRPC_CLIENT_FEATURES"
-  - cargo test --manifest-path=core-client/Cargo.toml --features "$JSONRPC_CLIENT_FEATURES"
+  - cargo test --manifest-path=core-client/Cargo.toml --features "http"
+  - cargo test --manifest-path=core-client/Cargo.toml --features "http, tls"
+  - cargo test --manifest-path=core-client/Cargo.toml --features "ws"
   - |
     ([ $TRAVIS_RUST_VERSION = stable ] && cargo fmt --all -- --check) || true
 
@@ -42,7 +43,6 @@ after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&
   [ $TRAVIS_RUST_VERSION = stable ] &&
-  [ $JSONRPC_CLIENT_FEATURES = '' ] &&
   cargo doc --all --no-deps &&
   echo '<meta http-equiv=refresh content=0;url=jsonrpc_core/index.html>' > target/doc/index.html &&
   pip install --user ghp-import &&
@@ -52,8 +52,4 @@ after_success: |
 env:
   global:
   - secure: "QA4Rw78VSsP1vH2Yve1eAVpjG32HH9DZZ79xrhxZXp34wKoemp+aGqaFN/8uXPfsXshlYxtMCTT6M9OiWTTLvku5tI5kBsDneu8mLut7eBZHVniYSp2SbKpTeqfpGMDHoCR0WD9AlWDn9Elm6txbghXjrxhCMg8gkhhsLGnQt/ARFF1wRHnXT0TjJg8fQtd+/OK0TaRfknx1RptruaznxfUi3DBwzDdzaMMZfd3VjWR1hPFRpDSL0mM+l6OjNrLbCeiR//k3lV4rpIhedsz0ODjfW2Hdk63qCaLJsXCkG1Bcuf/FYbYC+osm5SrHhGA1j2EgazWcLA6Wkzt15KPOR/HirNj+PCiS0YbGKM5Ac5LT6m6q0iYSF/pq1+jDurcSwBwYrTOY6X2FZCZQBfTP/4qnSjWgGPOkzBSMS6BNEBDQZgdc3xCASXadj7waF4Y4UGD0bDPuBtXopI4ppKLqSa7CsvKz6TX2yW0UVgUuQ5/jz/S+fkcz74o016d5x027yjaxAu/Z8fQFLSaBtiFU8sBzA+MDU3apFgjsYXiaGYZ8gDrp7WjbfHNYfBAMEHHKY4toywB5Vi8zJxF+Wn1n4hkvb/kDqSV9giFmWEg321U+pAGNAH4yY25tIJqS8gT89cz4oQJp7aWjA3Ke01e104yqqZU+N+CSyZHEeksdPt8="
-  matrix:
-  - JSONRPC_CLIENT_FEATURES=''
-  - JSONRPC_CLIENT_FEATURES='http, tls'
-  - JSONRPC_CLIENT_FEATURES='ws'
 

--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -21,6 +21,10 @@ categories = [
 [features]
 tls = ["hyper-tls"]
 http = ["hyper"]
+ws = [
+	"websocket",
+	"tokio",
+]
 
 [dependencies]
 failure = "0.1"
@@ -31,14 +35,15 @@ jsonrpc-core = { version = "11.0", path = "../core" }
 log = "0.4"
 serde = "1.0"
 serde_json = "1.0"
-tokio = "0.1"
-websocket = "0.22"
+tokio = { version = "0.1", optional = true }
+websocket = { version = "0.22", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.1"
 jsonrpc-http-server = { version = "11.0", path = "../http" }
 lazy_static = "1.0"
 env_logger = "0.6"
+tokio = "0.1"
 
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -20,11 +20,12 @@ categories = [
 
 [features]
 tls = ["hyper-tls"]
+http = ["hyper"]
 
 [dependencies]
 failure = "0.1"
 futures = "0.1.26"
-hyper = "0.12"
+hyper = { version = "0.12", optional = true }
 hyper-tls = { version = "0.3.2", optional = true }
 jsonrpc-core = { version = "11.0", path = "../core" }
 log = "0.4"

--- a/core-client/src/transports/mod.rs
+++ b/core-client/src/transports/mod.rs
@@ -9,6 +9,7 @@ pub mod duplex;
 #[cfg(feature = "http")]
 pub mod http;
 pub mod local;
+#[cfg(feature = "ws")]
 pub mod ws;
 
 pub use duplex::duplex;

--- a/core-client/src/transports/mod.rs
+++ b/core-client/src/transports/mod.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 use crate::{RpcError, RpcMessage};
 
 pub mod duplex;
+#[cfg(feature = "http")]
 pub mod http;
 pub mod local;
 pub mod ws;


### PR DESCRIPTION
Resolves #431.

I've changed the CI script to run `core-client` build for the new features with `--manifest-path=core-client/Cargo.toml` since the features don't work with the top level cargo workspace.