### PR TITLE
[core-client] add websockets connect method accepting valid Url

### DIFF
--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -46,6 +46,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "0.1", optional = true }
 websocket = { version = "0.23", optional = true }
+url = "1.7"
 
 [dev-dependencies]
 assert_matches = "1.1"


### PR DESCRIPTION
Currently `ws::connect` returns `Result<impl Future<_>>`, and the outer `Result` is only an `Err` if the supplied url is invalid.

This is a bit awkward when connecting to multiple rpc endpoints, and especially when we already have a valid url (parsed by structopt). E.g. I've created the helper method: https://github.com/paritytech/ink/pull/131/commits/aaab5b73e10beb20f94aab32acfd26335deaa4b3#diff-27c243a8ea077bfe4ff1b511702bcb59R229.

^^ **edit** *I've combined the multiple `ws::connect`s into a single one so this is less awkward now in my case - however it might still be useful to be able to pass a valid `Url` if we have one.*

This PR renames the current `connect` to `try_connect` (which attempts to parse the url) and changes `connect` to accept a `Url` struct and return the `impl Future` directly. Not 100% happy with those names so open to any suggestions.