### PR TITLE
Add notification to std example in jsonrpc-derive

### DIFF
--- a/derive/examples/meta-macros.rs
+++ b/derive/examples/meta-macros.rs
@@ -37,7 +37,7 @@ pub trait Rpc<One> {
 	#[rpc(meta, name = "callAsyncMeta", alias("callAsyncMetaAlias"))]
 	fn call_meta(&self, a: Self::Metadata, b: BTreeMap<String, Value>) -> FutureResult<String, Error>;
 
-	/// Handles notification.
+	/// Handles a notification.
 	#[rpc(name = "notify")]
 	fn notify(&self, a: u64);
 }

--- a/derive/examples/std.rs
+++ b/derive/examples/std.rs
@@ -8,17 +8,21 @@ use jsonrpc_derive::rpc;
 /// Rpc trait
 #[rpc]
 pub trait Rpc {
-	/// Returns a protocol version
+	/// Returns a protocol version.
 	#[rpc(name = "protocolVersion")]
 	fn protocol_version(&self) -> Result<String>;
 
-	/// Adds two numbers and returns a result
+	/// Adds two numbers and returns a result.
 	#[rpc(name = "add", alias("callAsyncMetaAlias"))]
 	fn add(&self, a: u64, b: u64) -> Result<u64>;
 
-	/// Performs asynchronous operation
+	/// Performs asynchronous operation.
 	#[rpc(name = "callAsync")]
 	fn call(&self, a: u64) -> FutureResult<String, Error>;
+
+	/// Handles a notification.
+	#[rpc(name = "notify")]
+	fn notify(&self, a: u64);
 }
 
 struct RpcImpl;
@@ -34,6 +38,10 @@ impl Rpc for RpcImpl {
 
 	fn call(&self, _: u64) -> FutureResult<String, Error> {
 		future::ok("OK".to_owned())
+	}
+
+	fn notify(&self, a: u64) {
+		println!("Received `notify` with value: {}", a);
 	}
 }
 


### PR DESCRIPTION
### Added

* Add a notification method to the `std` example in the `jsonrpc-derive` crate.

### Fixed

* Add missing "a" in doc comment.

Since support for notifications is now a basic feature of the `jsonrpc-derive` macro, I thought that a usage example should be provided in the basic example. This was unfortunately missed in #454 and is being introduced here instead.