### PR TITLE
Implement client notification support

### DIFF
--- a/core-client/transports/src/lib.rs
+++ b/core-client/transports/src/lib.rs
@@ -388,6 +388,10 @@ mod tests {
 		fn add(&self, a: u64, b: u64) -> impl Future<Item = u64, Error = RpcError> {
 			self.0.call_method("add", "u64", (a, b))
 		}
+
+		fn status(&self, successful: bool) -> impl Future<Item = (), Error = RpcError> {
+			self.0.notify("status", successful)
+		}
 	}
 
 	#[test]
@@ -413,6 +417,23 @@ mod tests {
 				eprintln!("{:?}", err);
 				assert!(false);
 			});
+		tokio::run(fut);
+	}
+
+	#[test]
+	fn should_send_notification() {
+		crate::logger::init_log();
+		let mut handler = IoHandler::new();
+		handler.add_notification("status", |params: Params| {
+			let successful = params.parse::<bool>().expect("expected to receive one boolean");
+			assert_eq!(successful, true);
+		});
+
+		let (client, rpc_client) = local::connect::<AddClient, _, _>(handler);
+		let fut = client.clone().status(true).join(rpc_client).map(|_| ()).map_err(|err| {
+			eprintln!("{:?}", err);
+			assert!(false);
+		});
 		tokio::run(fut);
 	}
 

--- a/core-client/transports/src/lib.rs
+++ b/core-client/transports/src/lib.rs
@@ -433,6 +433,7 @@ mod tests {
 		let fut = client
 			.clone()
 			.completed(true)
+			.map(move |()| drop(client))
 			.join(rpc_client)
 			.map(|_| ())
 			.map_err(|err| {

--- a/core-client/transports/src/transports/duplex.rs
+++ b/core-client/transports/src/transports/duplex.rs
@@ -144,6 +144,7 @@ where
 					}
 					request_str
 				}
+				RpcMessage::Notify(msg) => self.request_builder.notification(&msg),
 			};
 			log::debug!("outgoing: {}", request_str);
 			self.outgoing.push_back(request_str);

