### PR TITLE
Allow skipping and retrying publishing.

### DIFF
--- a/_automate/publish.sh
+++ b/_automate/publish.sh
@@ -27,7 +27,7 @@ for crate in ${ORDER[@]}; do
 		VERSION=$(grep "^version" ./Cargo.toml | sed -e 's/.*"\(.*\)"/\1/')
 		# give the user an opportunity to abort or skip before publishing
 		RET=""
-		read -t 5 -p "Publishing $crate@$VERSION. Type [s] to skip. " RET || true
+		read -t 5 -p "Publishing $crate@$VERSION. Type [s] to skip, or any key to proceed. " RET || true
 		if [ "$RET" != "s" ]; then
 			set -x
 			cargo publish $@ || read -p ">>>>> Publishing $crate failed. Press [enter] to continue or type [r] to retry. " CHOICE

--- a/_automate/publish.sh
+++ b/_automate/publish.sh
@@ -86,6 +86,10 @@ for CRATE_DIR in ${ORDER[@]}; do
 done
 
 # Make tags in one go
+set -x
+git fetch --tags
+set +x
+
 for CRATE_DIR in ${ORDER[@]}; do
 	cd $CRATE_DIR > /dev/null
 	read_toml

--- a/_automate/publish.sh
+++ b/_automate/publish.sh
@@ -39,7 +39,7 @@ for CRATE_DIR in ${ORDER[@]}; do
 	# Seems the latest version matches, skip by default.
 	if [ "$REMOTE_VERSION" = "$VERSION" ] || [[ "$REMOTE_VERSION" > "$VERSION" ]]; then
 		RET=""
-		echo "Seems that $NAME@$REMOTE_VERSION is available. Continuing in 5s. "
+		echo "Seems like $NAME@$REMOTE_VERSION is already published. Continuing in 5s. "
 		read -t 5 -p ">>>> Type [r][enter] to retry, or [enter] to continue... " RET || true
 		if [ "$RET" != "r" ]; then
 			echo "Skipping $NAME@$VERSION"
@@ -69,13 +69,13 @@ for CRATE_DIR in ${ORDER[@]}; do
 		fi
 	done
 
-	# Wait again to make sure the published version is already available.
-	echo "Waiting for $NAME@$VERSION to be available..."
+	# Wait again to make sure that the new version is published and available.
+	echo "Waiting for $NAME@$VERSION to become available at the registry..."
 	while : ; do
 		sleep 3
 		remote_version
 		if [ "$REMOTE_VERSION" = "$VERSION" ]; then
-			echo "🥳 $NAME@$VERSION published succesfuly."
+			echo "🥳 $NAME@$VERSION published succesfully."
 			sleep 3
 			break
 		else

--- a/_automate/publish.sh
+++ b/_automate/publish.sh
@@ -108,7 +108,7 @@ set +x
 cd core > /dev/null
 read_toml
 cd - > /dev/null
-echo "Tagging main $VERSION"
+echo "Tagging jsonrpc@$VERSION"
 set -x
 git tag -a v$VERSION -m "Version $VERSION"
 sleep 3


### PR DESCRIPTION
Towards idempotency :dancing_men: 

I think the next reasonable change would be to check version before publish and if it matches, skip by default, but propose to re-publish (maybe not even needed)?
But I had enough bash programming for today :)

The `set -x/+x` has been sprinkled to clean up the output a bit - I still like to see the commands that are actually made, but the looping/conditionals where causing havoc in the logs.