### PR TITLE
Add support for notifications in jsonrpc-derive

### DIFF
--- a/derive/examples/meta-macros.rs
+++ b/derive/examples/meta-macros.rs
@@ -38,7 +38,7 @@ pub trait Rpc<One> {
 	fn call_meta(&self, a: Self::Metadata, b: BTreeMap<String, Value>) -> FutureResult<String, Error>;
 
 	/// Handles notification.
-	#[notification(name = "notify")]
+	#[rpc(name = "notify")]
 	fn notify(&self, a: u64);
 }
 

--- a/derive/examples/meta-macros.rs
+++ b/derive/examples/meta-macros.rs
@@ -37,7 +37,7 @@ pub trait Rpc<One> {
 	#[rpc(meta, name = "callAsyncMeta", alias("callAsyncMetaAlias"))]
 	fn call_meta(&self, a: Self::Metadata, b: BTreeMap<String, Value>) -> FutureResult<String, Error>;
 
-	/// Responds to a notification.
+	/// Handles notification.
 	#[notification(name = "notify")]
 	fn notify(&self, a: u64);
 }

--- a/derive/examples/meta-macros.rs
+++ b/derive/examples/meta-macros.rs
@@ -36,6 +36,10 @@ pub trait Rpc<One> {
 	/// Performs an asynchronous operation with meta.
 	#[rpc(meta, name = "callAsyncMeta", alias("callAsyncMetaAlias"))]
 	fn call_meta(&self, a: Self::Metadata, b: BTreeMap<String, Value>) -> FutureResult<String, Error>;
+
+	/// Responds to a notification.
+	#[notification(name = "notify")]
+	fn notify(&self, a: u64);
 }
 
 struct RpcImpl;
@@ -64,6 +68,10 @@ impl Rpc<u64> for RpcImpl {
 
 	fn call_meta(&self, meta: Self::Metadata, map: BTreeMap<String, Value>) -> FutureResult<String, Error> {
 		futures::finished(format!("From: {}, got: {:?}", meta.0, map))
+	}
+
+	fn notify(&self, a: u64) {
+		println!("Received `notify` with value: {}", a);
 	}
 }
 

--- a/derive/src/rpc_attr.rs
+++ b/derive/src/rpc_attr.rs
@@ -41,7 +41,6 @@ const RAW_PARAMS_META_WORD: &str = "raw_params";
 const SUBSCRIBE_META_WORD: &str = "subscribe";
 const UNSUBSCRIBE_META_WORD: &str = "unsubscribe";
 const RETURNS_META_WORD: &str = "returns";
-const NOTIFICATION_ATTR_NAME: &str = "notification";
 
 const MULTIPLE_RPC_ATTRIBUTES_ERR: &str = "Expected only a single rpc attribute per method";
 const INVALID_ATTR_PARAM_NAMES_ERR: &str = "Invalid attribute parameter(s):";
@@ -187,11 +186,6 @@ fn validate_attribute_meta(meta: syn::Meta) -> Result<syn::Meta> {
 				&[SUBSCRIBE_META_WORD, UNSUBSCRIBE_META_WORD, RAW_PARAMS_META_WORD],
 			)?;
 			validate_idents(&meta, &visitor.name_value_names, &[SUBSCRIPTION_NAME_KEY, RPC_NAME_KEY])?;
-			validate_idents(&meta, &visitor.meta_list_names, &[ALIASES_KEY])
-		}
-		NOTIFICATION_ATTR_NAME => {
-			validate_idents(&meta, &visitor.meta_words, &[METADATA_META_WORD, RAW_PARAMS_META_WORD])?;
-			validate_idents(&meta, &visitor.name_value_names, &[RPC_NAME_KEY])?;
 			validate_idents(&meta, &visitor.meta_list_names, &[ALIASES_KEY])
 		}
 		_ => Ok(meta), // ignore other attributes - compiler will catch unknown ones

--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -119,6 +119,12 @@ fn compute_method_registrations(item_trait: &syn::ItemTrait) -> Result<(Vec<Meth
 					}
 				}
 			}
+			AttributeKind::Notification { has_metadata } => {
+				method_registrations.push(MethodRegistration::Notification {
+					method: method.clone(),
+					has_metadata: *has_metadata,
+				})
+			}
 		}
 	}
 