--- a/core-client/transports/src/transports/http.rs
+++ b/core-client/transports/src/transports/http.rs
@@ -43,18 +43,18 @@ where
 
 	let fut = receiver
 		.filter_map(move |msg: RpcMessage| {
-			let msg = match msg {
-				RpcMessage::Call(call) => call,
+			let (request, sender) = match msg {
+				RpcMessage::Call(call) => {
+					let (_, request) = request_builder.call_request(&call);
+					(request, Some(call.sender))
+				}
+				RpcMessage::Notify(notify) => (request_builder.notification(&notify), None),
 				RpcMessage::Subscribe(_) => {
 					log::warn!("Unsupported `RpcMessage` type `Subscribe`.");
 					return None;
 				}
-				RpcMessage::Notify(_) => {
-					log::warn!("Unsupported `RpcMessage` type `Notify`.");
-					return None;
-				}
 			};
-			let (_, request) = request_builder.call_request(&msg);
+
 			let request = Request::post(&url)
 				.header(
 					http::header::CONTENT_TYPE,
@@ -62,10 +62,11 @@ where
 				)
 				.body(request.into())
 				.expect("Uri and request headers are valid; qed");
-			Some(client.request(request).then(move |response| Ok((response, msg))))
+
+			Some(client.request(request).then(move |response| Ok((response, sender))))
 		})
 		.buffer_unordered(max_parallel)
-		.for_each(|(result, msg)| {
+		.for_each(|(result, sender)| {
 			let future = match result {
 				Ok(ref res) if !res.status().is_success() => {
 					log::trace!("http result status {}", res.status());
@@ -81,14 +82,16 @@ where
 				Err(err) => A(future::err(RpcError::Other(err.into()))),
 			};
 			future.then(|result| {
-				let response = result
-					.and_then(|response| {
-						let response_str = String::from_utf8_lossy(response.as_ref()).into_owned();
-						super::parse_response(&response_str)
-					})
-					.and_then(|r| r.1);
-				if let Err(err) = msg.sender.send(response) {
-					log::warn!("Error resuming asynchronous request: {:?}", err);
+				if let Some(sender) = sender {
+					let response = result
+						.and_then(|response| {
+							let response_str = String::from_utf8_lossy(response.as_ref()).into_owned();
+							super::parse_response(&response_str)
+						})
+						.and_then(|r| r.1);
+					if let Err(err) = sender.send(response) {
+						log::warn!("Error resuming asynchronous request: {:?}", err);
+					}
 				}
 				Ok(())
 			})
@@ -163,6 +166,10 @@ mod tests {
 			_ => Ok(Value::String("world".into())),
 		});
 		io.add_method("fail", |_: Params| Err(Error::new(ErrorCode::ServerError(-34))));
+		io.add_notification("notify", |params: Params| {
+			let (value,) = params.parse::<(u64,)>().expect("expected one u64 as param");
+			assert_eq!(value, 12);
+		});
 
 		io
 	}
@@ -182,6 +189,9 @@ mod tests {
 		}
 		fn fail(&self) -> impl Future<Item = (), Error = RpcError> {
 			self.0.call_method("fail", "()", ())
+		}
+		fn notify(&self, value: u64) -> impl Future<Item = (), Error = RpcError> {
+			self.0.notify("notify", (value,))
 		}
 	}
 
@@ -209,6 +219,31 @@ mod tests {
 		// then
 		let result = rx.recv_timeout(Duration::from_secs(3)).unwrap();
 		assert_eq!("hello http", result);
+	}
+
+	#[test]
+	fn should_send_notification() {
+		crate::logger::init_log();
+
+		// given
+		let server = TestServer::serve(id);
+		let (tx, rx) = std::sync::mpsc::channel();
+
+		// when
+		let run = connect(&server.uri)
+			.and_then(|client: TestClient| {
+				client.notify(12).and_then(move |result| {
+					drop(client);
+					let _ = tx.send(result);
+					Ok(())
+				})
+			})
+			.map_err(|e| log::error!("RPC Client error: {:?}", e));
+
+		rt::run(run);
+
+		// then
+		rx.recv_timeout(Duration::from_secs(3)).unwrap();
 	}
 
 	#[test]

--- a/core-client/transports/src/transports/http.rs
+++ b/core-client/transports/src/transports/http.rs
@@ -49,6 +49,10 @@ where
 					log::warn!("Unsupported `RpcMessage` type `Subscribe`.");
 					return None;
 				}
+				RpcMessage::Notify(_) => {
+					log::warn!("Unsupported `RpcMessage` type `Notify`.");
+					return None;
+				}
 			};
 			let (_, request) = request_builder.call_request(&msg);
 			let request = Request::post(&url)

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -134,14 +134,15 @@ fn generate_client_methods(methods: &[MethodRegistration]) -> Result<Vec<syn::Im
 			}
 			MethodRegistration::Notification { method, .. } => {
 				let attrs = get_doc_comments(&method.trait_item.attrs);
+				let rpc_name = method.name();
 				let name = &method.trait_item.sig.ident;
 				let args = compute_args(&method.trait_item);
 				let arg_names = compute_arg_identifiers(&args)?;
 				let client_method = syn::parse_quote! {
 					#(#attrs)*
-					pub fn #name(&self, #args) {
-						let _args_tuple = (#(#arg_names,)*);
-						unimplemented!()
+					pub fn #name(&self, #args) -> impl Future<Item = (), Error = RpcError> {
+						let args_tuple = (#(#arg_names,)*);
+						self.inner.notify(#rpc_name, args_tuple)
 					}
 				};
 				client_methods.push(client_method);

--- a/derive/tests/client.rs
+++ b/derive/tests/client.rs
@@ -7,6 +7,9 @@ use jsonrpc_derive::rpc;
 pub trait Rpc {
 	#[rpc(name = "add")]
 	fn add(&self, a: u64, b: u64) -> Result<u64>;
+
+	#[rpc(name = "notify")]
+	fn notify(&self, foo: u64);
 }
 
 struct RpcServer;
@@ -14,6 +17,10 @@ struct RpcServer;
 impl Rpc for RpcServer {
 	fn add(&self, a: u64, b: u64) -> Result<u64> {
 		Ok(a + b)
+	}
+
+	fn notify(&self, foo: u64) {
+		println!("received {}", foo);
 	}
 }
 
@@ -25,10 +32,10 @@ fn client_server_roundtrip() {
 	let fut = client
 		.clone()
 		.add(3, 4)
-		.and_then(move |res| client.add(res, 5))
+		.and_then(move |res| client.notify(res).map(move |_| res))
 		.join(rpc_client)
 		.map(|(res, ())| {
-			assert_eq!(res, 12);
+			assert_eq!(res, 7);
 		})
 		.map_err(|err| {
 			eprintln!("{:?}", err);


### PR DESCRIPTION
### Added

* Add `RawClient::notify()` and `TypedClient::notify()` methods to `jsonrpc-client-transports`.
* Add `RequestBuilder::notification()` method to `jsonrpc-client-transports`.
* Add notification support to `duplex` client transport.
* Add notification support to `http` client transport.
* Add two client notification unit tests to `jsonrpc-client-transports`.
* Add client notification support in `jsonrpc-derive`.

### Changed

* Update `client_server_roundtrip` integration test in `jsonrpc-derive`.

Closes #461.