### PR TITLE
Add an IPC client transport using parity-tokio-ipc

### DIFF
--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -22,6 +22,7 @@ categories = [
 tls = ["jsonrpc-client-transports/tls"]
 http = ["jsonrpc-client-transports/http"]
 ws = ["jsonrpc-client-transports/ws"]
+ipc = ["jsonrpc-client-transports/ipc"]
 
 [dependencies]
 jsonrpc-client-transports = { version = "13.0", path = "./transports", default-features = false }

--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -26,6 +26,11 @@ ws = [
 	"websocket",
 	"tokio",
 ]
+ipc = [
+	"parity-tokio-ipc",
+	"jsonrpc-server-utils",
+	"tokio",
+]
 
 [dependencies]
 failure = "0.1"
@@ -34,7 +39,9 @@ hyper = { version = "0.12", optional = true }
 hyper-tls = { version = "0.3.2", optional = true }
 jsonrpc-core = { version = "13.0", path = "../../core" }
 jsonrpc-pubsub = { version = "13.0", path = "../../pubsub" }
+jsonrpc-server-utils = { version = "13.0", path = "../../server-utils", optional = true }
 log = "0.4"
+parity-tokio-ipc = { version = "0.1", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "0.1", optional = true }
@@ -43,9 +50,10 @@ websocket = { version = "0.23", optional = true }
 [dev-dependencies]
 assert_matches = "1.1"
 jsonrpc-http-server = { version = "13.0", path = "../../http" }
+jsonrpc-ipc-server = { version = "13.0", path = "../../ipc" }
 lazy_static = "1.0"
 env_logger = "0.6"
 tokio = "0.1"
 
 [badges]
-travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}
+travis-ci = { repository = "paritytech/jsonrpc", branch = "master" }

--- a/core-client/transports/src/transports/ipc.rs
+++ b/core-client/transports/src/transports/ipc.rs
@@ -1,0 +1,125 @@
+//! JSON-RPC IPC client implementation using Unix Domain Sockets on UNIX-likes
+//! and Named Pipes on Windows.
+
+use crate::transports::duplex::duplex;
+use crate::{RpcChannel, RpcError};
+use futures::prelude::*;
+use jsonrpc_server_utils::codecs::StreamCodec;
+use parity_tokio_ipc::IpcConnection;
+use std::io;
+use std::path::Path;
+use tokio::codec::Decoder;
+
+/// Connect to a JSON-RPC IPC server.
+pub fn connect<P: AsRef<Path>, Client: From<RpcChannel>>(
+	path: P,
+	reactor: &tokio::reactor::Handle,
+) -> Result<impl Future<Item = Client, Error = RpcError>, io::Error> {
+	let connection = IpcConnection::connect(path, reactor)?;
+
+	Ok(futures::lazy(move || {
+		let (sink, stream) = StreamCodec::stream_incoming().framed(connection).split();
+		let sink = sink.sink_map_err(|e| RpcError::Other(e.into()));
+		let stream = stream.map_err(|e| RpcError::Other(e.into()));
+
+		let (client, sender) = duplex(sink, stream);
+
+		tokio::spawn(client.map_err(|e| log::warn!("IPC client error: {:?}", e)));
+		Ok(sender.into())
+	}))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::*;
+	use jsonrpc_core::{Error, ErrorCode, IoHandler, Params, Value};
+	use jsonrpc_ipc_server::ServerBuilder;
+	use parity_tokio_ipc::dummy_endpoint;
+	use serde_json::map::Map;
+	use tokio::runtime::Runtime;
+
+	#[test]
+	fn should_call_one() {
+		let mut rt = Runtime::new().unwrap();
+		#[allow(deprecated)]
+		let reactor = rt.reactor().clone();
+		let sock_path = dummy_endpoint();
+
+		let mut io = IoHandler::new();
+		io.add_method("greeting", |params| {
+			let map_obj = match params {
+				Params::Map(obj) => obj,
+				_ => return Err(Error::invalid_params("missing object")),
+			};
+			let name = match map_obj.get("name") {
+				Some(val) => val.as_str().unwrap(),
+				None => return Err(Error::invalid_params("no name")),
+			};
+			Ok(Value::String(format!("Hello {}!", name)))
+		});
+		let builder = ServerBuilder::new(io).event_loop_executor(rt.executor());
+		let server = builder.start(&sock_path).expect("Couldn't open socket");
+
+		let client: RawClient = rt.block_on(connect(sock_path, &reactor).unwrap()).unwrap();
+		let mut map = Map::new();
+		map.insert("name".to_string(), "Jeffry".into());
+		let fut = client.call_method("greeting", Params::Map(map));
+
+		// FIXME: it seems that IPC server on Windows won't be polled with
+		// default I/O reactor, work around with sending stop signal which polls
+		// the server (https://github.com/paritytech/jsonrpc/pull/459)
+		server.close();
+
+		match rt.block_on(fut) {
+			Ok(val) => assert_eq!(&val, "Hello Jeffry!"),
+			Err(err) => panic!("IPC RPC call failed: {}", err),
+		}
+		rt.shutdown_now().wait().unwrap();
+	}
+
+	// Windows currently panics in `IpcConnection::connect` if a given path doesn't exist
+	#[cfg(not(windows))]
+	#[test]
+	fn should_fail_without_server() {
+		let rt = Runtime::new().unwrap();
+		#[allow(deprecated)]
+		let reactor = rt.reactor();
+
+		match connect::<_, RawClient>(dummy_endpoint(), reactor) {
+			Err(..) => {}
+			Ok(..) => panic!("Should not be able to connect to an IPC socket that's not open"),
+		}
+		rt.shutdown_now().wait().unwrap();
+	}
+
+	#[test]
+	fn should_handle_server_error() {
+		let mut rt = Runtime::new().unwrap();
+		#[allow(deprecated)]
+		let reactor = rt.reactor().clone();
+		let sock_path = dummy_endpoint();
+
+		let mut io = IoHandler::new();
+		io.add_method("greeting", |_params| Err(Error::invalid_params("test error")));
+		let builder = ServerBuilder::new(io).event_loop_executor(rt.executor());
+		let server = builder.start(&sock_path).expect("Couldn't open socket");
+
+		let client: RawClient = rt.block_on(connect(sock_path, &reactor).unwrap()).unwrap();
+		let mut map = Map::new();
+		map.insert("name".to_string(), "Jeffry".into());
+		let fut = client.call_method("greeting", Params::Map(map));
+
+		// FIXME: it seems that IPC server on Windows won't be polled with
+		// default I/O reactor, work around with sending stop signal which polls
+		// the server (https://github.com/paritytech/jsonrpc/pull/459)
+		server.close();
+
+		match rt.block_on(fut) {
+			Err(RpcError::JsonRpcError(err)) => assert_eq!(err.code, ErrorCode::InvalidParams),
+			Ok(_) => panic!("Expected the call to fail"),
+			_ => panic!("Unexpected error type"),
+		}
+		rt.shutdown_now().wait().unwrap();
+	}
+}

