### PR TITLE
14.0.5 bump

### DIFF
--- a/_automate/publish.sh
+++ b/_automate/publish.sh
@@ -2,20 +2,15 @@
 
 set -exu
 
-VERSION=$(grep "^version" ./core/Cargo.toml | sed -e 's/.*"\(.*\)"/\1/')
-ORDER=(core server-utils tcp ws http ipc stdio pubsub core-client/transports core-client derive test)
+# NOTE https://github.com/sunng87/cargo-release is required.
 
+VERSION=$(grep "^version" ./core/Cargo.toml | sed -e 's/.*"\(.*\)"/\1/')
 echo "Publishing version $VERSION"
 cargo clean
-
-for crate in ${ORDER[@]}; do
-	cd $crate
-	echo "Publishing $crate@$VERSION"
-	sleep 5
-	cargo publish $@ || read -p "\n\t Publishing $crate failed. Press [enter] to continue."
-	cd -
-done
-
-echo "Tagging version $VERSION"
-git tag -a v$VERSION -m "Version $VERSION"
+read -p "\n\t Press [enter] to continue."
+cargo release --dry-run --sign --skip-push --no-dev-version
+read -p "\n\t Press [enter] to confirm release the plan."
+cargo release --sign --skip-push --no-dev-version
+echo "Release finished."
+git push
 git push --tags

--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
 name = "jsonrpc-core-client"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.4"
+version = "14.0.5"
 
 categories = [
 	"asynchronous",

--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
 name = "jsonrpc-client-transports"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.4"
+version = "14.0.5"
 
 categories = [
 	"asynchronous",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
 name = "jsonrpc-core"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.4"
+version = "14.0.5"
 
 categories = [
 	"asynchronous",

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-derive"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.4"
+version = "14.0.5"
 
 [lib]
 proc-macro = true

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "server"]
 license = "MIT"
 name = "jsonrpc-http-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.4"
+version = "14.0.5"
 
 [dependencies]
 hyper = "0.12"

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-ipc-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.4"
+version = "14.0.5"
 
 [dependencies]
 log = "0.4"

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "macros"]
 license = "MIT"
 name = "jsonrpc-pubsub"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.4"
+version = "14.0.5"
 
 [dependencies]
 log = "0.4"

--- a/pubsub/more-examples/Cargo.toml
+++ b/pubsub/more-examples/Cargo.toml
@@ -3,7 +3,7 @@ name = "jsonrpc-pubsub-examples"
 description = "Examples of Publish-Subscribe extension for jsonrpc."
 homepage = "https://github.com/paritytech/jsonrpc"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.4"
+version = "14.0.5"
 authors = ["tomusdrw <tomasz@parity.io>"]
 license = "MIT"
 

--- a/server-utils/Cargo.toml
+++ b/server-utils/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
 name = "jsonrpc-server-utils"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.4"
+version = "14.0.5"
 
 [dependencies]
 bytes = "0.4"

--- a/stdio/Cargo.toml
+++ b/stdio/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-stdio-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.4"
+version = "14.0.5"
 
 [dependencies]
 futures = "0.1.23"

--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-tcp-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.4"
+version = "14.0.5"
 
 [dependencies]
 log = "0.4"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsonrpc-test"
 description = "Simple test framework for JSON-RPC."
-version = "14.0.4"
+version = "14.0.5"
 authors = ["Tomasz Drwięga <tomasz@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/jsonrpc"

--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-ws-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.4"
+version = "14.0.5"
 
 [dependencies]
 jsonrpc-core = { version = "14.0", path = "../core" }


### PR DESCRIPTION
Release notes:
1. Regular updates (env_logger 0.6->0.7, websocket 0.23->0.24)
2. IPC socket permissioning (https://github.com/paritytech/jsonrpc/pull/519)
3. Support `serde_json` with `arbitrary_precision` feature.
4. Modify the HTTP server requests handling (avoid `buffer_unordered` with aribtrary limit in favour of spawning tasks on the runtime).