### PR TITLE
Bump parity-tokio-ipc to 0.2

### DIFF
--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -41,7 +41,7 @@ jsonrpc-core = { version = "13.0", path = "../../core" }
 jsonrpc-pubsub = { version = "13.0", path = "../../pubsub" }
 jsonrpc-server-utils = { version = "13.0", path = "../../server-utils", optional = true }
 log = "0.4"
-parity-tokio-ipc = { version = "0.1", optional = true }
+parity-tokio-ipc = { version = "0.2", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "0.1", optional = true }

--- a/core-client/transports/src/transports/ipc.rs
+++ b/core-client/transports/src/transports/ipc.rs
@@ -78,9 +78,6 @@ mod tests {
 		rt.shutdown_now().wait().unwrap();
 	}
 
-	// Windows currently panics in `IpcConnection::connect` if a given path doesn't exist.
-	// Should be fixed by https://github.com/NikVolf/parity-tokio-ipc/pull/12
-	#[cfg(not(windows))]
 	#[test]
 	fn should_fail_without_server() {
 		let rt = Runtime::new().unwrap();

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4"
 tokio-service = "0.1"
 jsonrpc-core = { version = "13.0", path = "../core" }
 jsonrpc-server-utils = { version = "13.0", path = "../server-utils" }
-parity-tokio-ipc = "0.1"
+parity-tokio-ipc = "0.2"
 parking_lot = "0.9"
 
 [dev-dependencies]


### PR DESCRIPTION
This also fixes an inner panic on Windows if a named pipe doesn't exist.