### PR TITLE
Add a method to handle empty response.

### DIFF
--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -530,6 +530,24 @@ mod tests {
 	}
 
 	#[test]
+	fn test_batch_notification() {
+		use std::sync::atomic;
+		use std::sync::Arc;
+
+		let mut io = IoHandler::new();
+
+		let called = Arc::new(atomic::AtomicBool::new(false));
+		let c = called.clone();
+		io.add_notification("say_hello", move |_| {
+			c.store(true, atomic::Ordering::SeqCst);
+		});
+
+		let request = r#"[{"jsonrpc": "2.0", "method": "say_hello", "params": [42, 23]}]"#;
+		assert_eq!(io.handle_request_sync(request), None);
+		assert_eq!(called.load(atomic::Ordering::SeqCst), true);
+	}
+
+	#[test]
 	fn test_send_sync() {
 		fn is_send_sync<T>(_obj: T) -> bool
 		where

--- a/core/src/types/response.rs
+++ b/core/src/types/response.rs
@@ -105,6 +105,17 @@ impl Response {
 		}
 		.into()
 	}
+
+	/// Deserialize `Response` from given JSON string.
+	///
+	/// This method will handle an empty string as empty batch response.
+	pub fn from_json(s: &str) -> Result<Self, serde_json::Error> {
+		if s.is_empty() {
+			Ok(Response::Batch(vec![]))
+		} else {
+			serde_json::from_str(s)
+		}
+	}
 }
 
 impl From<Failure> for Response {
@@ -267,4 +278,16 @@ fn handle_incorrect_responses() {
 		deserialized.is_err(),
 		"Expected error when deserializing invalid payload."
 	);
+}
+
+#[test]
+fn should_parse_empty_response_as_batch() {
+	use serde_json;
+
+	let dsr = r#""#;
+
+	let deserialized1: Result<Response, _>= serde_json::from_str(dsr);
+	let deserialized2: Result<Response, _> = Response::from_json(dsr);
+	assert!(deserialized1.is_err(), "Empty string is not valid JSON, so we should get an error.");
+	assert_eq!(deserialized2.unwrap(), Response::Batch(vec![]));
 }


### PR DESCRIPTION
Closes: #463 

>  If there are no Response objects contained within the Response array as it is to be sent to the client, the server MUST NOT return an empty Array and should return nothing at all.

But the issue is that "empty response" is not valid JSON (at least according to serde), so it's not possible to directly decode empty string to anything.

I'm a bit torn apart by this issue, since on one hand we can just ask the clients to check the empty response, but as a compromise this PR adds a `Response::from_json` helper method to parse the string into `Response` type and handle an empty string case.

@debris please let me know what you think of it.