### PR TITLE
Fix race condition on `wait()`

### DIFF
--- a/server-utils/Cargo.toml
+++ b/server-utils/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4"
 tokio = { version = "0.1.15" }
 tokio-codec = { version = "0.1" }
 unicase = "2.0"
+parking_lot = "0.9"
 
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}


### PR DESCRIPTION
`wait()` using `oneshot::channel()` makes race conditions. Call `Executor::wait()` directly.

It is possible that the thread that has executed `wait()`, which is usually the main thread, terminates before the thread executing `done_tx.send(())` drops `rpc_handler`.
Static variables are destructed at the end of termination of the main
thread, and then a segfault occurs when the thread dropping the
`rpc_handler` accesses the variables.