### PR TITLE
workaround serde deserializing incorrectly when arbitrary_precision enabled

### DIFF
--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -23,6 +23,7 @@ tls = ["jsonrpc-client-transports/tls"]
 http = ["jsonrpc-client-transports/http"]
 ws = ["jsonrpc-client-transports/ws"]
 ipc = ["jsonrpc-client-transports/ipc"]
+arbitrary_precision = ["jsonrpc-client-transports/arbitrary_precision"]
 
 [dependencies]
 jsonrpc-client-transports = { version = "14.0", path = "./transports", default-features = false }

--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -31,7 +31,7 @@ ipc = [
 	"jsonrpc-server-utils",
 	"tokio",
 ]
-arbitrary_precision = []
+arbitrary_precision = ["serde_json/arbitrary_precision", "jsonrpc-core/arbitrary_precision"]
 
 [dependencies]
 failure = "0.1"

--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -31,6 +31,7 @@ ipc = [
 	"jsonrpc-server-utils",
 	"tokio",
 ]
+arbitrary_precision = []
 
 [dependencies]
 failure = "0.1"

--- a/core-client/transports/src/transports/mod.rs
+++ b/core-client/transports/src/transports/mod.rs
@@ -81,16 +81,27 @@ impl RequestBuilder {
 pub fn parse_response(
 	response: &str,
 ) -> Result<(Id, Result<Value, RpcError>, Option<String>, Option<SubscriptionId>), RpcError> {
-	serde_json::from_str::<ClientResponse>(&response)
-		.map_err(|e| RpcError::ParseError(e.to_string(), e.into()))
-		.map(|response| {
-			let id = response.id().unwrap_or(Id::Null);
-			let sid = response.subscription_id();
-			let method = response.method();
-			let value: Result<Value, Error> = response.into();
-			let result = value.map_err(RpcError::JsonRpcError);
-			(id, result, method, sid)
-		})
+	// https://github.com/serde-rs/json/issues/505
+	// Arbitrary precision confuses serde when deserializing into untagged enums,
+	// this is a workaround
+	let response = if cfg!(feature = "arbitrary_precision") {
+		let value = serde_json::from_str::<Value>(&response)
+			.map_err(|e| RpcError::ParseError(e.to_string(), e.into()))?;
+		serde_json::from_value::<ClientResponse>(value)
+			.map_err(|e| RpcError::ParseError(e.to_string(), e.into()))
+	} else {
+		serde_json::from_str::<ClientResponse>(&response)
+			.map_err(|e| RpcError::ParseError(e.to_string(), e.into()))
+	};
+
+	response.map(|response| {
+		let id = response.id().unwrap_or(Id::Null);
+		let sid = response.subscription_id();
+		let method = response.method();
+		let value: Result<Value, Error> = response.into();
+		let result = value.map_err(RpcError::JsonRpcError);
+		(id, result, method, sid)
+	})
 }
 
 /// A type representing all possible values sent from the server to the client.

--- a/core-client/transports/src/transports/mod.rs
+++ b/core-client/transports/src/transports/mod.rs
@@ -178,10 +178,20 @@ mod tests {
 	use jsonrpc_core::{Failure, Notification, Output, Params, Success, Value, Version};
 	use serde_json;
 
+	fn arbitrary_precision_fix(input: &str) -> ClientResponse {
+		if cfg!(feature = "arbitrary_precision") {
+			let val: serde_json::Value = serde_json::from_str(input).unwrap();
+			serde_json::from_value(val).unwrap()
+		} else {
+			serde_json::from_str(input).unwrap()
+		}
+	}
+
 	#[test]
 	fn notification_deserialize() {
 		let dsr = r#"{"jsonrpc":"2.0","method":"hello","params":[10]}"#;
-		let deserialized: ClientResponse = serde_json::from_str(dsr).unwrap();
+
+		let deserialized: ClientResponse = arbitrary_precision_fix(dsr);
 		assert_eq!(
 			deserialized,
 			ClientResponse::Notification(Notification {
@@ -195,7 +205,8 @@ mod tests {
 	#[test]
 	fn success_deserialize() {
 		let dsr = r#"{"jsonrpc":"2.0","result":1,"id":1}"#;
-		let deserialized: ClientResponse = serde_json::from_str(dsr).unwrap();
+
+		let deserialized: ClientResponse = arbitrary_precision_fix(dsr);
 		assert_eq!(
 			deserialized,
 			ClientResponse::Output(Output::Success(Success {
@@ -210,7 +221,7 @@ mod tests {
 	fn failure_output_deserialize() {
 		let dfo = r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":1}"#;
 
-		let deserialized: ClientResponse = serde_json::from_str(dfo).unwrap();
+		let deserialized: ClientResponse = arbitrary_precision_fix(dfo);
 		assert_eq!(
 			deserialized,
 			ClientResponse::Output(Output::Failure(Failure {

--- a/core-client/transports/src/transports/mod.rs
+++ b/core-client/transports/src/transports/mod.rs
@@ -85,13 +85,11 @@ pub fn parse_response(
 	// Arbitrary precision confuses serde when deserializing into untagged enums,
 	// this is a workaround
 	let response = if cfg!(feature = "arbitrary_precision") {
-		let value = serde_json::from_str::<Value>(&response)
-			.map_err(|e| RpcError::ParseError(e.to_string(), e.into()))?;
-		serde_json::from_value::<ClientResponse>(value)
-			.map_err(|e| RpcError::ParseError(e.to_string(), e.into()))
+		let value =
+			serde_json::from_str::<Value>(&response).map_err(|e| RpcError::ParseError(e.to_string(), e.into()))?;
+		serde_json::from_value::<ClientResponse>(value).map_err(|e| RpcError::ParseError(e.to_string(), e.into()))
 	} else {
-		serde_json::from_str::<ClientResponse>(&response)
-			.map_err(|e| RpcError::ParseError(e.to_string(), e.into()))
+		serde_json::from_str::<ClientResponse>(&response).map_err(|e| RpcError::ParseError(e.to_string(), e.into()))
 	};
 
 	response.map(|response| {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,5 +25,8 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 
+[features]
+arbitrary_precision = ["serde_json/arbitrary_precision"]
+
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -10,7 +10,7 @@ use serde_json;
 
 use crate::calls::{Metadata, RemoteProcedure, RpcMethod, RpcMethodSimple, RpcNotification, RpcNotificationSimple};
 use crate::middleware::{self, Middleware};
-use crate::types::{Call, Output, Request, Response, Value};
+use crate::types::{Call, Output, Request, Response};
 use crate::types::{Error, ErrorCode, Version};
 
 /// A type representing middleware or RPC response before serialization.
@@ -455,12 +455,7 @@ impl<M: Metadata> IoHandlerExtension<M> for IoHandler<M> {
 }
 
 fn read_request(request_str: &str) -> Result<Request, Error> {
-	if cfg!(feature = "arbitrary_precision") {
-		let val: Value = serde_json::from_str(request_str).map_err(|_| Error::new(ErrorCode::ParseError))?;
-		serde_json::from_value(val).map_err(|_| Error::new(ErrorCode::ParseError))
-	} else {
-		serde_json::from_str(request_str).map_err(|_| Error::new(ErrorCode::ParseError))
-	}
+	crate::serde_from_str(request_str).map_err(|_| Error::new(ErrorCode::ParseError))
 }
 
 fn write_response(response: Response) -> String {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -55,14 +55,14 @@ pub use crate::io::{
 pub use crate::middleware::{Middleware, Noop as NoopMiddleware};
 pub use crate::types::*;
 
-use serde_json::{Error as SerdeError};
+use serde_json::Error as SerdeError;
 
 /// workaround for https://github.com/serde-rs/json/issues/505
 /// Arbitrary precision confuses serde when deserializing into untagged enums,
 /// this is a workaround
 pub fn serde_from_str<'a, T>(input: &'a str) -> ::std::result::Result<T, SerdeError>
 where
-	T: serde::de::Deserialize<'a>
+	T: serde::de::Deserialize<'a>,
 {
 	if cfg!(feature = "arbitrary_precision") {
 		let val = serde_json::from_str::<Value>(input)?;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -54,3 +54,20 @@ pub use crate::io::{
 };
 pub use crate::middleware::{Middleware, Noop as NoopMiddleware};
 pub use crate::types::*;
+
+use serde_json::{Error as SerdeError};
+
+/// workaround for https://github.com/serde-rs/json/issues/505
+/// Arbitrary precision confuses serde when deserializing into untagged enums,
+/// this is a workaround
+pub fn serde_from_str<'a, T>(input: &'a str) -> ::std::result::Result<T, SerdeError>
+where
+	T: serde::de::Deserialize<'a>
+{
+	if cfg!(feature = "arbitrary_precision") {
+		let val = serde_json::from_str::<Value>(input)?;
+		T::deserialize(val)
+	} else {
+		serde_json::from_str::<T>(input)
+	}
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -60,7 +60,7 @@ use serde_json::Error as SerdeError;
 /// workaround for https://github.com/serde-rs/json/issues/505
 /// Arbitrary precision confuses serde when deserializing into untagged enums,
 /// this is a workaround
-pub fn serde_from_str<'a, T>(input: &'a str) -> ::std::result::Result<T, SerdeError>
+pub fn serde_from_str<'a, T>(input: &'a str) -> std::result::Result<T, SerdeError>
 where
 	T: serde::de::Deserialize<'a>,
 {

--- a/core/src/types/response.rs
+++ b/core/src/types/response.rs
@@ -113,7 +113,12 @@ impl Response {
 		if s.is_empty() {
 			Ok(Response::Batch(vec![]))
 		} else {
-			serde_json::from_str(s)
+			if cfg!(feature = "arbitrary_precision") {
+				let val = serde_json::from_str::<Value>(s)?;
+				serde_json::from_value(val)
+			} else {
+				serde_json::from_str(s)
+			}
 		}
 	}
 }

--- a/core/src/types/response.rs
+++ b/core/src/types/response.rs
@@ -113,12 +113,7 @@ impl Response {
 		if s.is_empty() {
 			Ok(Response::Batch(vec![]))
 		} else {
-			if cfg!(feature = "arbitrary_precision") {
-				let val = serde_json::from_str::<Value>(s)?;
-				serde_json::from_value(val)
-			} else {
-				serde_json::from_str(s)
-			}
+			crate::serde_from_str(s)
 		}
 	}
 }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -17,6 +17,9 @@ log = "0.4"
 serde = "1.0"
 serde_json = "1.0"
 
+[features]
+arbitrary_precision = ["jsonrpc-core-client/arbitrary_precision", "serde_json/arbitrary_precision", "jsonrpc-core/arbitrary_precision"]
+
 [dev-dependencies]
 jsonrpc-derive = { version = "14.0", path = "../derive" }
 

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -119,16 +119,8 @@ impl Rpc {
 			.handle_request_sync(&request)
 			.expect("We are sending a method call not notification.");
 
-		// arbitrary precision workaround, https://github.com/serde-rs/json/issues/505
-		let response = if cfg!(feature = "arbitrary_precision") {
-			let val = serde_json::from_str::<serde_json::Value>(&response).expect("We will always get a single output.");
-			serde_json::from_value(val)
-		} else {
-			serde_json::from_str(&response)
-		};
-
 		// extract interesting part from the response
-		let extracted = match response.expect("We will always get a single output.") {
+		let extracted = match rpc::serde_from_str(&response).expect("We will always get a single output.") {
 			response::Output::Success(response::Success { result, .. }) => match encoding {
 				Encoding::Compact => serde_json::to_string(&result),
 				Encoding::Pretty => serde_json::to_string_pretty(&result),


### PR DESCRIPTION
serde deserializes incorrectly when arbitrary precision is enabled.

fixes #520 

The workaround is to deserialize into `Value` before `ClientResponse`. This is gated under the feature `arbitrary_precision` in core-client and `transports`.

