### PR TITLE
ipc: Allow specifying different event loop reactor in server builder

### DIFF
--- a/ipc/src/server.rs
+++ b/ipc/src/server.rs
@@ -50,6 +50,7 @@ pub struct ServerBuilder<M: Metadata = (), S: Middleware<M> = middleware::Noop> 
 	meta_extractor: Arc<dyn MetaExtractor<M>>,
 	session_stats: Option<Arc<dyn session::SessionStats>>,
 	executor: reactor::UninitializedExecutor,
+	reactor: Handle,
 	incoming_separator: codecs::Separator,
 	outgoing_separator: codecs::Separator,
 	security_attributes: SecurityAttributes,
@@ -78,6 +79,7 @@ impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
 			meta_extractor: Arc::new(extractor),
 			session_stats: None,
 			executor: reactor::UninitializedExecutor::Unspawned,
+			reactor: Handle::default(),
 			incoming_separator: codecs::Separator::Empty,
 			outgoing_separator: codecs::Separator::default(),
 			security_attributes: SecurityAttributes::empty(),
@@ -88,6 +90,12 @@ impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
 	/// Sets shared different event loop executor.
 	pub fn event_loop_executor(mut self, executor: TaskExecutor) -> Self {
 		self.executor = reactor::UninitializedExecutor::Shared(executor);
+		self
+	}
+
+	/// Sets different event loop I/O reactor.
+	pub fn event_loop_reactor(mut self, reactor: Handle) -> Self {
+		self.reactor = reactor;
 		self
 	}
 
@@ -128,6 +136,7 @@ impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
 	/// Creates a new server from the given endpoint.
 	pub fn start(self, path: &str) -> std::io::Result<Server> {
 		let executor = self.executor.initialize()?;
+		let reactor = self.reactor;
 		let rpc_handler = self.handler;
 		let endpoint_addr = path.to_owned();
 		let meta_extractor = self.meta_extractor;
@@ -151,8 +160,7 @@ impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
 				}
 			}
 
-			let endpoint_handle = Handle::default();
-			let connections = match endpoint.incoming(&endpoint_handle) {
+			let connections = match endpoint.incoming(&reactor) {
 				Ok(connections) => connections,
 				Err(e) => {
 					start_signal


### PR DESCRIPTION
Right now we use `Handle::default()` (which should lazily bind to a reactor) when creating an `IpcConnection` but that surprisingly doesn't work with either the user-specified executor or the lazily spawned pool as the fallback executor on Windows (only tested on Windows 10).

Using a simple [`Runtime::reactor`](https://docs.rs/tokio/0.1.22/tokio/runtime/struct.Runtime.html#method.reactor) works, so to work around the issue I'd like be able to specify a custom reactor to be used (which seems somewhat useful on its own, hopefully).

Disclaimer: I'm not yet well versed in the async-fu so I might be missing something obvious here, please correct me if I'm wrong.