### PR TITLE
Wait for published version to be available

### DIFF
--- a/_automate/publish.sh
+++ b/_automate/publish.sh
@@ -23,6 +23,7 @@ for crate in ${ORDER[@]}; do
 	cd $crate
 	VERSION=$(grep "^version" ./Cargo.toml | sed -e 's/.*"\(.*\)"/\1/')
 	echo "Publishing $crate@$VERSION"
+	sleep 5 # give the user an opportunity to abort before publishing
 	cargo publish $@ || read -p ">>>>> Publishing $crate failed. Press [enter] to continue. "
   echo "  Waiting for published version $VERSION to be available..."
 	CRATE_NAME=$(grep "^name" ./Cargo.toml | sed -e 's/.*"\(.*\)"/\1/')

--- a/_automate/publish.sh
+++ b/_automate/publish.sh
@@ -23,8 +23,16 @@ for crate in ${ORDER[@]}; do
 	cd $crate
 	VERSION=$(grep "^version" ./Cargo.toml | sed -e 's/.*"\(.*\)"/\1/')
 	echo "Publishing $crate@$VERSION"
-	sleep 5
 	cargo publish $@ || read -p ">>>>> Publishing $crate failed. Press [enter] to continue. "
+  echo "  Waiting for published version $VERSION to be available..."
+	CRATE_NAME=$(grep "^name" ./Cargo.toml | sed -e 's/.*"\(.*\)"/\1/')
+	LATEST_VERSION=0
+	while [[ $LATEST_VERSION != $VERSION ]]
+	do
+	  sleep 3
+	  LATEST_VERSION=$(cargo search "$CRATE_NAME" | grep "^$CRATE_NAME =" | sed -e 's/.*"\(.*\)".*/\1/')
+	  echo "    Latest available version: $LATEST_VERSION"
+	done
 	cd -
 done
 


### PR DESCRIPTION
When I was publishing `14.1.0` the publish script repeatedly failed where a dependency on a previously published crate was not yet available.

This PR waits for the published version to be available after publishing each package before moving on to the next one.

Note that I have only tested this with the `cargo publish` commented out, not with an actual release.