### PR TITLE
Allow access to raw Params object in jsonrpc-derive

### DIFF
--- a/derive/examples/meta-macros.rs
+++ b/derive/examples/meta-macros.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use jsonrpc_core::futures::future::FutureResult;
+use jsonrpc_core::types::params::Params;
 use jsonrpc_core::{futures, Error, MetaIoHandler, Metadata, Result, Value};
 use jsonrpc_derive::rpc;
 
@@ -16,7 +17,7 @@ pub trait Rpc<One> {
 	#[rpc(name = "getOne")]
 	fn one(&self) -> Result<One>;
 
-	/// Adds two numbers and returns a result
+	/// Adds two numbers and returns a result.
 	#[rpc(name = "add")]
 	fn add(&self, a: u64, b: u64) -> Result<u64>;
 
@@ -24,11 +25,15 @@ pub trait Rpc<One> {
 	#[rpc(name = "mul")]
 	fn mul(&self, a: u64, b: Option<u64>) -> Result<u64>;
 
-	/// Performs asynchronous operation
+	/// Retrieves and debug prints the underlying `Params` object.
+	#[rpc(name = "raw", raw_params)]
+	fn raw(&self, params: Params) -> Result<String>;
+
+	/// Performs an asynchronous operation.
 	#[rpc(name = "callAsync")]
 	fn call(&self, a: u64) -> FutureResult<String, Error>;
 
-	/// Performs asynchronous operation with meta
+	/// Performs an asynchronous operation with meta.
 	#[rpc(meta, name = "callAsyncMeta", alias("callAsyncMetaAlias"))]
 	fn call_meta(&self, a: Self::Metadata, b: BTreeMap<String, Value>) -> FutureResult<String, Error>;
 }
@@ -47,6 +52,10 @@ impl Rpc<u64> for RpcImpl {
 
 	fn mul(&self, a: u64, b: Option<u64>) -> Result<u64> {
 		Ok(a * b.unwrap_or(1))
+	}
+
+	fn raw(&self, params: Params) -> Result<String> {
+		Ok(format!("Got: {:?}", params))
 	}
 
 	fn call(&self, x: u64) -> FutureResult<String, Error> {

--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -198,6 +198,8 @@ impl RpcMethod {
 				self.params_with_trailing(trailing_args_num, param_types, tuple_fields)
 			} else if param_types.is_empty() {
 				quote! { let params = params.expect_no_params(); }
+			} else if self.attr.raw_params {
+				quote! { let params = Ok((params,)); }
 			} else {
 				quote! { let params = params.parse::<(#(#param_types, )*)>(); }
 			}

--- a/derive/tests/ui/attr-invalid-meta-words.stderr
+++ b/derive/tests/ui/attr-invalid-meta-words.stderr
@@ -1,4 +1,4 @@
-error: Invalid attribute parameter(s): 'Xmeta'. Expected 'meta'
+error: Invalid attribute parameter(s): 'Xmeta'. Expected 'meta, raw_params'
   --> $DIR/attr-invalid-meta-words.rs:8:2
    |
 8  |       /// Returns a protocol version


### PR DESCRIPTION
### Added

* Add new meta word `raw_params` to the `#[rpc]` attribute on trait methods. This is supported on both RPC and pub/sub methods.

### Changed

* Skip deserialization of `Params` if `raw_params` is set and pass it in as the sole argument instead.
* Update `meta-macros` example to include `raw_params` usage.

Closes #389.

---

The code for `jsonrpc-derive` was admittedly quite hairy, but I like how both it and the `Params` type rely quite heavily on the type system to ensure consistency. I've checked quite a few corner cases, and everything seems to be alright (e.g. rejecting multiple arguments when `raw_params` is set, rejecting non-`Params` arguments when `raw_params` is set, ensuring that pub/sub and custom metadata still work as expected with `raw_params`).

I chose the name `raw_params` over `rawParams`, as described in the issue linked above, to better adhere to idiomatic Rust style.

Please let me know if there is anything I should improve or fix further!