### PR TITLE
Add client transport over unix domain socket

### DIFF
--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -22,6 +22,7 @@ categories = [
 tls = ["jsonrpc-client-transports/tls"]
 http = ["jsonrpc-client-transports/http"]
 ws = ["jsonrpc-client-transports/ws"]
+uds = ["jsonrpc-client-transports/uds"]
 
 [dependencies]
 jsonrpc-client-transports = { version = "12.1", path = "./transports", default-features = false }

--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -26,6 +26,7 @@ ws = [
 	"websocket",
 	"tokio",
 ]
+uds = ["tokio", "tokio-uds"]
 
 [dependencies]
 failure = "0.1"
@@ -38,11 +39,13 @@ log = "0.4"
 serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "0.1", optional = true }
+tokio-uds = { version = "0.2", optional = true }
 websocket = { version = "0.23", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.1"
 jsonrpc-http-server = { version = "12.1", path = "../../http" }
+jsonrpc-ipc-server = { path = "../../ipc" }
 lazy_static = "1.0"
 env_logger = "0.6"
 tokio = "0.1"

--- a/core-client/transports/src/transports/mod.rs
+++ b/core-client/transports/src/transports/mod.rs
@@ -10,6 +10,8 @@ pub mod duplex;
 #[cfg(feature = "http")]
 pub mod http;
 pub mod local;
+#[cfg(all(unix, feature = "uds"))]
+pub mod uds;
 #[cfg(feature = "ws")]
 pub mod ws;
 

--- a/core-client/transports/src/transports/uds.rs
+++ b/core-client/transports/src/transports/uds.rs
@@ -1,0 +1,178 @@
+//! JSON-RPC unix domain socket client implementation.
+use crate::{RpcChannel, RpcError};
+use failure::Error;
+use futures::prelude::*;
+use std::{collections::VecDeque, path::Path};
+use tokio::codec::{Framed, LinesCodec};
+use tokio_uds::UnixStream;
+
+/// Connect to a JSON-RPC UDS server.
+pub fn connect<P, T>(path: P) -> impl Future<Item = T, Error = RpcError>
+where
+	P: AsRef<Path>,
+	T: From<RpcChannel>,
+{
+	UnixStream::connect(path)
+		.map(|unix_stream| {
+			let (sink, stream) = Framed::new(unix_stream, LinesCodec::new()).split();
+			let (sink, stream) = UdsClient::new(sink, stream).split();
+			let (rpc_client, sender) = super::duplex(sink, stream);
+			let rpc_client = rpc_client.map_err(|error| eprintln!("{:?}", error));
+			tokio::spawn(rpc_client);
+			sender.into()
+		})
+		.map_err(|error| RpcError::Other(error.into()))
+}
+
+/// Intermediate step in uds pipeline between tokio-uds and duplex sink and
+/// stream converting between io and rpc errors.
+struct UdsClient<TSink, TStream> {
+	sink: TSink,
+	stream: TStream,
+	queue: VecDeque<String>,
+}
+
+impl<TSink, TStream, TError> UdsClient<TSink, TStream>
+where
+	TSink: Sink<SinkItem = String, SinkError = TError>,
+	TStream: Stream<Item = String, Error = TError>,
+	TError: Into<Error>,
+{
+	pub fn new(sink: TSink, stream: TStream) -> Self {
+		Self {
+			sink,
+			stream,
+			queue: VecDeque::new(),
+		}
+	}
+}
+
+impl<TSink, TStream, TError> Sink for UdsClient<TSink, TStream>
+where
+	TSink: Sink<SinkItem = String, SinkError = TError>,
+	TStream: Stream<Item = String, Error = TError>,
+	TError: Into<Error>,
+{
+	type SinkItem = String;
+	type SinkError = RpcError;
+
+	fn start_send(&mut self, request: Self::SinkItem) -> Result<AsyncSink<Self::SinkItem>, Self::SinkError> {
+		self.queue.push_back(request);
+		Ok(AsyncSink::Ready)
+	}
+
+	fn poll_complete(&mut self) -> Result<Async<()>, Self::SinkError> {
+		loop {
+			match self.queue.pop_front() {
+				Some(request) => match self.sink.start_send(request) {
+					Ok(AsyncSink::Ready) => continue,
+					Ok(AsyncSink::NotReady(request)) => {
+						self.queue.push_front(request);
+						break;
+					}
+					Err(error) => return Err(RpcError::Other(error.into())),
+				},
+				None => break,
+			}
+		}
+		self.sink.poll_complete().map_err(|error| RpcError::Other(error.into()))
+	}
+}
+
+impl<TSink, TStream, TError> Stream for UdsClient<TSink, TStream>
+where
+	TSink: Sink<SinkItem = String, SinkError = TError>,
+	TStream: Stream<Item = String, Error = TError>,
+	TError: Into<Error>,
+{
+	type Item = String;
+	type Error = RpcError;
+
+	fn poll(&mut self) -> Result<Async<Option<Self::Item>>, Self::Error> {
+		match self.stream.poll() {
+			Ok(Async::Ready(Some(data))) => Ok(Async::Ready(Some(data))),
+			Ok(Async::Ready(None)) => Ok(Async::Ready(None)),
+			Ok(Async::NotReady) => Ok(Async::NotReady),
+			Err(error) => Err(RpcError::Other(error.into())),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::*;
+	use jsonrpc_core::{Error, ErrorCode, IoHandler, Params, Value};
+	use jsonrpc_ipc_server::ServerBuilder;
+	use serde_json::map::Map;
+	use tokio::runtime::Runtime;
+
+	#[test]
+	fn should_call_one() {
+		let sock_path = "/tmp/json-ipc-test.ipc";
+		let mut io = IoHandler::new();
+		io.add_method("greeting", |params| {
+			let map_obj = match params {
+				Params::Map(obj) => obj,
+				_ => return Err(Error::invalid_params("missing object")),
+			};
+			let name = match map_obj.get("name") {
+				Some(val) => val.as_str().unwrap(),
+				None => return Err(Error::invalid_params("no name")),
+			};
+			Ok(Value::String(format!("Hello {}!", name)))
+		});
+		let mut rt = Runtime::new().unwrap();
+		let builder = ServerBuilder::new(io).event_loop_executor(rt.executor());
+		let server = builder.start(sock_path).expect("Couldn't open socket");
+		let fut = connect(sock_path).and_then(|client: RawClient| {
+			let mut map = Map::new();
+			map.insert("name".to_string(), "Jeffry".into());
+			client.call_method("greeting", Params::Map(map))
+		});
+		match rt.block_on(fut) {
+			Ok(val) => assert_eq!(&val, "Hello Jeffry!"),
+			Err(err) => panic!("UDS RPC call failed: {}", err),
+		}
+		server.close();
+		rt.shutdown_now().wait().unwrap();
+	}
+
+	#[test]
+	fn should_fail_without_server() {
+		let mut rt = Runtime::new().unwrap();
+		let fut = connect("/tmp/json-ipc-test.ipc").and_then(|client: RawClient| {
+			let mut map = Map::new();
+			map.insert("name".to_string(), "Bill".into());
+			client.call_method("greeting", Params::Map(map))
+		});
+		match rt.block_on(fut) {
+			Err(RpcError::Other(_)) => (),
+			Ok(_) => panic!("Expected the call to fail"),
+			_ => panic!("Unexpected error type"),
+		}
+		rt.shutdown_now().wait().unwrap();
+	}
+
+	#[test]
+	fn should_handle_server_error() {
+		let sock_path = "/tmp/json-ipc-test.ipc";
+		let mut io = IoHandler::new();
+		io.add_method("greeting", |_params| Err(Error::invalid_params("test error")));
+		let mut rt = Runtime::new().unwrap();
+		let builder = ServerBuilder::new(io).event_loop_executor(rt.executor());
+		let server = builder.start(sock_path).expect("Couldn't open socket");
+		let fut = connect(sock_path).and_then(|client: RawClient| {
+			let mut map = Map::new();
+			map.insert("name".to_string(), "Jeffry".into());
+			client.call_method("greeting", Params::Map(map))
+		});
+		match rt.block_on(fut) {
+			Err(RpcError::JsonRpcError(err)) => assert_eq!(err.code, ErrorCode::InvalidParams),
+			Ok(_) => panic!("Expected the call to fail"),
+			_ => panic!("Unexpected error type"),
+		}
+		server.close();
+		rt.shutdown_now().wait().unwrap();
+	}
+}


### PR DESCRIPTION
I have noticed there is IPC server but no client implementation. I needed that for my project so I decided to add it. It's not IPC but unix domain socket (UDS) transport. So it does not work on windows unlike IPC, but I hope it can be still useful for people until it is replaced by IPC client.

A couple of remarks about the fix itself. Without much knowledge of jsonrpc implementation I took websocket transport implementation as a starting point and made minimal changes to it to make it work for UDS. I added three new test cases. All I ever tested are single method calls. I did not test subscribe functionality as I don't need that in my project. I have chosen newline as the delimiter between the messages sent over UDS. The uds feature is optional and turned off by default.

I will appreciate any help with making the PR to meet quality standards of jsonrpc code. Thanks!