### PR TITLE
Remove Notification from Output type.

### DIFF
--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -35,7 +35,7 @@ hyper-tls = { version = "0.3.2", optional = true }
 jsonrpc-core = { version = "13.0", path = "../../core" }
 jsonrpc-pubsub = { version = "13.0", path = "../../pubsub" }
 log = "0.4"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "0.1", optional = true }
 websocket = { version = "0.23", optional = true }

--- a/core-client/transports/src/transports/duplex.rs
+++ b/core-client/transports/src/transports/duplex.rs
@@ -166,16 +166,16 @@ where
 				Err(err) => Err(err)?,
 			};
 			log::debug!("incoming: {}", response_str);
-			for (id, result, method, sid) in super::parse_response(&response_str)? {
-				log::debug!(
-					"id: {:?} (sid: {:?}) result: {:?} method: {:?}",
-					id,
-					sid,
-					result,
-					method
-				);
-				self.incoming.push_back((id, result, method, sid));
-			}
+			// we only send one request at the time, so there can only be one response.
+			let (id, result, method, sid) = super::parse_response(&response_str)?;
+			log::debug!(
+				"id: {:?} (sid: {:?}) result: {:?} method: {:?}",
+				id,
+				sid,
+				result,
+				method
+			);
+			self.incoming.push_back((id, result, method, sid));
 		}
 
 		// Handle incoming queue.

--- a/core-client/transports/src/transports/http.rs
+++ b/core-client/transports/src/transports/http.rs
@@ -82,16 +82,7 @@ where
 						let response_str = String::from_utf8_lossy(response.as_ref()).into_owned();
 						super::parse_response(&response_str)
 					})
-					.and_then(|responses| {
-						if responses.len() == 1 {
-							responses.into_iter().nth(0).expect("Exactly one response; qed").1
-						} else {
-							Err(RpcError::Other(format_err!(
-								"Transport currently only supports Single requests"
-							)))
-						}
-					});
-
+					.and_then(|r| r.1);
 				if let Err(err) = msg.sender.send(response) {
 					log::warn!("Error resuming asynchronous request: {:?}", err);
 				}

--- a/core-client/transports/src/transports/mod.rs
+++ b/core-client/transports/src/transports/mod.rs
@@ -1,7 +1,8 @@
 //! Client transport implementations
 
-use jsonrpc_core::{Call, Error, Id, MethodCall, Output, Params, Response, Version};
+use jsonrpc_core::{Call, Error, Id, MethodCall, Params, Version};
 use jsonrpc_pubsub::SubscriptionId;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{CallMessage, RpcError};
@@ -60,27 +61,143 @@ impl RequestBuilder {
 	}
 }
 
