### PR TITLE
Use tokio-compat for 0.2 timers in stdio crate

### DIFF
--- a/core/src/types/request.rs
+++ b/core/src/types/request.rs
@@ -154,7 +154,10 @@ mod tests {
 		]);
 
 		let serialized = serde_json::to_string(&batch).unwrap();
-		assert_eq!(serialized, r#"[{"jsonrpc":"2.0","method":"update","params":[1,2],"id":1},{"jsonrpc":"2.0","method":"update","params":[1]}]"#);
+		assert_eq!(
+			serialized,
+			r#"[{"jsonrpc":"2.0","method":"update","params":[1,2],"id":1},{"jsonrpc":"2.0","method":"update","params":[1]}]"#
+		);
 	}
 
 	#[test]

--- a/stdio/Cargo.toml
+++ b/stdio/Cargo.toml
@@ -13,10 +13,10 @@ version = "14.0.1"
 futures = "0.1.23"
 jsonrpc-core = { version = "14.0", path = "../core" }
 log = "0.4"
-tokio = "0.1.7"
 tokio-codec = "0.1.0"
 tokio-io = "0.1.7"
 tokio-stdin-stdout = "0.1.4"
+tokio-compat = { version = "0.1.4", features = ["rt-full"] }
 
 [dev-dependencies]
 lazy_static = "1.0"

--- a/stdio/src/lib.rs
+++ b/stdio/src/lib.rs
@@ -17,16 +17,14 @@
 
 #![deny(missing_docs)]
 
-use tokio;
-use tokio_stdin_stdout;
 #[macro_use]
 extern crate log;
 
 pub use jsonrpc_core;
 
+use futures::prelude::{Future, Stream};
 use jsonrpc_core::IoHandler;
 use std::sync::Arc;
-use tokio::prelude::{Future, Stream};
 use tokio_codec::{FramedRead, FramedWrite, LinesCodec};
 
 /// Stdio server builder
@@ -62,7 +60,7 @@ impl ServerBuilder {
 			.map(|_| ())
 			.map_err(|e| panic!("{:?}", e));
 
-		tokio::run(future);
+		tokio_compat::run(future);
 	}
 }
 

--- a/tcp/src/tests.rs
+++ b/tcp/src/tests.rs
@@ -80,7 +80,7 @@ fn dummy_request(addr: &SocketAddr, data: Vec<u8>) -> Vec<u8> {
 			io::read_to_end(stream, vec![])
 		})
 		.and_then(move |(_stream, read_buf)| ret_tx.send(read_buf).map_err(|err| panic!("Unable to send {:?}", err)))
-		.map_err(|err| panic!("Error connecting or closing connection: {:?}", err));;
+		.map_err(|err| panic!("Error connecting or closing connection: {:?}", err));
 
 	tokio::run(stream);
 	ret_rx.wait().expect("Unable to receive result")


### PR DESCRIPTION
Use-case: we rely on tokio 0.2 timers in our application code, but the stdio server crate runs the futures on the 0.1 executor. With tokio-compat, we should be able to get the best of both words, until `jsonrpc-core` works with `std::future::Future`.