### PR TITLE
Bump quote crate version

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 syn = { version = "1.0", features = ["full", "extra-traits", "visit", "fold"] }
 proc-macro2 = "1.0"
-quote = "=1.0.1"
+quote = "1.0.6"
 proc-macro-crate = "0.1.4"
 
 [dev-dependencies]


### PR DESCRIPTION
There was an issue with quote v1.0.2 which is why
we were pinned to v1.0.1. This issue has been fixed
so we don't need to be pinned anymore.