### PR TITLE
ignore dropped connections

### DIFF
--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-tcp-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.0"
+version = "14.0.1"
 
 [dependencies]
 log = "0.4"

--- a/tcp/src/server.rs
+++ b/tcp/src/server.rs
@@ -91,7 +91,7 @@ impl<M: Metadata, S: Middleware<M> + 'static> ServerBuilder<M, S> {
 					let peer_addr = match socket.peer_addr() {
 						Ok(addr) => addr,
 						Err(e) => {
-							trace!(target: "tcp", "Unable to determine socket peer address, ignoring connection {}", e);
+							warn!(target: "tcp", "Unable to determine socket peer address, ignoring connection {}", e);
 							return future::Either::A(future::ok(()))
 						}
 					};

--- a/tcp/src/server.rs
+++ b/tcp/src/server.rs
@@ -88,7 +88,13 @@ impl<M: Metadata, S: Middleware<M> + 'static> ServerBuilder<M, S> {
 				let connections = SuspendableStream::new(listener.incoming());
 
 				let server = connections.map(move |socket| {
-					let peer_addr = socket.peer_addr().expect("Unable to determine socket peer address");
+					let peer_addr = match socket.peer_addr() {
+						Ok(addr) => addr,
+						Err(e) => {
+							trace!(target: "tcp", "Unable to determine socket peer address, ignoring connection {}", e);
+							return future::Either::A(future::ok(()))
+						}
+					};
 					trace!(target: "tcp", "Accepted incoming connection from {}", &peer_addr);
 					let (sender, receiver) = mpsc::channel(65536);
 
@@ -101,7 +107,10 @@ impl<M: Metadata, S: Middleware<M> + 'static> ServerBuilder<M, S> {
 					let service = Service::new(peer_addr, rpc_handler.clone(), meta);
 					let (writer, reader) = Framed::new(
 						socket,
-						codecs::StreamCodec::new(incoming_separator.clone(), outgoing_separator.clone()),
+						codecs::StreamCodec::new(
+							incoming_separator.clone(),
+							outgoing_separator.clone()
+						),
 					)
 					.split();
 
@@ -137,7 +146,7 @@ impl<M: Metadata, S: Middleware<M> + 'static> ServerBuilder<M, S> {
 						Ok(())
 					});
 
-					writer
+					future::Either::B(writer)
 				});
 
 				Ok(server)


### PR DESCRIPTION
Previously If there's no `peer_addr` on the socket, this causes the tcp-server to panic. 

https://github.com/paritytech/jsonrpc/blob/44184766aeb59a95b4d6f4c7eaff0c9e1ef278eb/tcp/src/server.rs#L87-L93

Instead of panicking this PR instead ignores the connection as it has most likely been dropped by the client.

closes #500