--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -79,10 +79,23 @@ fn compute_method_registrations(item_trait: &syn::ItemTrait) -> Result<(Vec<Meth
 
 	for method in methods.iter() {
 		match &method.attr().kind {
-			AttributeKind::Rpc { has_metadata, .. } => method_registrations.push(MethodRegistration::Standard {
-				method: method.clone(),
-				has_metadata: *has_metadata,
-			}),
+			AttributeKind::Rpc {
+				has_metadata,
+				is_notification,
+				..
+			} => {
+				if *is_notification {
+					method_registrations.push(MethodRegistration::Notification {
+						method: method.clone(),
+						has_metadata: *has_metadata,
+					})
+				} else {
+					method_registrations.push(MethodRegistration::Standard {
+						method: method.clone(),
+						has_metadata: *has_metadata,
+					})
+				}
+			}
 			AttributeKind::PubSub {
 				subscription_name,
 				kind,
@@ -118,12 +131,6 @@ fn compute_method_registrations(item_trait: &syn::ItemTrait) -> Result<(Vec<Meth
 						}
 					}
 				}
-			}
-			AttributeKind::Notification { has_metadata } => {
-				method_registrations.push(MethodRegistration::Notification {
-					method: method.clone(),
-					has_metadata: *has_metadata,
-				})
 			}
 		}
 	}

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -132,7 +132,20 @@ fn generate_client_methods(methods: &[MethodRegistration]) -> Result<Vec<syn::Im
 				);
 				client_methods.push(client_method);
 			}
-			MethodRegistration::Notification { .. } => continue,
+			MethodRegistration::Notification { method, .. } => {
+				let attrs = get_doc_comments(&method.trait_item.attrs);
+				let name = &method.trait_item.sig.ident;
+				let args = compute_args(&method.trait_item);
+				let arg_names = compute_arg_identifiers(&args)?;
+				let client_method = syn::parse_quote! {
+					#(#attrs)*
+					pub fn #name(&self, #args) {
+						let _args_tuple = (#(#arg_names,)*);
+						unimplemented!()
+					}
+				};
+				client_methods.push(client_method);
+			}
 		}
 	}
 	Ok(client_methods)

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -97,7 +97,7 @@ fn generate_client_methods(methods: &[MethodRegistration]) -> Result<Vec<syn::Im
 				let arg_names = compute_arg_identifiers(&args)?;
 				let returns = match &method.attr.kind {
 					AttributeKind::Rpc { returns, .. } => compute_returns(&method.trait_item, returns)?,
-					_ => continue,
+					AttributeKind::PubSub { .. } => continue,
 				};
 				let returns_str = quote!(#returns).to_string();
 				let client_method = syn::parse_quote! {
@@ -132,7 +132,7 @@ fn generate_client_methods(methods: &[MethodRegistration]) -> Result<Vec<syn::Im
 				);
 				client_methods.push(client_method);
 			}
-			_ => continue,
+			MethodRegistration::Notification { .. } => continue,
 		}
 	}
 	Ok(client_methods)

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -97,9 +97,7 @@ fn generate_client_methods(methods: &[MethodRegistration]) -> Result<Vec<syn::Im
 				let arg_names = compute_arg_identifiers(&args)?;
 				let returns = match &method.attr.kind {
 					AttributeKind::Rpc { returns, .. } => compute_returns(&method.trait_item, returns)?,
-					AttributeKind::PubSub { .. } => {
-						continue;
-					}
+					_ => continue,
 				};
 				let returns_str = quote!(#returns).to_string();
 				let client_method = syn::parse_quote! {
@@ -134,6 +132,7 @@ fn generate_client_methods(methods: &[MethodRegistration]) -> Result<Vec<syn::Im
 				);
 				client_methods.push(client_method);
 			}
+			_ => continue,
 		}
 	}
 	Ok(client_methods)