--- a/core-client/transports/src/transports/ipc.rs
+++ b/core-client/transports/src/transports/ipc.rs
@@ -78,7 +78,8 @@ mod tests {
 		rt.shutdown_now().wait().unwrap();
 	}
 
-	// Windows currently panics in `IpcConnection::connect` if a given path doesn't exist
+	// Windows currently panics in `IpcConnection::connect` if a given path doesn't exist.
+	// Should be fixed by https://github.com/NikVolf/parity-tokio-ipc/pull/12
 	#[cfg(not(windows))]
 	#[test]
 	fn should_fail_without_server() {

--- a/core-client/transports/src/transports/mod.rs
+++ b/core-client/transports/src/transports/mod.rs
@@ -10,6 +10,8 @@ use crate::{CallMessage, RpcError};
 pub mod duplex;
 #[cfg(feature = "http")]
 pub mod http;
+#[cfg(feature = "ipc")]
+pub mod ipc;
 pub mod local;
 #[cfg(feature = "ws")]
 pub mod ws;


### PR DESCRIPTION
An IPC version of https://github.com/paritytech/jsonrpc/pull/455.

Key differences:
- `parity_tokio_ipc::IpcConnection` requires an already running event loop (can probably be adapted upstream to use futures-only style) whereas `UnixStream::connect` (which it wraps on Unices) returns only a future
- Uses a stream codec (from server-utils) rather than newline-separated messages

As I mentioned in https://github.com/paritytech/jsonrpc/pull/459 I encountered a bug where the server will not be polled using lazily-bound I/O reactor. To work around it, in the test cases I need to signal it to stop using `server.close()` to make it progress, which is less than ideal (but makes it work cross-platform). Being able to specify custom reactor in ServerBuilder (https://github.com/paritytech/jsonrpc/pull/459) fixes the issue.

I'm not sure whether it's because of how `IpcConnection` is created. Maybe moving it to future-only style would fix the reactor binding on Windows? I'll experiment and get back with results.