### PR TITLE
Fix ServerBuilder::cors_max_age doc comment time unit

### DIFF
--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -364,8 +364,7 @@ impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> {
 
 	/// Configure CORS `AccessControlMaxAge` header returned.
 	///
-	/// Passing `Some(millis)` informs the client that the CORS preflight request is not necessary
-	/// for at least `millis` ms.
+	/// Informs the client that the CORS preflight request is not necessary for `cors_max_age` seconds.
 	/// Disabled by default.
 	pub fn cors_max_age<T: Into<Option<u32>>>(mut self, cors_max_age: T) -> Self {
 		self.cors_max_age = cors_max_age.into();


### PR DESCRIPTION
#### Problem
The `cors_max_age` doc comment states that the age is specified in millis. But according to the [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age), the header is specified in seconds.

#### Fix
Update doc comment to say "seconds"