### PR TITLE
Fix race condition on `wait()`

### DIFF
--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -566,7 +566,12 @@ fn serve<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>>(
 					}))
 					.map_err(|_| ())
 			})
-			.and_then(|_| done_tx.send(()))
+			.and_then(|(_, server)| {
+				// We drop the server first to prevent a situation where main thread terminates
+				// before the server is properly dropped (see #504 for more details)
+				drop(server);
+				done_tx.send(())
+			})
 	});
 }
 

--- a/ipc/src/server.rs
+++ b/ipc/src/server.rs
@@ -240,7 +240,10 @@ impl<M: Metadata, S: Middleware<M>> ServerBuilder<M, S> {
 					.buffer_unordered(1024)
 					.for_each(|_| Ok(()))
 					.select(stop)
-					.map(|_| {
+					.map(|(_, server)| {
+						// We drop the server first to prevent a situation where main thread terminates
+						// before the server is properly dropped (see #504 for more details)
+						drop(server);
 						let _ = wait_signal.send(());
 					})
 					.map_err(|_| ()),


### PR DESCRIPTION
Manually dropping the future passed from `Future::select` before sending
`done_tx` prevents the race condition.

`Future::select` pass the unresolved future, which is a `Server` holding
`rpc_handler`, to the following callback. Therefore, it is dropped after
the `done_tx.send(())` after the callback exits.
It is possible that the thread that has executed `wait()`, which is
usually the main thread, terminates before the thread sending `done_tx`
drops `rpc_handler`.
Static variables are destructed at the end of termination of the main
thread, and then a segfault occurs when the thread dropping the
rpc_handler accesses the variables.

I closed the previous PR (https://github.com/paritytech/jsonrpc/pull/501).
Sorry for the confusion.