--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -218,7 +218,7 @@ impl RpcMethod {
 			} else if param_types.is_empty() {
 				quote! { let params = params.expect_no_params(); }
 			} else if self.attr.raw_params {
-				quote! { let params: Result<_> = Ok((params,)); }
+				quote! { let params: _jsonrpc_core::Result<_> = Ok((params,)); }
 			} else {
 				quote! { let params = params.parse::<(#(#param_types, )*)>(); }
 			}

--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -229,16 +229,6 @@ impl RpcMethod {
 		let extra_closure_args: &Vec<_> = &special_args.iter().cloned().map(|arg| arg.0).collect();
 		let extra_method_types: &Vec<_> = &special_args.iter().cloned().map(|arg| arg.1).collect();
 
-		if self.attr.is_notification() {
-			match result {
-				syn::ReturnType::Default => {}
-				syn::ReturnType::Type(_, ret) => match **ret {
-					syn::Type::Tuple(ref tup) if tup.elems.empty_or_trailing() => {}
-					_ => return Err(syn::Error::new_spanned(&result, &"Notifications must return ()")),
-				},
-			}
-		}
-
 		let closure_args = quote! { base, params, #(#extra_closure_args), * };
 		let method_sig = quote! { fn(&Self, #(#extra_method_types, ) * #(#param_types), *) #result };
 		let method_call = quote! { (base, #(#extra_closure_args, )* #(#tuple_fields), *) };

--- a/derive/tests/macros.rs
+++ b/derive/tests/macros.rs
@@ -14,20 +14,25 @@ type Result<T> = ::std::result::Result<T, MyError>;
 
 #[rpc]
 pub trait Rpc {
-	/// Returns a protocol version
+	/// Returns a protocol version.
 	#[rpc(name = "protocolVersion")]
 	fn protocol_version(&self) -> Result<String>;
 
-	/// Negates number and returns a result
+	/// Negates number and returns a result.
 	#[rpc(name = "neg")]
 	fn neg(&self, a: i64) -> Result<i64>;
 
-	/// Adds two numbers and returns a result
+	/// Adds two numbers and returns a result.
 	#[rpc(name = "add", alias("add_alias1", "add_alias2"))]
 	fn add(&self, a: u64, b: u64) -> Result<u64>;
 
+	/// Retrieves and debug prints the underlying `Params` object.
 	#[rpc(name = "raw", raw_params)]
 	fn raw(&self, params: Params) -> Result<String>;
+
+	/// Responds to a notification.
+	#[notification(name = "notify")]
+	fn notify(&self, a: u64);
 }
 
 #[derive(Default)]
@@ -48,6 +53,10 @@ impl Rpc for RpcImpl {
 
 	fn raw(&self, _params: Params) -> Result<String> {
 		Ok("OK".into())
+	}
+
+	fn notify(&self, a: u64) {
+		println!("Received `notify` with value: {}", a);
 	}
 }
 

--- a/derive/tests/macros.rs
+++ b/derive/tests/macros.rs
@@ -31,7 +31,7 @@ pub trait Rpc {
 	fn raw(&self, params: Params) -> Result<String>;
 
 	/// Handles a notification.
-	#[notification(name = "notify")]
+	#[rpc(name = "notify")]
 	fn notify(&self, a: u64);
 }
 

--- a/derive/tests/macros.rs
+++ b/derive/tests/macros.rs
@@ -30,7 +30,7 @@ pub trait Rpc {
 	#[rpc(name = "raw", raw_params)]
 	fn raw(&self, params: Params) -> Result<String>;
 
-	/// Responds to a notification.
+	/// Handles a notification.
 	#[notification(name = "notify")]
 	fn notify(&self, a: u64);
 }

--- a/derive/tests/pubsub-macros.rs
+++ b/derive/tests/pubsub-macros.rs
@@ -35,7 +35,7 @@ pub trait Rpc {
 	fn add(&self, a: u64, b: u64) -> Result<u64>;
 
 	/// A notification alongside pubsub.
-	#[notification(name = "notify")]
+	#[rpc(name = "notify")]
 	fn notify(&self, a: u64);
 }
 

--- a/derive/tests/pubsub-macros.rs
+++ b/derive/tests/pubsub-macros.rs
@@ -22,7 +22,7 @@ type Result<T> = ::std::result::Result<T, MyError>;
 pub trait Rpc {
 	type Metadata;
 
-	/// Hello subscription
+	/// Hello subscription.
 	#[pubsub(subscription = "hello", subscribe, name = "hello_subscribe", alias("hello_alias"))]
 	fn subscribe(&self, a: Self::Metadata, b: Subscriber<String>, c: u32, d: Option<u64>);
 
@@ -30,9 +30,13 @@ pub trait Rpc {
 	#[pubsub(subscription = "hello", unsubscribe, name = "hello_unsubscribe")]
 	fn unsubscribe(&self, a: Option<Self::Metadata>, b: SubscriptionId) -> Result<bool>;
 
-	/// A regular rpc method alongside pubsub
+	/// A regular rpc method alongside pubsub.
 	#[rpc(name = "add")]
 	fn add(&self, a: u64, b: u64) -> Result<u64>;
+
+	/// A notification alongside pubsub.
+	#[notification(name = "notify")]
+	fn notify(&self, a: u64);
 }
 
 #[derive(Default)]
@@ -51,6 +55,10 @@ impl Rpc for RpcImpl {
 
 	fn add(&self, a: u64, b: u64) -> Result<u64> {
 		Ok(a + b)
+	}
+
+	fn notify(&self, a: u64) {
+		println!("Received `notify` with value: {}", a);
 	}
 }
 


### PR DESCRIPTION
### Added

* Add support for notifications to the `#[rpc]` macro in `jsonrpc-derive`. Annotating a trait method that returns `()` with `#[rpc]` will register a JSON-RPC notification.

### Changed

* Add missing `IoDelegate::add_notification_with_meta()` method. This was necessary for getting the `#[notification]` attribute to support the `meta` meta word.
* Update `meta-macros` example to include notification usage.
* Update `macros` and `pubsub-macros` integration tests.

### Fixed

* Improve type inference for `raw_params` in `to_delegate.rs` (introduced with #452) with a type annotation so it works for notification methods (the only trait methods which don't return a `T: IntoFuture`).

Closes #252.

---

Note that I had to make a change to `IoDelegate` in `jsonrpc-core` to make this work. It already had `add_method()`, `add_method_with_meta()`, and `add_notification()` methods, but lacked an `add_notification_with_meta()`. I added this method so notifications could reach feature parity with standard JSON-RPC methods and pubsub methods and support metadata as well.

I've updated the `meta-macros` example to include a notification, and all seems to work well. Please let me know if there is anything I should fix or improve!