### PR TITLE
Client call with named params

### DIFF
--- a/core-client/transports/src/lib.rs
+++ b/core-client/transports/src/lib.rs
@@ -303,9 +303,10 @@ impl TypedClient {
 		let params = match args {
 			Value::Array(vec) => Params::Array(vec),
 			Value::Null => Params::None,
+			Value::Object(map) => Params::Map(map),
 			_ => {
 				return future::Either::A(future::err(RpcError::Other(format_err!(
-					"RPC params should serialize to a JSON array, or null"
+					"RPC params should serialize to a JSON array, JSON object or null"
 				))))
 			}
 		};

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 syn = { version = "1.0", features = ["full", "extra-traits", "visit", "fold"] }
 proc-macro2 = "1.0"
-quote = "=1.0.2"
+quote = "=1.0.1"
 proc-macro-crate = "0.1.4"
 
 [dev-dependencies]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 syn = { version = "1.0", features = ["full", "extra-traits", "visit", "fold"] }
 proc-macro2 = "1.0"
-quote = "1.0"
+quote = "=1.0.2"
 proc-macro-crate = "0.1.4"
 
 [dev-dependencies]

--- a/derive/examples/meta-macros.rs
+++ b/derive/examples/meta-macros.rs
@@ -26,7 +26,7 @@ pub trait Rpc<One> {
 	fn mul(&self, a: u64, b: Option<u64>) -> Result<u64>;
 
 	/// Retrieves and debug prints the underlying `Params` object.
-	#[rpc(name = "raw", raw_params)]
+	#[rpc(name = "raw", params = "raw")]
 	fn raw(&self, params: Params) -> Result<String>;
 
 	/// Performs an asynchronous operation.

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -206,7 +206,7 @@ pub fn rpc(args: TokenStream, input: TokenStream) -> TokenStream {
 		Err(error) => return error.to_compile_error().into(),
 	};
 
-	match rpc_trait::rpc_impl(input_toks, options) {
+	match rpc_trait::rpc_impl(input_toks, &options) {
 		Ok(output) => output.into(),
 		Err(err) => err.to_compile_error().into(),
 	}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -199,6 +199,7 @@ mod to_delegate;
 #[proc_macro_attribute]
 pub fn rpc(args: TokenStream, input: TokenStream) -> TokenStream {
 	let input_toks = parse_macro_input!(input as syn::Item);
+	let args = syn::parse_macro_input!(args as syn::AttributeArgs);
 
 	let options = match options::DeriveOptions::try_from(args) {
 		Ok(options) => options,

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -186,11 +186,11 @@ use proc_macro::TokenStream;
 use syn::parse_macro_input;
 
 mod options;
+mod params_style;
 mod rpc_attr;
 mod rpc_trait;
 mod to_client;
 mod to_delegate;
-mod params_style;
 
 /// Apply `#[rpc]` to a trait, and a `to_delegate` method is generated which
 /// wires up methods decorated with `#[rpc]` or `#[pubsub]` attributes.

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -190,6 +190,7 @@ mod rpc_attr;
 mod rpc_trait;
 mod to_client;
 mod to_delegate;
+mod params_style;
 
 /// Apply `#[rpc]` to a trait, and a `to_delegate` method is generated which
 /// wires up methods decorated with `#[rpc]` or `#[pubsub]` attributes.

--- a/derive/src/options.rs
+++ b/derive/src/options.rs
@@ -64,7 +64,7 @@ impl DeriveOptions {
 		}
 		if options.enable_server && options.params_style == ParamStyle::Named {
 			// This is not allowed at this time
-			panic!("Server code generation only supports `params = \"positional\"` at this time. This is the default setting.")
+			panic!("Server code generation only supports `params = \"positional\"` (default) or `params = \"raw\" at this time.")
 		}
 		Ok(options)
 	}

--- a/derive/src/options.rs
+++ b/derive/src/options.rs
@@ -55,7 +55,8 @@ impl DeriveOptions {
 			options.enable_server = true;
 		}
 		if options.enable_server && options.params_style == ParamStyle::Named {
-			panic!()
+			// This is not allowed at this time
+			panic!("Server code generation only supports `params = \"positional\"` at this time. This is the default setting.")
 		}
 		Ok(options)
 	}

--- a/derive/src/options.rs
+++ b/derive/src/options.rs
@@ -54,6 +54,9 @@ impl DeriveOptions {
 			options.enable_client = true;
 			options.enable_server = true;
 		}
+		if options.enable_server && options.params_style == ParamStyle::Named {
+			panic!()
+		}
 		Ok(options)
 	}
 }

--- a/derive/src/options.rs
+++ b/derive/src/options.rs
@@ -28,8 +28,16 @@ impl DeriveOptions {
 		for arg in args {
 			if let syn::NestedMeta::Meta(meta) = arg {
 				match meta {
-					syn::Meta::Path(p) => {
-						match p.get_ident().unwrap().to_string().as_ref() {
+					syn::Meta::Path(ref p) => {
+						match p
+							.get_ident()
+							.ok_or(syn::Error::new_spanned(
+								p,
+								format!("Expecting identifier `{}` or `{}`", CLIENT_META_WORD, SERVER_META_WORD),
+							))?
+							.to_string()
+							.as_ref()
+						{
 							CLIENT_META_WORD => options.enable_client = true,
 							SERVER_META_WORD => options.enable_server = true,
 							_ => {}

--- a/derive/src/options.rs
+++ b/derive/src/options.rs
@@ -1,37 +1,59 @@
-use proc_macro::TokenStream;
+use std::str::FromStr;
+
+use crate::params_style::ParamStyle;
+use crate::rpc_attr::path_eq_str;
+
+const CLIENT_META_WORD: &str = "client";
+const SERVER_META_WORD: &str = "server";
+const PARAMS_META_KEY: &str = "params";
 
 #[derive(Debug)]
 pub struct DeriveOptions {
 	pub enable_client: bool,
 	pub enable_server: bool,
+	pub params_style: ParamStyle,
 }
 
 impl DeriveOptions {
-	pub fn new(enable_client: bool, enable_server: bool) -> Self {
+	pub fn new(enable_client: bool, enable_server: bool, params_style: ParamStyle) -> Self {
 		DeriveOptions {
 			enable_client,
 			enable_server,
+			params_style,
 		}
 	}
 
-	pub fn try_from(tokens: TokenStream) -> Result<Self, syn::Error> {
-		if tokens.is_empty() {
-			return Ok(Self::new(true, true));
-		}
-		let ident: syn::Ident = syn::parse::<syn::Ident>(tokens)?;
-		let options = {
-			let ident = ident.to_string();
-			if ident == "client" {
-				Some(Self::new(true, false))
-			} else if ident == "server" {
-				Some(Self::new(false, true))
-			} else {
-				None
+	pub fn try_from(args: syn::AttributeArgs) -> Result<Self, syn::Error> {
+		let mut options = DeriveOptions::new(false, false, ParamStyle::default());
+		for arg in args {
+			if let syn::NestedMeta::Meta(meta) = arg {
+				match meta {
+					syn::Meta::Path(p) => {
+						match p.get_ident().unwrap().to_string().as_ref() {
+							CLIENT_META_WORD => options.enable_client = true,
+							SERVER_META_WORD => options.enable_server = true,
+							_ => {}
+						};
+					}
+					syn::Meta::NameValue(nv) => {
+						if path_eq_str(&nv.path, PARAMS_META_KEY) {
+							if let syn::Lit::Str(ref lit) = nv.lit {
+								options.params_style = ParamStyle::from_str(&lit.value())
+									.map_err(|e| syn::Error::new_spanned(nv.clone(), e))?;
+							}
+						} else {
+							return Err(syn::Error::new_spanned(nv, "Unexpected RPC attribute key"));
+						}
+					}
+					_ => return Err(syn::Error::new_spanned(meta, "Unexpected use of RPC attribute macro")),
+				}
 			}
-		};
-		match options {
-			Some(options) => Ok(options),
-			None => Err(syn::Error::new(ident.span(), "Unknown attribute.")),
 		}
+		if !options.enable_client && !options.enable_server {
+			// if nothing provided default to both
+			options.enable_client = true;
+			options.enable_server = true;
+		}
+		Ok(options)
 	}
 }

--- a/derive/src/params_style.rs
+++ b/derive/src/params_style.rs
@@ -4,7 +4,7 @@ const POSITIONAL: &str = "positional";
 const NAMED: &str = "named";
 const RAW: &str = "raw";
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ParamStyle {
 	Positional,
 	Named,

--- a/derive/src/params_style.rs
+++ b/derive/src/params_style.rs
@@ -1,0 +1,31 @@
+use std::str::FromStr;
+
+const POSITIONAL: &str = "positional";
+const NAMED: &str = "named";
+const RAW: &str = "raw";
+
+#[derive(Clone, Debug)]
+pub enum ParamStyle {
+	Positional,
+	Named,
+	Raw,
+}
+
+impl Default for ParamStyle {
+	fn default() -> Self {
+		Self::Positional
+	}
+}
+
+impl FromStr for ParamStyle {
+	type Err = String;
+
+	fn from_str(s: &str) -> Result<Self, String> { 
+		match s {
+			POSITIONAL => Ok(Self::Positional),
+			NAMED => Ok(Self::Named),
+			RAW => Ok(Self::Raw),
+			_ => Err(format!("Invalid value for params key. Must be one of [{}, {}, {}]", POSITIONAL, NAMED, RAW))
+		}
+	}
+}

--- a/derive/src/params_style.rs
+++ b/derive/src/params_style.rs
@@ -20,12 +20,15 @@ impl Default for ParamStyle {
 impl FromStr for ParamStyle {
 	type Err = String;
 
-	fn from_str(s: &str) -> Result<Self, String> { 
+	fn from_str(s: &str) -> Result<Self, String> {
 		match s {
 			POSITIONAL => Ok(Self::Positional),
 			NAMED => Ok(Self::Named),
 			RAW => Ok(Self::Raw),
-			_ => Err(format!("Invalid value for params key. Must be one of [{}, {}, {}]", POSITIONAL, NAMED, RAW))
+			_ => Err(format!(
+				"Invalid value for params key. Must be one of [{}, {}, {}]",
+				POSITIONAL, NAMED, RAW
+			)),
 		}
 	}
 }

--- a/derive/src/rpc_attr.rs
+++ b/derive/src/rpc_attr.rs
@@ -11,7 +11,7 @@ pub struct RpcMethodAttribute {
 	pub name: String,
 	pub aliases: Vec<String>,
 	pub kind: AttributeKind,
-	pub params_style: Option<ParamStyle>, // None means do not overrite the top level default
+	pub params_style: Option<ParamStyle>, // None means do not override the top level default
 }
 
 #[derive(Clone, Debug)]

--- a/derive/src/rpc_attr.rs
+++ b/derive/src/rpc_attr.rs
@@ -11,7 +11,6 @@ pub struct RpcMethodAttribute {
 	pub name: String,
 	pub aliases: Vec<String>,
 	pub kind: AttributeKind,
-	pub raw_params: bool,
 	pub params_style: ParamStyle,
 }
 
@@ -85,15 +84,16 @@ impl RpcMethodAttribute {
 								let aliases = get_meta_list(&meta).map_or(Vec::new(), |ml| get_aliases(ml));
 								let raw_params =
 									get_meta_list(meta).map_or(false, |ml| has_meta_word(RAW_PARAMS_META_WORD, ml));
-								let params_style = get_meta_list(meta)
-									.map_or(ParamStyle::default(), |ml| get_params_style(ml).unwrap_or(ParamStyle::default()));
-								// TODO: Error on invalid value
+								let params_style = match raw_params {
+									true => ParamStyle::Raw,
+									false => get_meta_list(meta)
+										.map_or(ParamStyle::default(), |ml| get_params_style(ml).unwrap_or(ParamStyle::default()))
+								};
 								Ok(RpcMethodAttribute {
 									attr: attr.clone(),
 									name,
 									aliases,
 									kind,
-									raw_params,
 									params_style,
 								})
 							})

--- a/derive/src/rpc_attr.rs
+++ b/derive/src/rpc_attr.rs
@@ -85,7 +85,10 @@ impl RpcMethodAttribute {
 								let raw_params =
 									get_meta_list(meta).map_or(false, |ml| has_meta_word(RAW_PARAMS_META_WORD, ml));
 								let params_style = match raw_params {
-									true => Ok(Some(ParamStyle::Raw)),
+									true => {
+										// "`raw_params` will be deprecated in a future release. Use `params = \"raw\" instead`"
+										Ok(Some(ParamStyle::Raw))
+									}
 									false => {
 										get_meta_list(meta).map_or(Ok(None), |ml| get_params_style(ml).map(|s| Some(s)))
 									}

--- a/derive/src/rpc_attr.rs
+++ b/derive/src/rpc_attr.rs
@@ -39,7 +39,7 @@ const SUBSCRIPTION_NAME_KEY: &str = "subscription";
 const ALIASES_KEY: &str = "alias";
 const PUB_SUB_ATTR_NAME: &str = "pubsub";
 const METADATA_META_WORD: &str = "meta";
-const RAW_PARAMS_META_WORD: &str = "raw_params"; // to be deprecated in favor of `params = "raw"`
+const RAW_PARAMS_META_WORD: &str = "raw_params"; // to be deprecated and replaced with `params = "raw"`
 const SUBSCRIBE_META_WORD: &str = "subscribe";
 const UNSUBSCRIBE_META_WORD: &str = "unsubscribe";
 const RETURNS_META_WORD: &str = "returns";
@@ -298,7 +298,7 @@ fn get_params_style(ml: &syn::MetaList) -> Result<ParamStyle> {
 	})
 }
 
-fn path_eq_str(path: &syn::Path, s: &str) -> bool {
+pub fn path_eq_str(path: &syn::Path, s: &str) -> bool {
 	path.get_ident().map_or(false, |i| i == s)
 }
 

--- a/derive/src/rpc_attr.rs
+++ b/derive/src/rpc_attr.rs
@@ -11,7 +11,7 @@ pub struct RpcMethodAttribute {
 	pub name: String,
 	pub aliases: Vec<String>,
 	pub kind: AttributeKind,
-	pub params_style: ParamStyle,
+	pub params_style: Option<ParamStyle>, // None means do not overrite the top level default
 }
 
 #[derive(Clone, Debug)]
@@ -85,9 +85,9 @@ impl RpcMethodAttribute {
 								let raw_params =
 									get_meta_list(meta).map_or(false, |ml| has_meta_word(RAW_PARAMS_META_WORD, ml));
 								let params_style = match raw_params {
-									true => Ok(ParamStyle::Raw),
+									true => Ok(Some(ParamStyle::Raw)),
 									false => {
-										get_meta_list(meta).map_or(Ok(ParamStyle::default()), |ml| get_params_style(ml))
+										get_meta_list(meta).map_or(Ok(None), |ml| get_params_style(ml).map(|s| Some(s)))
 									}
 								}?;
 								Ok(RpcMethodAttribute {

--- a/derive/src/rpc_attr.rs
+++ b/derive/src/rpc_attr.rs
@@ -85,11 +85,11 @@ impl RpcMethodAttribute {
 								let raw_params =
 									get_meta_list(meta).map_or(false, |ml| has_meta_word(RAW_PARAMS_META_WORD, ml));
 								let params_style = match raw_params {
-									true => ParamStyle::Raw,
-									false => get_meta_list(meta).map_or(ParamStyle::default(), |ml| {
-										get_params_style(ml).unwrap_or(ParamStyle::default())
-									}),
-								};
+									true => Ok(ParamStyle::Raw),
+									false => {
+										get_meta_list(meta).map_or(Ok(ParamStyle::default()), |ml| get_params_style(ml))
+									}
+								}?;
 								Ok(RpcMethodAttribute {
 									attr: attr.clone(),
 									name,

--- a/derive/src/rpc_attr.rs
+++ b/derive/src/rpc_attr.rs
@@ -83,8 +83,8 @@ impl RpcMethodAttribute {
 								let aliases = get_meta_list(&meta).map_or(Vec::new(), |ml| get_aliases(ml));
 								let raw_params =
 									get_meta_list(meta).map_or(false, |ml| has_meta_word(RAW_PARAMS_META_WORD, ml));
-								let named_params =
-									get_meta_list(meta).map_or(false, |ml| has_meta_word(USE_NAMED_PARAMS_META_WORD, ml));
+								let named_params = get_meta_list(meta)
+									.map_or(false, |ml| has_meta_word(USE_NAMED_PARAMS_META_WORD, ml));
 								Ok(RpcMethodAttribute {
 									attr: attr.clone(),
 									name,
@@ -183,7 +183,11 @@ fn validate_attribute_meta(meta: syn::Meta) -> Result<syn::Meta> {
 	let ident = path_to_str(meta.path());
 	match ident.as_ref().map(String::as_str) {
 		Some(RPC_ATTR_NAME) => {
-			validate_idents(&meta, &visitor.meta_words, &[METADATA_META_WORD, RAW_PARAMS_META_WORD, USE_NAMED_PARAMS_META_WORD])?;
+			validate_idents(
+				&meta,
+				&visitor.meta_words,
+				&[METADATA_META_WORD, RAW_PARAMS_META_WORD, USE_NAMED_PARAMS_META_WORD],
+			)?;
 			validate_idents(&meta, &visitor.name_value_names, &[RPC_NAME_KEY, RETURNS_META_WORD])?;
 			validate_idents(&meta, &visitor.meta_list_names, &[ALIASES_KEY])
 		}

--- a/derive/src/rpc_attr.rs
+++ b/derive/src/rpc_attr.rs
@@ -10,6 +10,7 @@ pub struct RpcMethodAttribute {
 	pub aliases: Vec<String>,
 	pub kind: AttributeKind,
 	pub raw_params: bool,
+	pub named_params: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -38,6 +39,7 @@ const ALIASES_KEY: &str = "alias";
 const PUB_SUB_ATTR_NAME: &str = "pubsub";
 const METADATA_META_WORD: &str = "meta";
 const RAW_PARAMS_META_WORD: &str = "raw_params";
+const USE_NAMED_PARAMS_META_WORD: &str = "named_params";
 const SUBSCRIBE_META_WORD: &str = "subscribe";
 const UNSUBSCRIBE_META_WORD: &str = "unsubscribe";
 const RETURNS_META_WORD: &str = "returns";
@@ -81,12 +83,15 @@ impl RpcMethodAttribute {
 								let aliases = get_meta_list(&meta).map_or(Vec::new(), |ml| get_aliases(ml));
 								let raw_params =
 									get_meta_list(meta).map_or(false, |ml| has_meta_word(RAW_PARAMS_META_WORD, ml));
+								let named_params =
+									get_meta_list(meta).map_or(false, |ml| has_meta_word(USE_NAMED_PARAMS_META_WORD, ml));
 								Ok(RpcMethodAttribute {
 									attr: attr.clone(),
 									name,
 									aliases,
 									kind,
 									raw_params,
+									named_params,
 								})
 							})
 					})
@@ -178,7 +183,7 @@ fn validate_attribute_meta(meta: syn::Meta) -> Result<syn::Meta> {
 	let ident = path_to_str(meta.path());
 	match ident.as_ref().map(String::as_str) {
 		Some(RPC_ATTR_NAME) => {
-			validate_idents(&meta, &visitor.meta_words, &[METADATA_META_WORD, RAW_PARAMS_META_WORD])?;
+			validate_idents(&meta, &visitor.meta_words, &[METADATA_META_WORD, RAW_PARAMS_META_WORD, USE_NAMED_PARAMS_META_WORD])?;
 			validate_idents(&meta, &visitor.name_value_names, &[RPC_NAME_KEY, RETURNS_META_WORD])?;
 			validate_idents(&meta, &visitor.meta_list_names, &[ALIASES_KEY])
 		}

--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -226,7 +226,7 @@ fn rpc_wrapper_mod_name(rpc_trait: &syn::ItemTrait) -> syn::Ident {
 fn has_named_params(methods: &[RpcMethod]) -> bool {
 	methods
 		.iter()
-		.any(|method| method.attr.params_style == std::option::Option::Some(ParamStyle::Named))
+		.any(|method| method.attr.params_style == Some(ParamStyle::Named))
 }
 
 pub fn crate_name(name: &str) -> Result<Ident> {

--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -226,7 +226,7 @@ fn rpc_wrapper_mod_name(rpc_trait: &syn::ItemTrait) -> syn::Ident {
 fn has_named_params(methods: &[RpcMethod]) -> bool {
 	methods
 		.iter()
-		.any(|method| method.attr.params_style == ParamStyle::Named)
+		.any(|method| method.attr.params_style == std::option::Option::Some(ParamStyle::Named))
 }
 
 pub fn crate_name(name: &str) -> Result<Ident> {
@@ -235,7 +235,7 @@ pub fn crate_name(name: &str) -> Result<Ident> {
 		.map_err(|e| Error::new(Span::call_site(), &e))
 }
 
-pub fn rpc_impl(input: syn::Item, options: DeriveOptions) -> Result<proc_macro2::TokenStream> {
+pub fn rpc_impl(input: syn::Item, options: &DeriveOptions) -> Result<proc_macro2::TokenStream> {
 	let rpc_trait = match input {
 		syn::Item::Trait(item_trait) => item_trait,
 		item => {
@@ -256,7 +256,7 @@ pub fn rpc_impl(input: syn::Item, options: DeriveOptions) -> Result<proc_macro2:
 	let mut submodules = Vec::new();
 	let mut exports = Vec::new();
 	if options.enable_client {
-		let rpc_client_module = generate_client_module(&method_registrations, &rpc_trait)?;
+		let rpc_client_module = generate_client_module(&method_registrations, &rpc_trait, options)?;
 		submodules.push(rpc_client_module);
 		exports.push(quote! {
 			pub use self::#mod_name_ident::gen_client;

--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -2,6 +2,7 @@ use crate::options::DeriveOptions;
 use crate::rpc_attr::{AttributeKind, PubSubMethodKind, RpcMethodAttribute};
 use crate::to_client::generate_client_module;
 use crate::to_delegate::{generate_trait_item_method, MethodRegistration, RpcMethod};
+use crate::params_style::ParamStyle;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use std::collections::HashMap;
@@ -22,7 +23,7 @@ const MISSING_UNSUBSCRIBE_METHOD_ERR: &str =
 	 e.g. `#[pubsub(subscription = \"hello\", unsubscribe, name = \"hello_unsubscribe\")]`";
 
 const USING_NAMED_PARAMS_WITH_SERVER_ERR: &str =
-	"The named_params switch can only be used to generate a client (on a trait annotated with #[rpc(client)]). \
+	"`params = \"named\"` can only be used to generate a client (on a trait annotated with #[rpc(client)]). \
 	 At this time the server does not support named parameters.";
 
 const RPC_MOD_NAME_PREFIX: &str = "rpc_impl_";
@@ -223,7 +224,7 @@ fn rpc_wrapper_mod_name(rpc_trait: &syn::ItemTrait) -> syn::Ident {
 }
 
 fn has_named_params(methods: &[RpcMethod]) -> bool {
-	methods.iter().any(|method| method.attr.named_params)
+	methods.iter().any(|method| method.attr.params_style == ParamStyle::Named)
 }
 
 pub fn crate_name(name: &str) -> Result<Ident> {

--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -223,9 +223,7 @@ fn rpc_wrapper_mod_name(rpc_trait: &syn::ItemTrait) -> syn::Ident {
 }
 
 fn has_named_params(methods: &[RpcMethod]) -> bool {
-	methods.iter().any(|method| {
-		method.attr.named_params
-	})
+	methods.iter().any(|method| method.attr.named_params)
 }
 
 pub fn crate_name(name: &str) -> Result<Ident> {
@@ -263,10 +261,7 @@ pub fn rpc_impl(input: syn::Item, options: DeriveOptions) -> Result<proc_macro2:
 	}
 	if options.enable_server {
 		if has_named_params(&methods) {
-			return Err(syn::Error::new_spanned(
-				rpc_trait,
-				USING_NAMED_PARAMS_WITH_SERVER_ERR,
-			));
+			return Err(syn::Error::new_spanned(rpc_trait, USING_NAMED_PARAMS_WITH_SERVER_ERR));
 		}
 		let rpc_server_module = generate_server_module(&method_registrations, &rpc_trait, &methods)?;
 		submodules.push(rpc_server_module);

--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -1,8 +1,8 @@
 use crate::options::DeriveOptions;
+use crate::params_style::ParamStyle;
 use crate::rpc_attr::{AttributeKind, PubSubMethodKind, RpcMethodAttribute};
 use crate::to_client::generate_client_module;
 use crate::to_delegate::{generate_trait_item_method, MethodRegistration, RpcMethod};
-use crate::params_style::ParamStyle;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use std::collections::HashMap;
@@ -224,7 +224,9 @@ fn rpc_wrapper_mod_name(rpc_trait: &syn::ItemTrait) -> syn::Ident {
 }
 
 fn has_named_params(methods: &[RpcMethod]) -> bool {
-	methods.iter().any(|method| method.attr.params_style == ParamStyle::Named)
+	methods
+		.iter()
+		.any(|method| method.attr.params_style == ParamStyle::Named)
 }
 
 pub fn crate_name(name: &str) -> Result<Ident> {

--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -22,7 +22,7 @@ const MISSING_UNSUBSCRIBE_METHOD_ERR: &str =
 	"Can't find unsubscribe method, expected a method annotated with `unsubscribe` \
 	 e.g. `#[pubsub(subscription = \"hello\", unsubscribe, name = \"hello_unsubscribe\")]`";
 
-const USING_NAMED_PARAMS_WITH_SERVER_ERR: &str =
+pub const USING_NAMED_PARAMS_WITH_SERVER_ERR: &str =
 	"`params = \"named\"` can only be used to generate a client (on a trait annotated with #[rpc(client)]). \
 	 At this time the server does not support named parameters.";
 

--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -21,6 +21,10 @@ const MISSING_UNSUBSCRIBE_METHOD_ERR: &str =
 	"Can't find unsubscribe method, expected a method annotated with `unsubscribe` \
 	 e.g. `#[pubsub(subscription = \"hello\", unsubscribe, name = \"hello_unsubscribe\")]`";
 
+const USING_NAMED_PARAMS_WITH_SERVER_ERR: &str =
+	"The named_params switch can only be used to generate a client (on a trait annotated with #[rpc(client)]). \
+	 At this time the server does not support named parameters.";
+
 const RPC_MOD_NAME_PREFIX: &str = "rpc_impl_";
 
 struct RpcTrait {
@@ -261,9 +265,7 @@ pub fn rpc_impl(input: syn::Item, options: DeriveOptions) -> Result<proc_macro2:
 		if has_named_params(&methods) {
 			return Err(syn::Error::new_spanned(
 				rpc_trait,
-				"The named_params switch can only be used to generate a client (on a trait annotated with #[rpc(client)]).
-				 At this time the server does not support named parameters.
-				",
+				USING_NAMED_PARAMS_WITH_SERVER_ERR,
 			));
 		}
 		let rpc_server_module = generate_server_module(&method_registrations, &rpc_trait, &methods)?;

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -102,14 +102,16 @@ fn generate_client_methods(methods: &[MethodRegistration]) -> Result<Vec<syn::Im
 				let returns_str = quote!(#returns).to_string();
 
 				let args_serialized = match method.attr.named_params {
-					true => quote! {  // use object style serialization with field names taken from the function param names
-						serde_json::json!({
-							#(stringify!(#arg_names): #arg_names,)*
-						})
-					}, 
+					true => {
+						quote! {  // use object style serialization with field names taken from the function param names
+							serde_json::json!({
+								#(stringify!(#arg_names): #arg_names,)*
+							})
+						}
+					}
 					false => quote! {  // use tuple style serialization
 						(#(#arg_names,)*)
-					}, 
+					},
 				};
 
 				let client_method = syn::parse_quote! {

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -1,7 +1,7 @@
+use crate::params_style::ParamStyle;
 use crate::rpc_attr::AttributeKind;
 use crate::rpc_trait::crate_name;
 use crate::to_delegate::{generate_where_clause_serialization_predicates, MethodRegistration};
-use crate::params_style::ParamStyle;
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use syn::punctuated::Punctuated;
@@ -110,8 +110,12 @@ fn generate_client_methods(methods: &[MethodRegistration]) -> Result<Vec<syn::Im
 							})
 						}
 					}
-					ParamStyle::Positional | ParamStyle::Raw => quote! {  // use tuple style serialization
+					ParamStyle::Positional => quote! {  // use tuple style serialization
 						(#(#arg_names,)*)
+					},
+					ParamStyle::Raw => match arg_names.first() {
+						Some(arg_name) => quote! {#arg_name},
+						None => quote! {serde_json::Value::Null},
 					},
 				};
 

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -1,3 +1,4 @@
+use crate::options::DeriveOptions;
 use crate::params_style::ParamStyle;
 use crate::rpc_attr::AttributeKind;
 use crate::rpc_trait::crate_name;
@@ -7,8 +8,12 @@ use quote::quote;
 use syn::punctuated::Punctuated;
 use syn::Result;
 
-pub fn generate_client_module(methods: &[MethodRegistration], item_trait: &syn::ItemTrait) -> Result<TokenStream> {
-	let client_methods = generate_client_methods(methods)?;
+pub fn generate_client_module(
+	methods: &[MethodRegistration],
+	item_trait: &syn::ItemTrait,
+	options: &DeriveOptions,
+) -> Result<TokenStream> {
+	let client_methods = generate_client_methods(methods, &options)?;
 	let generics = &item_trait.generics;
 	let where_clause = generate_where_clause_serialization_predicates(&item_trait, true);
 	let where_clause2 = where_clause.clone();
@@ -86,7 +91,7 @@ pub fn generate_client_module(methods: &[MethodRegistration], item_trait: &syn::
 	})
 }
 
-fn generate_client_methods(methods: &[MethodRegistration]) -> Result<Vec<syn::ImplItem>> {
+fn generate_client_methods(methods: &[MethodRegistration], options: &DeriveOptions) -> Result<Vec<syn::ImplItem>> {
 	let mut client_methods = vec![];
 	for method in methods {
 		match method {
@@ -102,7 +107,7 @@ fn generate_client_methods(methods: &[MethodRegistration]) -> Result<Vec<syn::Im
 				};
 				let returns_str = quote!(#returns).to_string();
 
-				let args_serialized = match method.attr.params_style {
+				let args_serialized = match method.attr.params_style.clone().unwrap_or(options.params_style.clone()) {
 					ParamStyle::Named => {
 						quote! {  // use object style serialization with field names taken from the function param names
 							serde_json::json!({

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -1,6 +1,7 @@
 use crate::rpc_attr::AttributeKind;
 use crate::rpc_trait::crate_name;
 use crate::to_delegate::{generate_where_clause_serialization_predicates, MethodRegistration};
+use crate::params_style::ParamStyle;
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use syn::punctuated::Punctuated;
@@ -101,15 +102,15 @@ fn generate_client_methods(methods: &[MethodRegistration]) -> Result<Vec<syn::Im
 				};
 				let returns_str = quote!(#returns).to_string();
 
-				let args_serialized = match method.attr.named_params {
-					true => {
+				let args_serialized = match method.attr.params_style {
+					ParamStyle::Named => {
 						quote! {  // use object style serialization with field names taken from the function param names
 							serde_json::json!({
 								#(stringify!(#arg_names): #arg_names,)*
 							})
 						}
 					}
-					false => quote! {  // use tuple style serialization
+					ParamStyle::Positional | ParamStyle::Raw => quote! {  // use tuple style serialization
 						(#(#arg_names,)*)
 					},
 				};

--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -240,8 +240,10 @@ impl RpcMethod {
 				quote! { let params = params.expect_no_params(); }
 			} else if self.attr.params_style == Some(ParamStyle::Raw) {
 				quote! { let params: _jsonrpc_core::Result<_> = Ok((params,)); }
-			} else {
+			} else if self.attr.params_style == Some(ParamStyle::Positional) {
 				quote! { let params = params.parse::<(#(#param_types, )*)>(); }
+			} else /* if self.attr.params_style == Some(ParamStyle::Named) */ {
+				unimplemented!("Server side named parameters are not implemented");
 			}
 		};
 

--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use crate::rpc_attr::RpcMethodAttribute;
+use crate::params_style::ParamStyle;
 use quote::quote;
 use syn::{
 	parse_quote,
@@ -218,7 +219,6 @@ impl RpcMethod {
 		// special args are those which are not passed directly via rpc params: metadata, subscriber
 		let special_args = Self::special_args(&param_types);
 		param_types.retain(|ty| special_args.iter().find(|(_, sty)| sty == ty).is_none());
-
 		if param_types.len() > TUPLE_FIELD_NAMES.len() {
 			return Err(syn::Error::new_spanned(
 				&self.trait_item,
@@ -238,7 +238,7 @@ impl RpcMethod {
 				self.params_with_trailing(trailing_args_num, param_types, tuple_fields)
 			} else if param_types.is_empty() {
 				quote! { let params = params.expect_no_params(); }
-			} else if self.attr.raw_params {
+			} else if self.attr.params_style == ParamStyle::Raw {
 				quote! { let params: _jsonrpc_core::Result<_> = Ok((params,)); }
 			} else {
 				quote! { let params = params.parse::<(#(#param_types, )*)>(); }

--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -242,7 +242,9 @@ impl RpcMethod {
 				quote! { let params: _jsonrpc_core::Result<_> = Ok((params,)); }
 			} else if self.attr.params_style == Some(ParamStyle::Positional) {
 				quote! { let params = params.parse::<(#(#param_types, )*)>(); }
-			} else /* if self.attr.params_style == Some(ParamStyle::Named) */ {
+			} else
+			/* if self.attr.params_style == Some(ParamStyle::Named) */
+			{
 				unimplemented!("Server side named parameters are not implemented");
 			}
 		};

--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -238,7 +238,7 @@ impl RpcMethod {
 				self.params_with_trailing(trailing_args_num, param_types, tuple_fields)
 			} else if param_types.is_empty() {
 				quote! { let params = params.expect_no_params(); }
-			} else if self.attr.params_style == ParamStyle::Raw {
+			} else if self.attr.params_style == Some(ParamStyle::Raw) {
 				quote! { let params: _jsonrpc_core::Result<_> = Ok((params,)); }
 			} else {
 				quote! { let params = params.parse::<(#(#param_types, )*)>(); }

--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
-use crate::rpc_attr::RpcMethodAttribute;
 use crate::params_style::ParamStyle;
+use crate::rpc_attr::RpcMethodAttribute;
 use quote::quote;
 use syn::{
 	parse_quote,

--- a/derive/tests/client.rs
+++ b/derive/tests/client.rs
@@ -46,9 +46,7 @@ mod client_server {
 			});
 		tokio::run(fut);
 	}
-
 }
-
 
 mod named_params {
 	use super::*;
@@ -75,9 +73,7 @@ mod named_params {
 		});
 
 		let mut handler = IoHandler::new();
-		handler.add_method("call_with_named", |params: Params| {
-			Ok(params.into())
-		});
+		handler.add_method("call_with_named", |params: Params| Ok(params.into()));
 
 		let (client, rpc_client) = local::connect::<gen_client::Client, _, _>(handler);
 		let fut = client
@@ -94,5 +90,4 @@ mod named_params {
 			});
 		tokio::run(fut);
 	}
-
 }

--- a/derive/tests/client.rs
+++ b/derive/tests/client.rs
@@ -6,7 +6,7 @@ use jsonrpc_derive::rpc;
 mod client_server {
 	use super::*;
 
-	#[rpc]
+	#[rpc(params = "positional")]
 	pub trait Rpc {
 		#[rpc(name = "add")]
 		fn add(&self, a: u64, b: u64) -> Result<u64>;

--- a/derive/tests/client.rs
+++ b/derive/tests/client.rs
@@ -3,43 +3,96 @@ use jsonrpc_core::{IoHandler, Result};
 use jsonrpc_core_client::transports::local;
 use jsonrpc_derive::rpc;
 
-#[rpc]
-pub trait Rpc {
-	#[rpc(name = "add")]
-	fn add(&self, a: u64, b: u64) -> Result<u64>;
+mod client_server {
+	use super::*;
 
-	#[rpc(name = "notify")]
-	fn notify(&self, foo: u64);
-}
+	#[rpc]
+	pub trait Rpc {
+		#[rpc(name = "add")]
+		fn add(&self, a: u64, b: u64) -> Result<u64>;
 
-struct RpcServer;
-
-impl Rpc for RpcServer {
-	fn add(&self, a: u64, b: u64) -> Result<u64> {
-		Ok(a + b)
+		#[rpc(name = "notify")]
+		fn notify(&self, foo: u64);
 	}
 
-	fn notify(&self, foo: u64) {
-		println!("received {}", foo);
+	struct RpcServer;
+
+	impl Rpc for RpcServer {
+		fn add(&self, a: u64, b: u64) -> Result<u64> {
+			Ok(a + b)
+		}
+
+		fn notify(&self, foo: u64) {
+			println!("received {}", foo);
+		}
 	}
+
+	#[test]
+	fn client_server_roundtrip() {
+		let mut handler = IoHandler::new();
+		handler.extend_with(RpcServer.to_delegate());
+		let (client, rpc_client) = local::connect::<gen_client::Client, _, _>(handler);
+		let fut = client
+			.clone()
+			.add(3, 4)
+			.and_then(move |res| client.notify(res).map(move |_| res))
+			.join(rpc_client)
+			.map(|(res, ())| {
+				assert_eq!(res, 7);
+			})
+			.map_err(|err| {
+				eprintln!("{:?}", err);
+				assert!(false);
+			});
+		tokio::run(fut);
+	}
+
 }
 
-#[test]
-fn client_server_roundtrip() {
-	let mut handler = IoHandler::new();
-	handler.extend_with(RpcServer.to_delegate());
-	let (client, rpc_client) = local::connect::<gen_client::Client, _, _>(handler);
-	let fut = client
-		.clone()
-		.add(3, 4)
-		.and_then(move |res| client.notify(res).map(move |_| res))
-		.join(rpc_client)
-		.map(|(res, ())| {
-			assert_eq!(res, 7);
-		})
-		.map_err(|err| {
-			eprintln!("{:?}", err);
-			assert!(false);
+
+mod named_params {
+	use super::*;
+	use jsonrpc_core::Params;
+	use serde_json::json;
+
+	#[rpc(client)]
+	pub trait Rpc {
+		#[rpc(name = "call_with_named", named_params)]
+		fn call_with_named(&self, number: u64, string: String, json: serde_json::Value) -> Result<serde_json::Value>;
+
+		#[rpc(name = "notify")]
+		fn notify(&self, payload: serde_json::Value);
+	}
+
+	#[test]
+	fn client_generates_correct_named_params_payload() {
+		let expected = json!({ // key names are derived from function parameter names in the trait
+			"number": 3,
+			"string": String::from("test string"),
+			"json": {
+				"key": ["value"]
+			}
 		});
-	tokio::run(fut);
+
+		let mut handler = IoHandler::new();
+		handler.add_method("call_with_named", |params: Params| {
+			Ok(params.into())
+		});
+
+		let (client, rpc_client) = local::connect::<gen_client::Client, _, _>(handler);
+		let fut = client
+			.clone()
+			.call_with_named(3, String::from("test string"), json!({"key": ["value"]}))
+			.and_then(move |res| client.notify(res.clone()).map(move |_| res))
+			.join(rpc_client)
+			.map(move |(res, ())| {
+				assert_eq!(res, expected);
+			})
+			.map_err(|err| {
+				eprintln!("{:?}", err);
+				assert!(false);
+			});
+		tokio::run(fut);
+	}
+
 }

--- a/derive/tests/client.rs
+++ b/derive/tests/client.rs
@@ -102,7 +102,7 @@ mod raw_params {
 		#[rpc(name = "call_raw", params = "raw")]
 		fn call_raw_single_param(&self, params: Value) -> Result<Value>;
 
-		#[rpc(name = "notify")]
+		#[rpc(name = "notify", params = "raw")]
 		fn notify(&self, payload: Value);
 	}
 

--- a/derive/tests/client.rs
+++ b/derive/tests/client.rs
@@ -56,10 +56,10 @@ mod named_params {
 	#[rpc(client)]
 	pub trait Rpc {
 		#[rpc(name = "call_with_named", params = "named")]
-		fn call_with_named(&self, number: u64, string: String, json: serde_json::Value) -> Result<serde_json::Value>;
+		fn call_with_named(&self, number: u64, string: String, json: Value) -> Result<Value>;
 
 		#[rpc(name = "notify")]
-		fn notify(&self, payload: serde_json::Value);
+		fn notify(&self, payload: Value);
 	}
 
 	#[test]
@@ -79,6 +79,48 @@ mod named_params {
 		let fut = client
 			.clone()
 			.call_with_named(3, String::from("test string"), json!({"key": ["value"]}))
+			.and_then(move |res| client.notify(res.clone()).map(move |_| res))
+			.join(rpc_client)
+			.map(move |(res, ())| {
+				assert_eq!(res, expected);
+			})
+			.map_err(|err| {
+				eprintln!("{:?}", err);
+				assert!(false);
+			});
+		tokio::run(fut);
+	}
+}
+
+mod raw_params {
+	use super::*;
+	use jsonrpc_core::Params;
+	use serde_json::json;
+
+	#[rpc(client)]
+	pub trait Rpc {
+		#[rpc(name = "call_raw", params = "raw")]
+		fn call_raw_single_param(&self, params: Value) -> Result<Value>;
+
+		#[rpc(name = "notify")]
+		fn notify(&self, payload: Value);
+	}
+
+	#[test]
+	fn client_generates_correct_raw_params_payload() {
+		let expected = json!({
+			"sub_object": {
+				"key": ["value"]
+			}
+		});
+
+		let mut handler = IoHandler::new();
+		handler.add_method("call_raw", |params: Params| Ok(params.into()));
+
+		let (client, rpc_client) = local::connect::<gen_client::Client, _, _>(handler);
+		let fut = client
+			.clone()
+			.call_raw_single_param(expected.clone())
 			.and_then(move |res| client.notify(res.clone()).map(move |_| res))
 			.join(rpc_client)
 			.map(move |(res, ())| {

--- a/derive/tests/client.rs
+++ b/derive/tests/client.rs
@@ -53,12 +53,12 @@ mod named_params {
 	use jsonrpc_core::Params;
 	use serde_json::json;
 
-	#[rpc(client)]
+	#[rpc(client, params = "named")]
 	pub trait Rpc {
-		#[rpc(name = "call_with_named", params = "named")]
+		#[rpc(name = "call_with_named")]
 		fn call_with_named(&self, number: u64, string: String, json: Value) -> Result<Value>;
 
-		#[rpc(name = "notify")]
+		#[rpc(name = "notify", params = "raw")]
 		fn notify(&self, payload: Value);
 	}
 

--- a/derive/tests/client.rs
+++ b/derive/tests/client.rs
@@ -55,7 +55,7 @@ mod named_params {
 
 	#[rpc(client)]
 	pub trait Rpc {
-		#[rpc(name = "call_with_named", named_params)]
+		#[rpc(name = "call_with_named", params = "named")]
 		fn call_with_named(&self, number: u64, string: String, json: serde_json::Value) -> Result<serde_json::Value>;
 
 		#[rpc(name = "notify")]

--- a/derive/tests/macros.rs
+++ b/derive/tests/macros.rs
@@ -27,7 +27,7 @@ pub trait Rpc {
 	fn add(&self, a: u64, b: u64) -> Result<u64>;
 
 	/// Retrieves and debug prints the underlying `Params` object.
-	#[rpc(name = "raw", raw_params)]
+	#[rpc(name = "raw", params = "raw")]
 	fn raw(&self, params: Params) -> Result<String>;
 
 	/// Handles a notification.

--- a/derive/tests/ui/attr-invalid-meta-words.stderr
+++ b/derive/tests/ui/attr-invalid-meta-words.stderr
@@ -1,4 +1,4 @@
-error: Invalid attribute parameter(s): 'Xmeta'. Expected 'meta, raw_params'
+error: Invalid attribute parameter(s): 'Xmeta'. Expected 'meta, raw_params, named_params'
  --> $DIR/attr-invalid-meta-words.rs:5:2
   |
 5 |       /// Returns a protocol version

--- a/derive/tests/ui/attr-invalid-meta-words.stderr
+++ b/derive/tests/ui/attr-invalid-meta-words.stderr
@@ -1,4 +1,4 @@
-error: Invalid attribute parameter(s): 'Xmeta'. Expected 'meta, raw_params, named_params'
+error: Invalid attribute parameter(s): 'Xmeta'. Expected 'meta, raw_params'
  --> $DIR/attr-invalid-meta-words.rs:5:2
   |
 5 |       /// Returns a protocol version

--- a/derive/tests/ui/attr-invalid-name-values.stderr
+++ b/derive/tests/ui/attr-invalid-name-values.stderr
@@ -1,4 +1,4 @@
-error: Invalid attribute parameter(s): 'Xname'. Expected 'name, returns'
+error: Invalid attribute parameter(s): 'Xname'. Expected 'name, returns, params'
  --> $DIR/attr-invalid-name-values.rs:5:2
   |
 5 |       /// Returns a protocol version

--- a/derive/tests/ui/attr-named-params-on-server.rs
+++ b/derive/tests/ui/attr-named-params-on-server.rs
@@ -1,0 +1,10 @@
+use jsonrpc_derive::rpc;
+
+#[rpc]
+pub trait Rpc {
+	/// Returns a protocol version
+	#[rpc(name = "add", named_params)]
+	fn add(&self, a: u32, b: u32) -> Result<String>;
+}
+
+fn main() {}

--- a/derive/tests/ui/attr-named-params-on-server.rs
+++ b/derive/tests/ui/attr-named-params-on-server.rs
@@ -3,7 +3,7 @@ use jsonrpc_derive::rpc;
 #[rpc]
 pub trait Rpc {
 	/// Returns a protocol version
-	#[rpc(name = "add", named_params)]
+	#[rpc(name = "add", params = "named")]
 	fn add(&self, a: u32, b: u32) -> Result<String>;
 }
 

--- a/derive/tests/ui/attr-named-params-on-server.stderr
+++ b/derive/tests/ui/attr-named-params-on-server.stderr
@@ -1,0 +1,9 @@
+error: The named_params switch can only be used to generate a client (on a trait annotated with #[rpc(client)]). At this time the server does not support named parameters.
+ --> $DIR/attr-named-params-on-server.rs:4:1
+  |
+4 | / pub trait Rpc {
+5 | |     /// Returns a protocol version
+6 | |     #[rpc(name = "add", named_params)]
+7 | |     fn add(&self, a: u32, b: u32) -> Result<String>;
+8 | | }
+  | |_^

--- a/derive/tests/ui/attr-named-params-on-server.stderr
+++ b/derive/tests/ui/attr-named-params-on-server.stderr
@@ -1,9 +1,9 @@
-error: The named_params switch can only be used to generate a client (on a trait annotated with #[rpc(client)]). At this time the server does not support named parameters.
+error: `params = "named"` can only be used to generate a client (on a trait annotated with #[rpc(client)]). At this time the server does not support named parameters.
  --> $DIR/attr-named-params-on-server.rs:4:1
   |
 4 | / pub trait Rpc {
 5 | |     /// Returns a protocol version
-6 | |     #[rpc(name = "add", named_params)]
+6 | |     #[rpc(name = "add", params = "named")]
 7 | |     fn add(&self, a: u32, b: u32) -> Result<String>;
 8 | | }
   | |_^

--- a/derive/tests/ui/trait-attr-named-params-on-server.rs
+++ b/derive/tests/ui/trait-attr-named-params-on-server.rs
@@ -1,0 +1,7 @@
+use jsonrpc_derive::rpc;
+
+#[rpc(server, params = "named")]
+pub trait Rpc {
+}
+
+fn main() {}

--- a/derive/tests/ui/trait-attr-named-params-on-server.stderr
+++ b/derive/tests/ui/trait-attr-named-params-on-server.stderr
@@ -1,0 +1,7 @@
+error: custom attribute panicked
+ --> $DIR/trait-attr-named-params-on-server.rs:3:1
+  |
+3 | #[rpc(server, params = "named")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: Server code generation only supports `params = "positional"` at this time. This is the default setting.

--- a/derive/tests/ui/trait-attr-named-params-on-server.stderr
+++ b/derive/tests/ui/trait-attr-named-params-on-server.stderr
@@ -4,4 +4,4 @@ error: custom attribute panicked
 3 | #[rpc(server, params = "named")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = help: message: Server code generation only supports `params = "positional"` at this time. This is the default setting.
+  = help: message: Server code generation only supports `params = "positional"` (default) or `params = "raw" at this time.


### PR DESCRIPTION
# Add named_params option to RPC derive macro

Closes #540 

While the server generated by the derive macro doesn't support calling functions with named params some other systems do (some exclusively). It would still be nice to use the clean derive macro syntax to generate a client in this case.

This PR adds a flag `named_params` to the rpc method attribute. Example:
```rust
#[rpc(name = "add", named_params)]
fn add(&self, a: u32, b: u32) -> Result<String>;
```
In this case the json-rpc call object produced by calling the generated method on a client will have a params object that takes the key names from the function parameter names.
```json
{
   "jsonrpc": "2.0",
   "params": {"a": 4, "b": 2},
   ...
}
```

As the server doesn't support this it is important that this cannot be used when deriving server RPC methods. The rpc derive macro will throw a compile time error if the `named_params` switch is used in any case other than `#[rpc(client)]`. See (derive/tests/ui/attr-named-params-on-server.rs)