### PR TITLE
Solve compiler error when serde is not a dependency of user project (#481)

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -30,6 +30,8 @@ pub use futures;
 
 #[doc(hidden)]
 pub extern crate serde_json;
+#[doc(hidden)]
+pub extern crate serde;
 
 mod calls;
 mod io;

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -9,7 +9,7 @@
 //! use jsonrpc_core::{IoHandler, Error, Result};
 //! use jsonrpc_core::futures::future::{self, FutureResult};
 //!
-//! #[rpc]
+//! #[rpc(server)]
 //! pub trait Rpc {
 //! 	#[rpc(name = "protocolVersion")]
 //! 	fn protocol_version(&self) -> Result<String>;

--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -236,7 +236,6 @@ pub fn rpc_impl(input: syn::Item, options: DeriveOptions) -> Result<proc_macro2:
 	let mod_name_ident = rpc_wrapper_mod_name(&rpc_trait);
 
 	let core_name = crate_name("jsonrpc-core")?;
-	let serde_name = crate_name("serde")?;
 
 	let mut submodules = Vec::new();
 	let mut exports = Vec::new();
@@ -256,7 +255,6 @@ pub fn rpc_impl(input: syn::Item, options: DeriveOptions) -> Result<proc_macro2:
 	}
 	Ok(quote!(
 		mod #mod_name_ident {
-			use #serde_name as _serde;
 			use #core_name as _jsonrpc_core;
 			use super::*;
 

--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -449,17 +449,17 @@ pub fn generate_where_clause_serialization_predicates(
 			// add json serialization trait bounds
 			if client {
 				if visitor.server_to_client_type_params.contains(&ty.ident) {
-					bounds.push(parse_quote!(_serde::de::DeserializeOwned))
+					bounds.push(parse_quote!(_jsonrpc_core::serde::de::DeserializeOwned))
 				}
 				if visitor.client_to_server_type_params.contains(&ty.ident) {
-					bounds.push(parse_quote!(_serde::Serialize))
+					bounds.push(parse_quote!(_jsonrpc_core::serde::Serialize))
 				}
 			} else {
 				if visitor.server_to_client_type_params.contains(&ty.ident) {
-					bounds.push(parse_quote!(_serde::Serialize))
+					bounds.push(parse_quote!(_jsonrpc_core::serde::Serialize))
 				}
 				if visitor.client_to_server_type_params.contains(&ty.ident) {
-					bounds.push(parse_quote!(_serde::de::DeserializeOwned))
+					bounds.push(parse_quote!(_jsonrpc_core::serde::de::DeserializeOwned))
 				}
 			}
 			syn::WherePredicate::Type(syn::PredicateType {

--- a/derive/tests/run-pass/client_only.rs
+++ b/derive/tests/run-pass/client_only.rs
@@ -1,4 +1,3 @@
-extern crate serde;
 extern crate jsonrpc_core;
 extern crate jsonrpc_core_client;
 #[macro_use]

--- a/derive/tests/run-pass/pubsub-dependency-not-required-for-vanilla-rpc.rs
+++ b/derive/tests/run-pass/pubsub-dependency-not-required-for-vanilla-rpc.rs
@@ -1,4 +1,3 @@
-extern crate serde;
 extern crate jsonrpc_core;
 extern crate jsonrpc_core_client;
 #[macro_use]

--- a/derive/tests/run-pass/server_only.rs
+++ b/derive/tests/run-pass/server_only.rs
@@ -1,4 +1,3 @@
-extern crate serde;
 extern crate jsonrpc_core;
 #[macro_use]
 extern crate jsonrpc_derive;

--- a/derive/tests/ui/attr-invalid-meta-list-names.rs
+++ b/derive/tests/ui/attr-invalid-meta-list-names.rs
@@ -1,4 +1,3 @@
-extern crate serde;
 extern crate jsonrpc_core;
 #[macro_use]
 extern crate jsonrpc_derive;

--- a/derive/tests/ui/attr-invalid-meta-list-names.stderr
+++ b/derive/tests/ui/attr-invalid-meta-list-names.stderr
@@ -1,8 +1,8 @@
 error: Invalid attribute parameter(s): 'Xalias'. Expected 'alias'
-  --> $DIR/attr-invalid-meta-list-names.rs:8:2
-   |
-8  |       /// Returns a protocol version
-   |  _____^
-9  | |     #[rpc(name = "protocolVersion", Xalias("alias"))]
-10 | |     fn protocol_version(&self) -> Result<String>;
-   | |_________________________________________________^
+ --> $DIR/attr-invalid-meta-list-names.rs:7:2
+  |
+7 |       /// Returns a protocol version
+  |  _____^
+8 | |     #[rpc(name = "protocolVersion", Xalias("alias"))]
+9 | |     fn protocol_version(&self) -> Result<String>;
+  | |_________________________________________________^

--- a/derive/tests/ui/attr-invalid-meta-words.rs
+++ b/derive/tests/ui/attr-invalid-meta-words.rs
@@ -1,4 +1,3 @@
-extern crate serde;
 extern crate jsonrpc_core;
 #[macro_use]
 extern crate jsonrpc_derive;

--- a/derive/tests/ui/attr-invalid-meta-words.stderr
+++ b/derive/tests/ui/attr-invalid-meta-words.stderr
@@ -1,8 +1,8 @@
 error: Invalid attribute parameter(s): 'Xmeta'. Expected 'meta, raw_params'
-  --> $DIR/attr-invalid-meta-words.rs:8:2
-   |
-8  |       /// Returns a protocol version
-   |  _____^
-9  | |     #[rpc(name = "protocolVersion", Xmeta)]
-10 | |     fn protocol_version(&self) -> Result<String>;
-   | |_________________________________________________^
+ --> $DIR/attr-invalid-meta-words.rs:7:2
+  |
+7 |       /// Returns a protocol version
+  |  _____^
+8 | |     #[rpc(name = "protocolVersion", Xmeta)]
+9 | |     fn protocol_version(&self) -> Result<String>;
+  | |_________________________________________________^

--- a/derive/tests/ui/attr-invalid-name-values.rs
+++ b/derive/tests/ui/attr-invalid-name-values.rs
@@ -1,4 +1,3 @@
-extern crate serde;
 extern crate jsonrpc_core;
 #[macro_use]
 extern crate jsonrpc_derive;

--- a/derive/tests/ui/attr-invalid-name-values.stderr
+++ b/derive/tests/ui/attr-invalid-name-values.stderr
@@ -1,8 +1,8 @@
 error: Invalid attribute parameter(s): 'Xname'. Expected 'name, returns'
-  --> $DIR/attr-invalid-name-values.rs:8:2
-   |
-8  |       /// Returns a protocol version
-   |  _____^
-9  | |     #[rpc(Xname = "protocolVersion")]
-10 | |     fn protocol_version(&self) -> Result<String>;
-   | |_________________________________________________^
+ --> $DIR/attr-invalid-name-values.rs:7:2
+  |
+7 |       /// Returns a protocol version
+  |  _____^
+8 | |     #[rpc(Xname = "protocolVersion")]
+9 | |     fn protocol_version(&self) -> Result<String>;
+  | |_________________________________________________^

--- a/derive/tests/ui/attr-missing-rpc-name.rs
+++ b/derive/tests/ui/attr-missing-rpc-name.rs
@@ -1,4 +1,3 @@
-extern crate serde;
 extern crate jsonrpc_core;
 #[macro_use]
 extern crate jsonrpc_derive;

--- a/derive/tests/ui/attr-missing-rpc-name.stderr
+++ b/derive/tests/ui/attr-missing-rpc-name.stderr
@@ -1,8 +1,8 @@
 error: rpc attribute should have a name e.g. `name = "method_name"`
-  --> $DIR/attr-missing-rpc-name.rs:8:2
-   |
-8  |       /// Returns a protocol version
-   |  _____^
-9  | |     #[rpc]
-10 | |     fn protocol_version(&self) -> Result<String>;
-   | |_________________________________________________^
+ --> $DIR/attr-missing-rpc-name.rs:7:2
+  |
+7 |       /// Returns a protocol version
+  |  _____^
+8 | |     #[rpc]
+9 | |     fn protocol_version(&self) -> Result<String>;
+  | |_________________________________________________^

--- a/derive/tests/ui/multiple-rpc-attributes.rs
+++ b/derive/tests/ui/multiple-rpc-attributes.rs
@@ -1,4 +1,3 @@
-extern crate serde;
 extern crate jsonrpc_core;
 #[macro_use]
 extern crate jsonrpc_derive;

--- a/derive/tests/ui/multiple-rpc-attributes.stderr
+++ b/derive/tests/ui/multiple-rpc-attributes.stderr
@@ -1,9 +1,9 @@
 error: Expected only a single rpc attribute per method
-  --> $DIR/multiple-rpc-attributes.rs:8:2
+  --> $DIR/multiple-rpc-attributes.rs:7:2
    |
-8  |       /// Returns a protocol version
+7  |       /// Returns a protocol version
    |  _____^
-9  | |     #[rpc(name = "protocolVersion")]
-10 | |     #[rpc(name = "protocolVersionAgain")]
-11 | |     fn protocol_version(&self) -> Result<String>;
+8  | |     #[rpc(name = "protocolVersion")]
+9  | |     #[rpc(name = "protocolVersionAgain")]
+10 | |     fn protocol_version(&self) -> Result<String>;
    | |_________________________________________________^

--- a/derive/tests/ui/too-many-params.rs
+++ b/derive/tests/ui/too-many-params.rs
@@ -1,4 +1,3 @@
-extern crate serde;
 extern crate jsonrpc_core;
 #[macro_use]
 extern crate jsonrpc_derive;

--- a/derive/tests/ui/too-many-params.stderr
+++ b/derive/tests/ui/too-many-params.stderr
@@ -1,12 +1,12 @@
 error: Maximum supported number of params is 16
-  --> $DIR/too-many-params.rs:8:2
+  --> $DIR/too-many-params.rs:7:2
    |
-8  |       /// Has too many params
+7  |       /// Has too many params
    |  _____^
-9  | |     #[rpc(name = "tooManyParams")]
-10 | |     fn to_many_params(
-11 | |         &self,
-12 | |         a: u64, b: u64, c: u64, d: u64, e: u64, f: u64, g: u64, h: u64, i: u64, j: u64,
-13 | |         k: u64, l: u64, m: u64, n: u64, o: u64, p: u64, q: u64,
-14 | |     ) -> Result<String>;
+8  | |     #[rpc(name = "tooManyParams")]
+9  | |     fn to_many_params(
+10 | |         &self,
+11 | |         a: u64, b: u64, c: u64, d: u64, e: u64, f: u64, g: u64, h: u64, i: u64, j: u64,
+12 | |         k: u64, l: u64, m: u64, n: u64, o: u64, p: u64, q: u64,
+13 | |     ) -> Result<String>;
    | |________________________^


### PR DESCRIPTION
Use `serde` directly instead of ask for user of the library to add it as a
dependency.

Tests are modified since this is a ui change.

The doc comment gives an example using `#[rpc(server)]` instead of original
`#[rpc]`, telling users that this attribute has an option to be used to
configure it.