### PR TITLE
bump parking_lot and patch versions

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "server"]
 license = "MIT"
 name = "jsonrpc-http-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.5"
+version = "14.0.6"
 
 [dependencies]
 hyper = "0.12"
@@ -17,7 +17,7 @@ jsonrpc-server-utils = { version = "14.0", path = "../server-utils" }
 log = "0.4"
 net2 = "0.2"
 unicase = "2.0"
-parking_lot = "0.9.0"
+parking_lot = "0.10.0"
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-ipc-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.6"
+version = "14.0.7"
 
 [dependencies]
 log = "0.4"
@@ -15,7 +15,7 @@ tokio-service = "0.1"
 jsonrpc-core = { version = "14.0", path = "../core" }
 jsonrpc-server-utils = { version = "14.0", path = "../server-utils" }
 parity-tokio-ipc = "0.4"
-parking_lot = "0.9"
+parking_lot = "0.10.0"
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -8,11 +8,11 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "macros"]
 license = "MIT"
 name = "jsonrpc-pubsub"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.5"
+version = "14.0.6"
 
 [dependencies]
 log = "0.4"
-parking_lot = "0.9"
+parking_lot = "0.10.0"
 jsonrpc-core = { version = "14.0", path = "../core" }
 serde = "1.0"
 

--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -7,11 +7,11 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-tcp-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.5"
+version = "14.0.6"
 
 [dependencies]
 log = "0.4"
-parking_lot = "0.9"
+parking_lot = "0.10.0"
 tokio-service = "0.1"
 jsonrpc-core = { version = "14.0", path = "../core" }
 jsonrpc-server-utils = { version = "14.0", path = "../server-utils" }

--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -7,13 +7,13 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-ws-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.0.5"
+version = "14.0.6"
 
 [dependencies]
 jsonrpc-core = { version = "14.0", path = "../core" }
 jsonrpc-server-utils = { version = "14.0", path = "../server-utils" }
 log = "0.4"
-parking_lot = "0.9"
+parking_lot = "0.10.0"
 slab = "0.4"
 ws = "0.9"
 


### PR DESCRIPTION
similar to https://github.com/paritytech/parity-common/pull/332 (but here `parking_lot` is not exposed in the public API, right?)