-/// Parse raw string into JSON values, together with the request Id
+/// Parse raw string into a single JSON value, together with the request Id.
+///
+/// This method will attempt to parse a JSON-RPC response object (either `Failure` or `Success`)
+/// and a `Notification` (for Subscriptions).
+/// Note that if you have more specific expectations about the returned type and don't want
+/// to handle all of them it might be best to deserialize on your own.
 pub fn parse_response(
 	response: &str,
-) -> Result<Vec<(Id, Result<Value, RpcError>, Option<String>, Option<SubscriptionId>)>, RpcError> {
-	serde_json::from_str::<Response>(&response)
+) -> Result<(Id, Result<Value, RpcError>, Option<String>, Option<SubscriptionId>), RpcError> {
+	serde_json::from_str::<ClientResponse>(&response)
 		.map_err(|e| RpcError::ParseError(e.to_string(), e.into()))
 		.map(|response| {
-			let outputs: Vec<Output> = match response {
-				Response::Single(output) => vec![output],
-				Response::Batch(outputs) => outputs,
-			};
-			outputs
-				.into_iter()
-				.map(|output| {
-					let id = output.id().clone();
-					let sid = SubscriptionId::parse_output(&output);
-					let method = output.method();
-					let value: Result<Value, Error> = output.into();
-					let result = value.map_err(RpcError::JsonRpcError);
-					(id, result, method, sid)
-				})
-				.collect::<Vec<_>>()
+			let id = response.id().unwrap_or(Id::Null);
+			let sid = response.subscription_id();
+			let method = response.method();
+			let value: Result<Value, Error> = response.into();
+			let result = value.map_err(RpcError::JsonRpcError);
+			(id, result, method, sid)
 		})
+}
+
+/// A type representing all possible values sent from the server to the client.
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[serde(untagged)]
+pub enum ClientResponse {
+	/// A regular JSON-RPC request output (single response).
+	Output(jsonrpc_core::Output),
+	/// A notification.
+	Notification(jsonrpc_core::Notification),
+}
+
+impl ClientResponse {
+	/// Get the id of the response (if any).
+	pub fn id(&self) -> Option<Id> {
+		match *self {
+			ClientResponse::Output(ref output) => Some(output.id().clone()),
+			ClientResponse::Notification(_) => None,
+		}
+	}
+
+	/// Get the method name if the output is a notification.
+	pub fn method(&self) -> Option<String> {
+		match *self {
+			ClientResponse::Notification(ref n) => Some(n.method.to_owned()),
+			ClientResponse::Output(_) => None,
+		}
+	}
+
+	/// Parses the response into a subscription id.
+	pub fn subscription_id(&self) -> Option<SubscriptionId> {
+		match *self {
+			ClientResponse::Notification(ref n) => match &n.params {
+				jsonrpc_core::Params::Map(map) => match map.get("subscription") {
+					Some(value) => SubscriptionId::parse_value(value),
+					None => None,
+				},
+				_ => None,
+			},
+			_ => None,
+		}
+	}
+}
+
+impl From<ClientResponse> for Result<Value, Error> {
+	fn from(res: ClientResponse) -> Self {
+		match res {
+			ClientResponse::Output(output) => output.into(),
+			ClientResponse::Notification(n) => match &n.params {
+				Params::Map(map) => {
+					let subscription = map.get("subscription");
+					let result = map.get("result");
+					let error = map.get("error");
+
+					match (subscription, result, error) {
+						(Some(_), Some(result), _) => Ok(result.to_owned()),
+						(Some(_), _, Some(error)) => {
+							let error = serde_json::from_value::<Error>(error.to_owned())
+								.ok()
+								.unwrap_or_else(|| Error::parse_error());
+							Err(error)
+						}
+						_ => Ok(n.params.into()),
+					}
+				}
+				_ => Ok(n.params.into()),
+			},
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use jsonrpc_core::{Value, Version, Params, Failure, Success, Output, Notification};
+	use serde_json;
+
+	#[test]
+	fn notification_deserialize() {
+		let dsr = r#"{"jsonrpc":"2.0","method":"hello","params":[10]}"#;
+		let deserialized: ClientResponse = serde_json::from_str(dsr).unwrap();
+		assert_eq!(
+			deserialized,
+			ClientResponse::Notification(Notification {
+				jsonrpc: Some(Version::V2),
+				method: "hello".into(),
+				params: Params::Array(vec![Value::from(10)]),
+			})
+		);
+	}
+
+	#[test]
+	fn success_deserialize() {
+		let dsr = r#"{"jsonrpc":"2.0","result":1,"id":1}"#;
+		let deserialized: ClientResponse = serde_json::from_str(dsr).unwrap();
+		assert_eq!(
+			deserialized,
+			ClientResponse::Output(Output::Success(Success {
+				jsonrpc: Some(Version::V2),
+				id: Id::Num(1),
+				result: 1.into(),
+			}))
+		);
+	}
+
+	#[test]
+	fn failure_output_deserialize() {
+		let dfo = r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":1}"#;
+
+		let deserialized: ClientResponse = serde_json::from_str(dfo).unwrap();
+		assert_eq!(
+			deserialized,
+			ClientResponse::Output(Output::Failure(Failure {
+				jsonrpc: Some(Version::V2),
+				error: Error::parse_error(),
+				id: Id::Num(1)
+			}))
+		);
+	}
 }

--- a/pubsub/src/types.rs
+++ b/pubsub/src/types.rs
@@ -53,20 +53,6 @@ impl SubscriptionId {
 			_ => None,
 		}
 	}
-
-	/// Parses an output into a subscription id.
-	pub fn parse_output(output: &core::Output) -> Option<SubscriptionId> {
-		match output {
-			core::Output::Notification(n) => match &n.params {
-				core::Params::Map(map) => match map.get("subscription") {
-					Some(value) => Self::parse_value(value),
-					None => None,
-				},
-				_ => None,
-			},
-			_ => None,
-		}
-	}
 }
 
 impl From<String> for SubscriptionId {

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -129,10 +129,6 @@ impl Rpc {
 				Encoding::Compact => serde_json::to_string(&error),
 				Encoding::Pretty => serde_json::to_string_pretty(&error),
 			},
-			response::Output::Notification(notification) => match encoding {
-				Encoding::Compact => serde_json::to_string(&notification),
-				Encoding::Pretty => serde_json::to_string_pretty(&notification),
-			},
 		}
 		.expect("Serialization is infallible; qed");
 


### PR DESCRIPTION
Resolves #458

We should backport it to 12.2 and after it's released consider yanking 12.1