### PR TITLE
Add a subscription manager

### DIFF
--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -20,6 +20,7 @@ rand = "0.7"
 [dev-dependencies]
 jsonrpc-tcp-server = { version = "14.1", path = "../tcp" }
 futures = { version = "0.3", features = ["compat", "thread-pool"] }
+lazy_static = "1.4"
 
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4"
 parking_lot = "0.10.0"
 jsonrpc-core = { version = "14.1", path = "../core" }
 serde = "1.0"
+rand = "0.7"
 
 [dev-dependencies]
 jsonrpc-tcp-server = { version = "14.1", path = "../tcp" }

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -19,6 +19,7 @@ rand = "0.7"
 
 [dev-dependencies]
 jsonrpc-tcp-server = { version = "14.1", path = "../tcp" }
+futures = { version = "0.3", features = ["compat", "thread-pool"] }
 
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/pubsub/src/lib.rs
+++ b/pubsub/src/lib.rs
@@ -9,6 +9,7 @@ extern crate log;
 
 mod delegates;
 mod handler;
+pub mod manager;
 pub mod oneshot;
 mod subscription;
 pub mod typed;

--- a/pubsub/src/manager.rs
+++ b/pubsub/src/manager.rs
@@ -130,12 +130,12 @@ impl Default for RandomStringIdProvider {
 pub struct SubscriptionManager<I: IdProvider = RandomStringIdProvider> {
 	id_provider: I,
 	active_subscriptions: ActiveSubscriptions,
-	executor: TaskExecutor, // Make generic?
+	executor: TaskExecutor,
 }
 
 impl<I: IdProvider> SubscriptionManager<I> {
 	/// Creates a new SubscriptionManager.
-	pub fn new_with_id_provider(id_provider: I, executor: TaskExecutor) -> Self {
+	pub fn with_id_provider(id_provider: I, executor: TaskExecutor) -> Self {
 		Self {
 			id_provider,
 			active_subscriptions: Default::default(),

--- a/pubsub/src/manager.rs
+++ b/pubsub/src/manager.rs
@@ -127,7 +127,7 @@ impl Default for RandomStringIdProvider {
 /// Takes care of assigning unique subscription ids and
 /// driving the sinks into completion.
 #[derive(Clone)]
-pub struct SubscriptionManager<I: IdProvider=RandomStringIdProvider> {
+pub struct SubscriptionManager<I: IdProvider = RandomStringIdProvider> {
 	id_provider: I,
 	active_subscriptions: ActiveSubscriptions,
 	executor: TaskExecutor,

--- a/pubsub/src/manager.rs
+++ b/pubsub/src/manager.rs
@@ -336,7 +336,7 @@ mod tests {
 	#[test]
 	fn subscription_is_canceled_if_it_existed() {
 		let manager = SubscriptionManager::<NumericIdProvider>::with_executor(Arc::new(TestTaskExecutor));
-		let subscriber = Subscriber::<u64>::new_test("test_subTest").0;
+		let (subscriber, _recv, _) = Subscriber::<u64>::new_test("test_subTest");
 
 		let (mut tx, rx) = futures::channel::mpsc::channel(8);
 		tx.start_send(1).unwrap();

--- a/pubsub/src/manager.rs
+++ b/pubsub/src/manager.rs
@@ -68,10 +68,10 @@ impl NumericIdProvider {
 }
 
 impl IdProvider for NumericIdProvider {
-	type Id = usize;
+	type Id = u64;
 
 	fn next_id(&self) -> Self::Id {
-		self.current_id.fetch_add(1, Ordering::AcqRel)
+		self.current_id.fetch_add(1, Ordering::AcqRel) as u64
 	}
 }
 

--- a/pubsub/src/manager.rs
+++ b/pubsub/src/manager.rs
@@ -1,0 +1,115 @@
+//! Provides an executor for subscription Futures.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::{
+	atomic::{self, AtomicUsize},
+	Arc,
+};
+
+use crate::core::futures::sync::oneshot;
+use crate::core::futures::{future, Future};
+use crate::{
+	typed::{Sink, Subscriber},
+	SubscriptionId,
+};
+use log::{error, warn};
+use parking_lot::Mutex;
+
+/// Alias for an implementation of `futures::future::Executor`.
+pub type TaskExecutor = Arc<dyn future::Executor<Box<dyn Future<Item = (), Error = ()> + Send>> + Send + Sync>;
+
+/// Trait used to provide unique subscription ids.
+pub trait IdProvider {
+	// TODO: Maybe have this impl Into<u64>?
+	type Id: Clone + Default + Eq + Hash;
+
+	/// Returns next id for the subscription.
+	fn next_id(&self) -> Self::Id;
+}
+
+/// Trait used to drive subscription Futures to completion.
+pub trait SubscriptionManager {
+	/// Create a new `SubscriptionManager`.
+	fn new(&self) -> Self;
+	/// Borrows the internal task executor.
+	///
+	/// This can be used to spawn additional tasks on the underlying event loop.
+	fn executor(&self) -> &TaskExecutor;
+	/// Create new subscription for given subscriber.
+	///
+	/// Second parameter is a function that converts Subscriber sink into a future.
+	/// This future will be driven to completion by the underlying event loop
+	/// or will be cancelled in case #cancel is invoked.
+	fn add<T, E, G, R, F, N>(&self, subscriber: Subscriber<T, E>, into_future: G) -> SubscriptionId<N>
+	where
+		G: FnOnce(Sink<T, E>) -> R,
+		R: future::IntoFuture<Future = F, Item = (), Error = ()>,
+		F: future::Future<Item = (), Error = ()> + Send + 'static;
+	/// Cancel subscription.
+	///
+	/// Should true if subscription existed or false otherwise.
+	fn cancel<N>(&self, id: SubscriptionId<N>) -> bool;
+}
+
+/// Subscriptions manager.
+///
+/// Takes care of assigning unique subscription ids and
+/// driving the sinks into completion.
+#[derive(Clone)]
+pub struct Manager<I: Default + IdProvider> {
+	next_id: I,
+	active_subscriptions: Arc<Mutex<HashMap<I::Id, oneshot::Sender<()>>>>,
+	executor: TaskExecutor, // Make generic?
+}
+
+impl<I: Default + IdProvider> SubscriptionManager for Manager<I> {
+	fn new(&self) -> Self {
+		Self {
+			next_id: Default::default(),
+			active_subscriptions: Default::default(),
+			executor: self.executor,
+		}
+	}
+
+	fn executor(&self) -> &TaskExecutor {
+		&self.executor
+	}
+
+	fn add<T, E, G, R, F, N>(&self, subscriber: Subscriber<T, E>, into_future: G) -> SubscriptionId<N>
+	where
+		G: FnOnce(Sink<T, E>) -> R,
+		R: future::IntoFuture<Future = F, Item = (), Error = ()>,
+		F: future::Future<Item = (), Error = ()> + Send + 'static,
+	{
+		let id = self.next_id.next_id();
+		let subscription_id: SubscriptionId = id.into();
+		if let Ok(sink) = subscriber.assign_id(subscription_id.clone()) {
+			let (tx, rx) = oneshot::channel();
+			let future = into_future(sink)
+				.into_future()
+				.select(rx.map_err(|e| warn!("Error timing out: {:?}", e)))
+				.then(|_| Ok(()));
+
+			self.active_subscriptions.lock().insert(id, tx);
+			if self.executor.execute(Box::new(future)).is_err() {
+				error!("Failed to spawn RPC subscription task");
+			}
+		}
+
+		subscription_id
+	}
+
+	/// Cancel subscription.
+	///
+	/// Returns true if subscription existed or false otherwise.
+	fn cancel<N>(&self, id: SubscriptionId<N>) -> bool {
+		if let SubscriptionId::Number(id) = id {
+			if let Some(tx) = self.active_subscriptions.lock().remove(&id) {
+				let _ = tx.send(());
+				return true;
+			}
+		}
+		false
+	}
+}

--- a/pubsub/src/manager.rs
+++ b/pubsub/src/manager.rs
@@ -342,6 +342,8 @@ mod tests {
 	#[test]
 	fn subscription_is_canceled_if_it_existed() {
 		let manager = SubscriptionManager::<NumericIdProvider>::with_executor(Arc::new(TestTaskExecutor));
+		// Need to bind receiver here (unlike the other tests) or else the subscriber
+		// will think the client has disconnected and not update `active_subscriptions`
 		let (subscriber, _recv, _) = Subscriber::<u64>::new_test("test_subTest");
 
 		let (mut tx, rx) = futures::channel::mpsc::channel(8);

--- a/pubsub/src/manager.rs
+++ b/pubsub/src/manager.rs
@@ -302,7 +302,11 @@ mod tests {
 			sink.sink_map_err(|_| ()).send_all(stream).map(|_| ())
 		});
 
-		assert!(matches!(id, SubscriptionId::String(_)))
+		if let SubscriptionId::String(_) = id {
+			assert!(true)
+		} else {
+			assert!(false, "Expected SubscriptionId::String");
+		}
 	}
 
 	#[test]
@@ -319,7 +323,11 @@ mod tests {
 			sink.sink_map_err(|_| ()).send_all(stream).map(|_| ())
 		});
 
-		assert!(matches!(id, SubscriptionId::Number(_)))
+		if let SubscriptionId::Number(_) = id {
+			assert!(true)
+		} else {
+			assert!(false, "Expected SubscriptionId::Number");
+		}
 	}
 
 	#[test]
@@ -336,7 +344,11 @@ mod tests {
 			sink.sink_map_err(|_| ()).send_all(stream).map(|_| ())
 		});
 
-		assert!(matches!(id, SubscriptionId::String(_)))
+		if let SubscriptionId::String(_) = id {
+			assert!(true)
+		} else {
+			assert!(false, "Expected SubscriptionId::String");
+		}
 	}
 
 	#[test]

--- a/pubsub/src/types.rs
+++ b/pubsub/src/types.rs
@@ -39,9 +39,9 @@ impl<T: PubSubMetadata> PubSubMetadata for Option<T> {
 /// NOTE Assigning same id to different requests will cause the previous request to be unsubscribed.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SubscriptionId {
-	/// Number
+	/// A numerical ID, represented by a `u64`.
 	Number(u64),
-	/// String
+	/// A non-numerical ID, for example a hash.
 	String(String),
 }
 
@@ -92,24 +92,62 @@ mod tests {
 	use crate::core::Value;
 
 	#[test]
-	fn should_convert_between_value_and_subscription_id() {
-		// given
-		let val1 = Value::Number(5.into());
-		let val2 = Value::String("asdf".into());
-		let val3 = Value::Null;
+	fn should_convert_between_number_value_and_subscription_id() {
+		let val = Value::Number(5.into());
+		let res = SubscriptionId::parse_value(&val);
 
-		// when
-		let res1 = SubscriptionId::parse_value(&val1);
-		let res2 = SubscriptionId::parse_value(&val2);
-		let res3 = SubscriptionId::parse_value(&val3);
+		assert_eq!(res, Some(SubscriptionId::Number(5)));
+		assert_eq!(Value::from(res.unwrap()), val);
+	}
 
-		// then
-		assert_eq!(res1, Some(SubscriptionId::Number(5)));
-		assert_eq!(res2, Some(SubscriptionId::String("asdf".into())));
-		assert_eq!(res3, None);
+	#[test]
+	fn should_convert_between_string_value_and_subscription_id() {
+		let val = Value::String("asdf".into());
+		let res = SubscriptionId::parse_value(&val);
 
-		// and back
-		assert_eq!(Value::from(res1.unwrap()), val1);
-		assert_eq!(Value::from(res2.unwrap()), val2);
+		assert_eq!(res, Some(SubscriptionId::String("asdf".into())));
+		assert_eq!(Value::from(res.unwrap()), val);
+	}
+
+	#[test]
+	fn should_convert_between_null_value_and_subscription_id() {
+		let val = Value::Null;
+		let res = SubscriptionId::parse_value(&val);
+		assert_eq!(res, None);
+	}
+
+	#[test]
+	fn should_convert_from_u8_to_subscription_id() {
+		let val = 5u8;
+		let res: SubscriptionId = val.into();
+		assert_eq!(res, SubscriptionId::Number(5));
+	}
+
+	#[test]
+	fn should_convert_from_u16_to_subscription_id() {
+		let val = 5u16;
+		let res: SubscriptionId = val.into();
+		assert_eq!(res, SubscriptionId::Number(5));
+	}
+
+	#[test]
+	fn should_convert_from_u32_to_subscription_id() {
+		let val = 5u32;
+		let res: SubscriptionId = val.into();
+		assert_eq!(res, SubscriptionId::Number(5));
+	}
+
+	#[test]
+	fn should_convert_from_u64_to_subscription_id() {
+		let val = 5u64;
+		let res: SubscriptionId = val.into();
+		assert_eq!(res, SubscriptionId::Number(5));
+	}
+
+	#[test]
+	fn should_convert_from_string_to_subscription_id() {
+		let val = "String".to_string();
+		let res: SubscriptionId = val.into();
+		assert_eq!(res, SubscriptionId::String("String".to_string()));
 	}
 }

--- a/pubsub/src/types.rs
+++ b/pubsub/src/types.rs
@@ -62,6 +62,14 @@ impl From<String> for SubscriptionId {
 	}
 }
 
+// TODO: Don't unwrap, and probably implement TryFrom instead of From
+use std::convert::TryInto;
+impl From<usize> for SubscriptionId {
+	fn from(id: usize) -> Self {
+		SubscriptionId::Number(id.try_into().unwrap())
+	}
+}
+
 impl From<SubscriptionId> for core::Value {
 	fn from(sub: SubscriptionId) -> Self {
 		match sub {

--- a/pubsub/src/types.rs
+++ b/pubsub/src/types.rs
@@ -62,14 +62,6 @@ impl From<String> for SubscriptionId {
 	}
 }
 
-// TODO: Don't unwrap, and probably implement TryFrom instead of From
-use std::convert::TryInto;
-impl From<usize> for SubscriptionId {
-	fn from(id: usize) -> Self {
-		SubscriptionId::Number(id.try_into().unwrap())
-	}
-}
-
 impl From<SubscriptionId> for core::Value {
 	fn from(sub: SubscriptionId) -> Self {
 		match sub {

--- a/pubsub/src/types.rs
+++ b/pubsub/src/types.rs
@@ -78,7 +78,7 @@ macro_rules! impl_from_num {
 				SubscriptionId::Number(other.into())
 			}
 		}
-	}
+	};
 }
 
 impl_from_num!(u8);


### PR DESCRIPTION
I was implementing some pubsub APIs in Substrate, outside of `sc-rpc`, and got to a point where I needed something to execute the subscription Futures. There's nothing provided out of the box for doing that, so after talking with @tomusdrw we figured that it might be useful to have the [Substrate subscription manager](https://github.com/paritytech/substrate/blob/master/client/rpc-api/src/subscriptions.rs) be a part of the `pubsub` crate.

What I've done is I've stolen that code and changed it to try and be a little less opinionated. One concern I have though is that I've changed `SubscriptionId` to now take a generic parameter, `N`, to avoid only working with `u64` ids, and I think this will break people's code.

I'm looking for feedback on whether the general approach is alright, and if the change to `SubscriptionId` is acceptable.