### PR TITLE
Add "Accept:application/json" header for all requests.

### DIFF
--- a/core-client/transports/src/transports/http.rs
+++ b/core-client/transports/src/transports/http.rs
@@ -60,6 +60,10 @@ where
 					http::header::CONTENT_TYPE,
 					http::header::HeaderValue::from_static("application/json"),
 				)
+				.header(
+					http::header::ACCEPT,
+					http::header::HeaderValue::from_static("application/json"),
+				)
 				.body(request.into())
 				.expect("Uri and request headers are valid; qed");
 


### PR DESCRIPTION
As discussed in #542 .
Add accept header for client http requests so that it can work with some other libs/existing servers that require this field.