### PR TITLE
Migrate core to futures=0.3

### DIFF
--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
 name = "jsonrpc-core-client"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.2.0"
+version = "15.0.0"
 
 categories = [
 	"asynchronous",
@@ -26,7 +26,7 @@ ipc = ["jsonrpc-client-transports/ipc", "futures01"]
 arbitrary_precision = ["jsonrpc-client-transports/arbitrary_precision"]
 
 [dependencies]
-jsonrpc-client-transports = { version = "14.2", path = "./transports", default-features = false }
+jsonrpc-client-transports = { version = "15.0", path = "./transports", default-features = false }
 # Only for client transports, should be removed when we fully transition to futures=0.3
 futures01 = { version = "0.1", package = "futures", optional = true }
 futures = { version = "0.3", features = [ "compat" ] }

--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -27,6 +27,9 @@ arbitrary_precision = ["jsonrpc-client-transports/arbitrary_precision"]
 
 [dependencies]
 jsonrpc-client-transports = { version = "14.2", path = "./transports", default-features = false }
+# Only for jsonrpc-derive, should be removed when we fully transition to futures=0.3
+futures01 = { version = "0.1", package = "futures" }
+futures03 = { version = "0.3", package = "futures", features = [ "compat" ] }
 
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -19,17 +19,17 @@ categories = [
 ]
 
 [features]
-tls = ["jsonrpc-client-transports/tls"]
-http = ["jsonrpc-client-transports/http"]
-ws = ["jsonrpc-client-transports/ws"]
-ipc = ["jsonrpc-client-transports/ipc"]
+tls = ["jsonrpc-client-transports/tls", "futures01"]
+http = ["jsonrpc-client-transports/http", "futures01"]
+ws = ["jsonrpc-client-transports/ws", "futures01"]
+ipc = ["jsonrpc-client-transports/ipc", "futures01"]
 arbitrary_precision = ["jsonrpc-client-transports/arbitrary_precision"]
 
 [dependencies]
 jsonrpc-client-transports = { version = "14.2", path = "./transports", default-features = false }
-# Only for jsonrpc-derive, should be removed when we fully transition to futures=0.3
-futures01 = { version = "0.1", package = "futures" }
-futures03 = { version = "0.3", package = "futures", features = [ "compat" ] }
+# Only for client transports, should be removed when we fully transition to futures=0.3
+futures01 = { version = "0.1", package = "futures", optional = true }
+futures = { version = "0.3", features = [ "compat" ] }
 
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -8,6 +8,7 @@
 #![deny(missing_docs)]
 
 pub use jsonrpc_client_transports::*;
+pub use futures;
 
+#[cfg(feature = "futures01")]
 pub use futures01;
-pub use futures03;

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -7,8 +7,8 @@
 
 #![deny(missing_docs)]
 
-pub use jsonrpc_client_transports::*;
 pub use futures;
+pub use jsonrpc_client_transports::*;
 
 #[cfg(feature = "futures01")]
 pub use futures01;

--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -8,3 +8,6 @@
 #![deny(missing_docs)]
 
 pub use jsonrpc_client_transports::*;
+
+pub use futures01;
+pub use futures03;

--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -21,34 +21,37 @@ categories = [
 [features]
 default = ["http", "tls", "ws"]
 tls = ["hyper-tls", "http"]
-http = ["hyper"]
+http = ["hyper", "futures01"]
 ws = [
 	"websocket",
 	"tokio",
+	"futures01",
 ]
 ipc = [
 	"parity-tokio-ipc",
 	"jsonrpc-server-utils",
 	"tokio",
+	"futures01",
 ]
 arbitrary_precision = ["serde_json/arbitrary_precision", "jsonrpc-core/arbitrary_precision"]
 
 [dependencies]
 failure = "0.1"
-futures01 = { version = "0.1.26", package = "futures" }
-futures03 = { version = "0.3", package = "futures", features = [ "compat" ] }
-hyper = { version = "0.12", optional = true }
-hyper-tls = { version = "0.3.2", optional = true }
+futures = { version = "0.3", features = [ "compat" ] }
 jsonrpc-core = { version = "14.2", path = "../../core" }
 jsonrpc-pubsub = { version = "14.2", path = "../../pubsub" }
-jsonrpc-server-utils = { version = "14.2", path = "../../server-utils", optional = true }
 log = "0.4"
-parity-tokio-ipc = { version = "0.2", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+url = "1.7"
+
+futures01 = { version = "0.1.26", package = "futures", optional = true }
+hyper = { version = "0.12", optional = true }
+hyper-tls = { version = "0.3.2", optional = true }
+jsonrpc-server-utils = { version = "14.2", path = "../../server-utils", optional = true }
+parity-tokio-ipc = { version = "0.2", optional = true }
 tokio = { version = "0.1", optional = true }
 websocket = { version = "0.24", optional = true }
-url = "1.7"
 
 [dev-dependencies]
 assert_matches = "1.1"

--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -59,7 +59,6 @@ jsonrpc-http-server = { version = "15.0", path = "../../http" }
 jsonrpc-ipc-server = { version = "15.0", path = "../../ipc" }
 lazy_static = "1.0"
 env_logger = "0.7"
-tokio = "0.1"
 
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master" }

--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
 name = "jsonrpc-client-transports"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.2.0"
+version = "15.0.0"
 
 categories = [
 	"asynchronous",
@@ -38,8 +38,8 @@ arbitrary_precision = ["serde_json/arbitrary_precision", "jsonrpc-core/arbitrary
 [dependencies]
 failure = "0.1"
 futures = { version = "0.3", features = [ "compat" ] }
-jsonrpc-core = { version = "14.2", path = "../../core" }
-jsonrpc-pubsub = { version = "14.2", path = "../../pubsub" }
+jsonrpc-core = { version = "15.0", path = "../../core" }
+jsonrpc-pubsub = { version = "15.0", path = "../../pubsub" }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -48,15 +48,15 @@ url = "1.7"
 futures01 = { version = "0.1.26", package = "futures", optional = true }
 hyper = { version = "0.12", optional = true }
 hyper-tls = { version = "0.3.2", optional = true }
-jsonrpc-server-utils = { version = "14.2", path = "../../server-utils", optional = true }
+jsonrpc-server-utils = { version = "15.0", path = "../../server-utils", optional = true }
 parity-tokio-ipc = { version = "0.2", optional = true }
 tokio = { version = "0.1", optional = true }
 websocket = { version = "0.24", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.1"
-jsonrpc-http-server = { version = "14.2", path = "../../http" }
-jsonrpc-ipc-server = { version = "14.2", path = "../../ipc" }
+jsonrpc-http-server = { version = "15.0", path = "../../http" }
+jsonrpc-ipc-server = { version = "15.0", path = "../../ipc" }
 lazy_static = "1.0"
 env_logger = "0.7"
 tokio = "0.1"

--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -35,7 +35,8 @@ arbitrary_precision = ["serde_json/arbitrary_precision", "jsonrpc-core/arbitrary
 
 [dependencies]
 failure = "0.1"
-futures = "0.1.26"
+futures01 = { version = "0.1.26", package = "futures" }
+futures03 = { version = "0.3", package = "futures", features = [ "compat" ] }
 hyper = { version = "0.12", optional = true }
 hyper-tls = { version = "0.3.2", optional = true }
 jsonrpc-core = { version = "14.2", path = "../../core" }

--- a/core-client/transports/src/lib.rs
+++ b/core-client/transports/src/lib.rs
@@ -329,8 +329,9 @@ impl TypedClient {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use futures01::prelude::{Future as _};
 	use crate::transports::local;
-	use crate::{RpcChannel, RpcError, TypedClient};
+	use crate::{RpcChannel, TypedClient};
 	use jsonrpc_core::{self as core, IoHandler};
 	use jsonrpc_pubsub::{PubSubHandler, Subscriber, SubscriptionId};
 	use std::sync::atomic::{AtomicBool, Ordering};

--- a/core-client/transports/src/lib.rs
+++ b/core-client/transports/src/lib.rs
@@ -192,11 +192,9 @@ impl RawClient {
 		};
 		let result = self.0.send(msg.into());
 		async move {
-			let () = result
-				.map_err(|e| RpcError::Other(e.into()))?;
+			let () = result.map_err(|e| RpcError::Other(e.into()))?;
 
-			receiver.await
-				.map_err(|e| RpcError::Other(e.into()))?
+			receiver.await.map_err(|e| RpcError::Other(e.into()))?
 		}
 	}
 
@@ -270,7 +268,7 @@ impl TypedClient {
 			Value::Object(map) => Ok(Params::Map(map)),
 			_ => Err(RpcError::Other(format_err!(
 				"RPC params should serialize to a JSON array, JSON object or null"
-			)))
+			))),
 		};
 		let result = params.map(|params| self.0.call_method(method, params));
 
@@ -279,8 +277,7 @@ impl TypedClient {
 
 			log::debug!("response: {:?}", value);
 
-			serde_json::from_value::<R>(value)
-				.map_err(|error| RpcError::ParseError(returns, error.into()))
+			serde_json::from_value::<R>(value).map_err(|error| RpcError::ParseError(returns, error.into()))
 		}
 	}
 

--- a/core-client/transports/src/lib.rs
+++ b/core-client/transports/src/lib.rs
@@ -3,8 +3,8 @@
 #![deny(missing_docs)]
 
 use failure::{format_err, Fail};
-use futures::sync::{mpsc, oneshot};
-use futures::{future, prelude::*};
+use futures01::sync::{mpsc, oneshot};
+use futures01::{future, prelude::*};
 use jsonrpc_core::{Error, Params};
 use serde::de::DeserializeOwned;
 use serde::Serialize;

--- a/core-client/transports/src/transports/duplex.rs
+++ b/core-client/transports/src/transports/duplex.rs
@@ -1,8 +1,8 @@
 //! Duplex transport
 
 use failure::format_err;
-use futures::prelude::*;
-use futures::sync::{mpsc, oneshot};
+use futures01::prelude::*;
+use futures01::sync::{mpsc, oneshot};
 use jsonrpc_core::Id;
 use jsonrpc_pubsub::SubscriptionId;
 use log::debug;

--- a/core-client/transports/src/transports/duplex.rs
+++ b/core-client/transports/src/transports/duplex.rs
@@ -90,7 +90,11 @@ impl<TSink, TStream> Duplex<TSink, TStream> {
 pub fn duplex<TSink, TStream>(
 	sink: Pin<Box<TSink>>,
 	stream: Pin<Box<TStream>>,
-) -> (Duplex<TSink, TStream>, RpcChannel) {
+) -> (Duplex<TSink, TStream>, RpcChannel)
+where
+	TSink: Sink<String>,
+	TStream: Stream<Item = String>,
+{
 	let (sender, receiver) = mpsc::unbounded();
 	let client = Duplex::new(sink, stream, receiver);
 	(client, sender.into())

--- a/core-client/transports/src/transports/http.rs
+++ b/core-client/transports/src/transports/http.rs
@@ -5,7 +5,7 @@
 use super::RequestBuilder;
 use crate::{RpcChannel, RpcError, RpcMessage};
 use failure::format_err;
-use futures::{
+use futures01::{
 	future::{
 		self,
 		Either::{A, B},

--- a/core-client/transports/src/transports/http.rs
+++ b/core-client/transports/src/transports/http.rs
@@ -165,11 +165,11 @@ mod tests {
 
 	fn io() -> IoHandler {
 		let mut io = IoHandler::default();
-		io.add_method("hello", |params: Params| match params.parse::<(String,)>() {
+		io.add_sync_method("hello", |params: Params| match params.parse::<(String,)>() {
 			Ok((msg,)) => Ok(Value::String(format!("hello {}", msg))),
 			_ => Ok(Value::String("world".into())),
 		});
-		io.add_method("fail", |_: Params| Err(Error::new(ErrorCode::ServerError(-34))));
+		io.add_sync_method("fail", |_: Params| Err(Error::new(ErrorCode::ServerError(-34))));
 		io.add_notification("notify", |params: Params| {
 			let (value,) = params.parse::<(u64,)>().expect("expected one u64 as param");
 			assert_eq!(value, 12);

--- a/core-client/transports/src/transports/http.rs
+++ b/core-client/transports/src/transports/http.rs
@@ -128,7 +128,6 @@ mod tests {
 	use crate::*;
 	use jsonrpc_core::{Error, ErrorCode, IoHandler, Params, Value};
 	use jsonrpc_http_server::*;
-	use std::net::SocketAddr;
 	use super::*;
 
 	fn id<T>(t: T) -> T {
@@ -137,7 +136,6 @@ mod tests {
 
 	struct TestServer {
 		uri: String,
-		socket_addr: SocketAddr,
 		server: Option<Server>,
 	}
 
@@ -146,25 +144,11 @@ mod tests {
 			let builder = ServerBuilder::new(io()).rest_api(RestApi::Unsecure);
 
 			let server = alter(builder).start_http(&"127.0.0.1:0".parse().unwrap()).unwrap();
-			let socket_addr = server.address().clone();
-			let uri = format!("http://{}", socket_addr);
+			let uri = format!("http://{}", server.address());
 
 			TestServer {
 				uri,
-				socket_addr,
 				server: Some(server),
-			}
-		}
-
-		fn start(&mut self) {
-			if self.server.is_none() {
-				let server = ServerBuilder::new(io())
-					.rest_api(RestApi::Unsecure)
-					.start_http(&self.socket_addr)
-					.unwrap();
-				self.server = Some(server);
-			} else {
-				panic!("Server already running")
 			}
 		}
 

--- a/core-client/transports/src/transports/ipc.rs
+++ b/core-client/transports/src/transports/ipc.rs
@@ -3,7 +3,7 @@
 
 use crate::transports::duplex::duplex;
 use crate::{RpcChannel, RpcError};
-use futures::prelude::*;
+use futures01::prelude::*;
 use jsonrpc_server_utils::codecs::StreamCodec;
 use parity_tokio_ipc::IpcConnection;
 use std::io;
@@ -17,7 +17,7 @@ pub fn connect<P: AsRef<Path>, Client: From<RpcChannel>>(
 ) -> Result<impl Future<Item = Client, Error = RpcError>, io::Error> {
 	let connection = IpcConnection::connect(path, reactor)?;
 
-	Ok(futures::lazy(move || {
+	Ok(futures01::lazy(move || {
 		let (sink, stream) = StreamCodec::stream_incoming().framed(connection).split();
 		let sink = sink.sink_map_err(|e| RpcError::Other(e.into()));
 		let stream = stream.map_err(|e| RpcError::Other(e.into()));

--- a/core-client/transports/src/transports/local.rs
+++ b/core-client/transports/src/transports/local.rs
@@ -1,20 +1,21 @@
 //! Rpc client implementation for `Deref<Target=MetaIoHandler<Metadata>>`.
 
-use crate::{RpcChannel, RpcError};
-use futures01::prelude::*;
-use futures03::channel::mpsc;
+use crate::{RpcChannel, RpcError, RpcResult};
+use futures::channel::mpsc;
+use futures::{Stream, StreamExt, Sink, SinkExt, Future, task::{Context, Poll}};
 use jsonrpc_core::{MetaIoHandler, Metadata};
 use jsonrpc_pubsub::Session;
-use std::collections::VecDeque;
 use std::ops::Deref;
+use std::pin::Pin;
 use std::sync::Arc;
 
 /// Implements a rpc client for `MetaIoHandler`.
 pub struct LocalRpc<THandler, TMetadata> {
 	handler: THandler,
 	meta: TMetadata,
-	queue: VecDeque<String>,
+	queue: (mpsc::UnboundedSender<String>, mpsc::UnboundedReceiver<String>),
 }
+
 
 impl<TMetadata, THandler> LocalRpc<THandler, TMetadata>
 where
@@ -34,45 +35,59 @@ where
 		Self {
 			handler,
 			meta,
-			queue: Default::default(),
+			queue: mpsc::unbounded(),
 		}
 	}
 }
 
 impl<TMetadata, THandler> Stream for LocalRpc<THandler, TMetadata>
 where
-	TMetadata: Metadata,
-	THandler: Deref<Target = MetaIoHandler<TMetadata>>,
+	TMetadata: Metadata + Unpin,
+	THandler: Deref<Target = MetaIoHandler<TMetadata>> + Unpin,
 {
 	type Item = String;
-	type Error = RpcError;
 
-	fn poll(&mut self) -> Result<Async<Option<Self::Item>>, Self::Error> {
-		match self.queue.pop_front() {
-			Some(response) => Ok(Async::Ready(Some(response))),
-			None => Ok(Async::NotReady),
-		}
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+    ) -> Poll<Option<Self::Item>> {
+		self.queue.1.poll_next_unpin(cx)
 	}
 }
 
-impl<TMetadata, THandler> Sink for LocalRpc<THandler, TMetadata>
+impl<TMetadata, THandler> Sink<String> for LocalRpc<THandler, TMetadata>
 where
-	TMetadata: Metadata,
-	THandler: Deref<Target = MetaIoHandler<TMetadata>>,
+	TMetadata: Metadata + Unpin,
+	THandler: Deref<Target = MetaIoHandler<TMetadata>> + Unpin,
 {
-	type SinkItem = String;
-	type SinkError = RpcError;
+    type Error = RpcError;
 
-	fn start_send(&mut self, request: Self::SinkItem) -> Result<AsyncSink<Self::SinkItem>, Self::SinkError> {
-		match self.handler.handle_request_sync(&request, self.meta.clone()) {
-			Some(response) => self.queue.push_back(response),
-			None => {}
-		};
-		Ok(AsyncSink::Ready)
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+		futures::ready!(self.queue.0.poll_ready(cx))
+			.map_err(|e| RpcError::Other(e.into()))
+			.into()
 	}
 
-	fn poll_complete(&mut self) -> Result<Async<()>, Self::SinkError> {
-		Ok(Async::Ready(()))
+    fn start_send(mut self: Pin<&mut Self>, item: String) -> Result<(), Self::Error> {
+		if let Some(res) = self.handler.handle_request_sync(&item, self.meta.clone()) {
+			self.queue.0.start_send(res)
+				.map_err(|e| RpcError::Other(e.into()))
+				.into()
+		} else {
+			Ok(())
+		}
+	}
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+		futures::ready!(self.queue.0.poll_flush_unpin(cx))
+			.map_err(|e| RpcError::Other(e.into()))
+			.into()
+	}
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+		futures::ready!(self.queue.0.poll_close_unpin(cx))
+			.map_err(|e| RpcError::Other(e.into()))
+			.into()
 	}
 }
 
@@ -80,24 +95,26 @@ where
 pub fn connect_with_metadata<TClient, THandler, TMetadata>(
 	handler: THandler,
 	meta: TMetadata,
-) -> (TClient, impl Future<Item = (), Error = RpcError>)
+) -> (TClient, impl Future<Output = RpcResult<()>>)
 where
 	TClient: From<RpcChannel>,
-	THandler: Deref<Target = MetaIoHandler<TMetadata>>,
-	TMetadata: Metadata,
+	THandler: Deref<Target = MetaIoHandler<TMetadata>> + Unpin,
+	TMetadata: Metadata + Unpin,
 {
 	let (sink, stream) = LocalRpc::with_metadata(handler, meta).split();
-	let (rpc_client, sender) = crate::transports::duplex(sink, stream);
+	let (rpc_client, sender) = crate::transports::duplex(Box::pin(sink), Box::pin(stream));
 	let client = TClient::from(sender);
 	(client, rpc_client)
 }
 
 /// Connects to a `Deref<Target = MetaIoHandler<Metadata + Default>`.
-pub fn connect<TClient, THandler, TMetadata>(handler: THandler) -> (TClient, impl Future<Item = (), Error = RpcError>)
+pub fn connect<TClient, THandler, TMetadata>(
+	handler: THandler,
+) -> (TClient, impl Future<Output = RpcResult<()>>)
 where
 	TClient: From<RpcChannel>,
-	THandler: Deref<Target = MetaIoHandler<TMetadata>>,
-	TMetadata: Metadata + Default,
+	THandler: Deref<Target = MetaIoHandler<TMetadata>> + Unpin,
+	TMetadata: Metadata + Default + Unpin,
 {
 	connect_with_metadata(handler, Default::default())
 }
@@ -106,19 +123,21 @@ where
 pub type LocalMeta = Arc<Session>;
 
 /// Connects with pubsub.
-pub fn connect_with_pubsub<TClient, THandler>(handler: THandler) -> (TClient, impl Future<Item = (), Error = RpcError>)
+pub fn connect_with_pubsub<TClient, THandler>(
+	handler: THandler,
+) -> (TClient, impl Future<Output = RpcResult<()>>)
 where
 	TClient: From<RpcChannel>,
-	THandler: Deref<Target = MetaIoHandler<LocalMeta>>,
+	THandler: Deref<Target = MetaIoHandler<LocalMeta>> + Unpin,
 {
-	use futures03::{StreamExt, TryStreamExt};
-
 	let (tx, rx) = mpsc::unbounded();
 	let meta = Arc::new(Session::new(tx));
 	let (sink, stream) = LocalRpc::with_metadata(handler, meta).split();
-	let rx = rx.map(Ok).compat();
-	let stream = stream.select(rx.map_err(|()| unreachable!()));
-	let (rpc_client, sender) = crate::transports::duplex(sink, stream);
+	let stream = futures::stream::select(
+		stream,
+		rx
+	);
+	let (rpc_client, sender) = crate::transports::duplex(Box::pin(sink), Box::pin(stream));
 	let client = TClient::from(sender);
 	(client, rpc_client)
 }

--- a/core-client/transports/src/transports/ws.rs
+++ b/core-client/transports/src/transports/ws.rs
@@ -1,7 +1,7 @@
 //! JSON-RPC websocket client implementation.
 use crate::{RpcChannel, RpcError};
 use failure::Error;
-use futures::prelude::*;
+use futures01::prelude::*;
 use log::info;
 use std::collections::VecDeque;
 use websocket::{ClientBuilder, OwnedMessage};

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,7 @@ categories = [
 
 [dependencies]
 log = "0.4"
-futures = "~0.1.6"
+futures = "0.3"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
 name = "jsonrpc-core"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.2.0"
+version = "15.0.0"
 
 categories = [
 	"asynchronous",

--- a/core/examples/async.rs
+++ b/core/examples/async.rs
@@ -1,15 +1,16 @@
-use jsonrpc_core::futures::Future;
 use jsonrpc_core::*;
 
 fn main() {
-	let mut io = IoHandler::new();
+	futures::executor::block_on(async {
+		let mut io = IoHandler::new();
 
-	io.add_method("say_hello", |_: Params| {
-		futures::finished(Value::String("Hello World!".to_owned()))
+		io.add_method("say_hello", |_: Params| async {
+			Ok(Value::String("Hello World!".to_owned()))
+		});
+
+		let request = r#"{"jsonrpc": "2.0", "method": "say_hello", "params": [42, 23], "id": 1}"#;
+		let response = r#"{"jsonrpc":"2.0","result":"hello","id":1}"#;
+
+		assert_eq!(io.handle_request(request).await, Some(response.to_owned()));
 	});
-
-	let request = r#"{"jsonrpc": "2.0", "method": "say_hello", "params": [42, 23], "id": 1}"#;
-	let response = r#"{"jsonrpc":"2.0","result":"hello","id":1}"#;
-
-	assert_eq!(io.handle_request(request).wait().unwrap(), Some(response.to_owned()));
 }

--- a/core/examples/basic.rs
+++ b/core/examples/basic.rs
@@ -3,7 +3,7 @@ use jsonrpc_core::*;
 fn main() {
 	let mut io = IoHandler::new();
 
-	io.add_method("say_hello", |_: Params| Ok(Value::String("Hello World!".to_owned())));
+	io.add_sync_method("say_hello", |_: Params| Ok(Value::String("Hello World!".to_owned())));
 
 	let request = r#"{"jsonrpc": "2.0", "method": "say_hello", "params": [42, 23], "id": 1}"#;
 	let response = r#"{"jsonrpc":"2.0","result":"hello","id":1}"#;

--- a/core/examples/meta.rs
+++ b/core/examples/meta.rs
@@ -1,4 +1,3 @@
-use jsonrpc_core::futures::Future;
 use jsonrpc_core::*;
 
 #[derive(Clone, Default)]
@@ -8,7 +7,7 @@ impl Metadata for Meta {}
 pub fn main() {
 	let mut io = MetaIoHandler::default();
 
-	io.add_method_with_meta("say_hello", |_params: Params, meta: Meta| {
+	io.add_method_with_meta("say_hello", |_params: Params, meta: Meta| async move {
 		Ok(Value::String(format!("Hello World: {}", meta.0)))
 	});
 
@@ -17,7 +16,7 @@ pub fn main() {
 
 	let headers = 5;
 	assert_eq!(
-		io.handle_request(request, Meta(headers)).wait().unwrap(),
+		io.handle_request_sync(request, Meta(headers)),
 		Some(response.to_owned())
 	);
 }

--- a/core/examples/middlewares.rs
+++ b/core/examples/middlewares.rs
@@ -17,7 +17,7 @@ impl Middleware<Meta> for MyMiddleware {
 	fn on_request<F, X>(&self, request: Request, meta: Meta, next: F) -> Either<Self::Future, X>
 	where
 		F: FnOnce(Request, Meta) -> X + Send,
-		X: Future<Item = Option<Response>, Error = ()> + Send + 'static,
+		X: Future<Output = Result<Option<Response>, ()>> + Send + 'static,
 	{
 		let start = Instant::now();
 		let request_number = self.0.fetch_add(1, atomic::Ordering::SeqCst);

--- a/core/examples/middlewares.rs
+++ b/core/examples/middlewares.rs
@@ -1,5 +1,5 @@
 use jsonrpc_core::futures::future::Either;
-use jsonrpc_core::futures::Future;
+use jsonrpc_core::futures::{Future, FutureExt};
 use jsonrpc_core::*;
 use std::sync::atomic::{self, AtomicUsize};
 use std::time::Instant;
@@ -17,13 +17,13 @@ impl Middleware<Meta> for MyMiddleware {
 	fn on_request<F, X>(&self, request: Request, meta: Meta, next: F) -> Either<Self::Future, X>
 	where
 		F: FnOnce(Request, Meta) -> X + Send,
-		X: Future<Output = Result<Option<Response>, ()>> + Send + 'static,
+		X: Future<Output = Option<Response>> + Send + 'static,
 	{
 		let start = Instant::now();
 		let request_number = self.0.fetch_add(1, atomic::Ordering::SeqCst);
 		println!("Processing request {}: {:?}, {:?}", request_number, request, meta);
 
-		Either::A(Box::new(next(request, meta).map(move |res| {
+		Either::Left(Box::pin(next(request, meta).map(move |res| {
 			println!("Processing took: {:?}", start.elapsed());
 			res
 		})))
@@ -33,7 +33,7 @@ impl Middleware<Meta> for MyMiddleware {
 pub fn main() {
 	let mut io = MetaIoHandler::with_middleware(MyMiddleware::default());
 
-	io.add_method_with_meta("say_hello", |_params: Params, meta: Meta| {
+	io.add_method_with_meta("say_hello", |_params: Params, meta: Meta| async move {
 		Ok(Value::String(format!("Hello World: {}", meta.0)))
 	});
 
@@ -42,7 +42,7 @@ pub fn main() {
 
 	let headers = 5;
 	assert_eq!(
-		io.handle_request(request, Meta(headers)).wait().unwrap(),
+		io.handle_request_sync(request, Meta(headers)),
 		Some(response.to_owned())
 	);
 }

--- a/core/examples/params.rs
+++ b/core/examples/params.rs
@@ -9,7 +9,7 @@ struct HelloParams {
 fn main() {
 	let mut io = IoHandler::new();
 
-	io.add_method("say_hello", |params: Params| {
+	io.add_method("say_hello", |params: Params| async move {
 		let parsed: HelloParams = params.parse().unwrap();
 		Ok(Value::String(format!("hello, {}", parsed.name)))
 	});

--- a/core/src/calls.rs
+++ b/core/src/calls.rs
@@ -22,7 +22,7 @@ pub trait RpcMethodSimple: Send + Sync + 'static {
 /// Asynchronous Method with Metadata
 pub trait RpcMethod<T: Metadata>: Send + Sync + 'static {
 	/// Call method
-	fn call(&self, params: Params, meta: T) -> BoxFuture<Value>;
+	fn call(&self, params: Params, meta: T) -> BoxFuture<crate::Result<Value>>;
 }
 
 /// Notification
@@ -86,7 +86,7 @@ where
 	F: Fn(Params, T) -> X,
 	X: Future<Output = Result<Value, Error>>,
 {
-	fn call(&self, params: Params, meta: T) -> BoxFuture<Value> {
+	fn call(&self, params: Params, meta: T) -> BoxFuture<crate::Result<Value>> {
 		Box::pin(self(params, meta))
 	}
 }

--- a/core/src/calls.rs
+++ b/core/src/calls.rs
@@ -11,6 +11,30 @@ impl<T: Metadata> Metadata for Option<T> {}
 impl<T: Metadata> Metadata for Box<T> {}
 impl<T: Sync + Send + 'static> Metadata for Arc<T> {}
 
+/// A future-conversion trait.
+pub trait WrapFuture<T, E> {
+	/// Convert itself into a boxed future.
+	fn into_future(self) -> BoxFuture<Result<T, E>>;
+}
+
+impl<T: Send + 'static, E: Send + 'static> WrapFuture<T, E> for Result<T, E> {
+	fn into_future(self) -> BoxFuture<Result<T, E>> {
+		Box::pin(futures::future::ready(self))
+	}
+}
+
+impl<T, E> WrapFuture<T, E> for BoxFuture<Result<T, E>> {
+	fn into_future(self) -> BoxFuture<Result<T, E>> {
+		self
+	}
+}
+
+/// A synchronous or asynchronous method.
+pub trait RpcMethodSync: Send + Sync + 'static {
+	/// Call method
+	fn call(&self, params: Params) -> BoxFuture<crate::Result<Value>>;
+}
+
 /// Asynchronous Method
 pub trait RpcMethodSimple: Send + Sync + 'static {
 	/// Output future
@@ -68,6 +92,16 @@ where
 	type Out = X;
 	fn call(&self, params: Params) -> Self::Out {
 		self(params)
+	}
+}
+
+impl<F: Send + Sync + 'static, X: Send + 'static> RpcMethodSync for F
+where
+	F: Fn(Params) -> X,
+	X: WrapFuture<Value, Error>,
+{
+	fn call(&self, params: Params) -> BoxFuture<crate::Result<Value>> {
+		self(params).into_future()
 	}
 }
 

--- a/core/src/calls.rs
+++ b/core/src/calls.rs
@@ -14,7 +14,7 @@ impl<T: Sync + Send + 'static> Metadata for Arc<T> {}
 /// Asynchronous Method
 pub trait RpcMethodSimple: Send + Sync + 'static {
 	/// Output future
-	type Out: Future<Item = Value, Error = Error> + Send;
+	type Out: Future<Output = Result<Value, Error>> + Send;
 	/// Call method
 	fn call(&self, params: Params) -> Self::Out;
 }
@@ -62,8 +62,8 @@ impl<T: Metadata> fmt::Debug for RemoteProcedure<T> {
 impl<F: Send + Sync + 'static, X: Send + 'static, I> RpcMethodSimple for F
 where
 	F: Fn(Params) -> I,
-	X: Future<Item = Value, Error = Error>,
-	I: IntoFuture<Item = Value, Error = Error, Future = X>,
+	X: Future<Output = Result<Value, Error>>,
+	I: IntoFuture<Output = Result<Value, Error, Future = X>>,
 {
 	type Out = X;
 	fn call(&self, params: Params) -> Self::Out {
@@ -84,8 +84,8 @@ impl<F: Send + Sync + 'static, X: Send + 'static, T, I> RpcMethod<T> for F
 where
 	T: Metadata,
 	F: Fn(Params, T) -> I,
-	I: IntoFuture<Item = Value, Error = Error, Future = X>,
-	X: Future<Item = Value, Error = Error>,
+	I: IntoFuture<Output = Result<Value, Error, Future = X>>,
+	X: Future<Output = Result<Value, Error>>,
 {
 	fn call(&self, params: Params, meta: T) -> BoxFuture<Value> {
 		Box::new(self(params, meta).into_future())

--- a/core/src/calls.rs
+++ b/core/src/calls.rs
@@ -83,7 +83,6 @@ impl<T: Metadata> fmt::Debug for RemoteProcedure<T> {
 	}
 }
 
-// TODO [ToDr] Check all the bounds
 impl<F: Send + Sync + 'static, X: Send + 'static> RpcMethodSimple for F
 where
 	F: Fn(Params) -> X,

--- a/core/src/delegates.rs
+++ b/core/src/delegates.rs
@@ -21,7 +21,7 @@ where
 	T: Send + Sync + 'static,
 	F: Send + Sync + 'static,
 {
-	fn call(&self, params: Params, _meta: M) -> BoxFuture<Value> {
+	fn call(&self, params: Params, _meta: M) -> BoxFuture<crate::Result<Value>> {
 		let closure = &self.closure;
 		Box::pin(closure(&self.delegate, params))
 	}
@@ -40,7 +40,7 @@ where
 	T: Send + Sync + 'static,
 	F: Send + Sync + 'static,
 {
-	fn call(&self, params: Params, meta: M) -> BoxFuture<Value> {
+	fn call(&self, params: Params, meta: M) -> BoxFuture<crate::Result<Value>> {
 		let closure = &self.closure;
 		Box::pin(closure(&self.delegate, params, meta))
 	}

--- a/core/src/delegates.rs
+++ b/core/src/delegates.rs
@@ -17,7 +17,7 @@ impl<T, M, F, I> RpcMethod<M> for DelegateAsyncMethod<T, F>
 where
 	M: Metadata,
 	F: Fn(&T, Params) -> I,
-	I: IntoFuture<Item = Value, Error = Error>,
+	I: IntoFuture<Output = Result<Value, Error>>,
 	T: Send + Sync + 'static,
 	F: Send + Sync + 'static,
 	I::Future: Send + 'static,
@@ -37,7 +37,7 @@ impl<T, M, F, I> RpcMethod<M> for DelegateMethodWithMeta<T, F>
 where
 	M: Metadata,
 	F: Fn(&T, Params, M) -> I,
-	I: IntoFuture<Item = Value, Error = Error>,
+	I: IntoFuture<Output = Result<Value, Error>>,
 	T: Send + Sync + 'static,
 	F: Send + Sync + 'static,
 	I::Future: Send + 'static,
@@ -117,7 +117,7 @@ where
 	pub fn add_method<F, I>(&mut self, name: &str, method: F)
 	where
 		F: Fn(&T, Params) -> I,
-		I: IntoFuture<Item = Value, Error = Error>,
+		I: IntoFuture<Output = Result<Value, Error>>,
 		F: Send + Sync + 'static,
 		I::Future: Send + 'static,
 	{
@@ -134,7 +134,7 @@ where
 	pub fn add_method_with_meta<F, I>(&mut self, name: &str, method: F)
 	where
 		F: Fn(&T, Params, M) -> I,
-		I: IntoFuture<Item = Value, Error = Error>,
+		I: IntoFuture<Output = Result<Value, Error>>,
 		F: Send + Sync + 'static,
 		I::Future: Send + 'static,
 	{

--- a/core/src/delegates.rs
+++ b/core/src/delegates.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use crate::calls::{Metadata, RemoteProcedure, RpcMethod, RpcNotification};
 use crate::types::{Error, Params, Value};
 use crate::BoxFuture;
-use futures::IntoFuture;
+use futures::Future;
 
 struct DelegateAsyncMethod<T, F> {
 	delegate: Arc<T>,
@@ -17,14 +17,13 @@ impl<T, M, F, I> RpcMethod<M> for DelegateAsyncMethod<T, F>
 where
 	M: Metadata,
 	F: Fn(&T, Params) -> I,
-	I: IntoFuture<Output = Result<Value, Error>>,
+	I: Future<Output = Result<Value, Error>> + Send + 'static,
 	T: Send + Sync + 'static,
 	F: Send + Sync + 'static,
-	I::Future: Send + 'static,
 {
 	fn call(&self, params: Params, _meta: M) -> BoxFuture<Value> {
 		let closure = &self.closure;
-		Box::new(closure(&self.delegate, params).into_future())
+		Box::pin(closure(&self.delegate, params))
 	}
 }
 
@@ -37,14 +36,13 @@ impl<T, M, F, I> RpcMethod<M> for DelegateMethodWithMeta<T, F>
 where
 	M: Metadata,
 	F: Fn(&T, Params, M) -> I,
-	I: IntoFuture<Output = Result<Value, Error>>,
+	I: Future<Output = Result<Value, Error>> + Send + 'static,
 	T: Send + Sync + 'static,
 	F: Send + Sync + 'static,
-	I::Future: Send + 'static,
 {
 	fn call(&self, params: Params, meta: M) -> BoxFuture<Value> {
 		let closure = &self.closure;
-		Box::new(closure(&self.delegate, params, meta).into_future())
+		Box::pin(closure(&self.delegate, params, meta))
 	}
 }
 
@@ -117,9 +115,8 @@ where
 	pub fn add_method<F, I>(&mut self, name: &str, method: F)
 	where
 		F: Fn(&T, Params) -> I,
-		I: IntoFuture<Output = Result<Value, Error>>,
+		I: Future<Output = Result<Value, Error>> + Send + 'static,
 		F: Send + Sync + 'static,
-		I::Future: Send + 'static,
 	{
 		self.methods.insert(
 			name.into(),
@@ -134,9 +131,8 @@ where
 	pub fn add_method_with_meta<F, I>(&mut self, name: &str, method: F)
 	where
 		F: Fn(&T, Params, M) -> I,
-		I: IntoFuture<Output = Result<Value, Error>>,
+		I: Future<Output = Result<Value, Error>> + Send + 'static,
 		F: Send + Sync + 'static,
-		I::Future: Send + 'static,
 	{
 		self.methods.insert(
 			name.into(),

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -146,6 +146,8 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 	/// Adds new supported synchronous method.
 	///
 	/// A backward-compatible wrapper.
+	///
+	/// TODO [ToDr] Remove in favour of conversion trait!
 	pub fn add_sync_method<F>(&mut self, name: &str, method: F)
 	where
 		F: Fn(crate::Params) -> crate::Result<crate::Value> + Send + Sync + 'static,
@@ -630,7 +632,7 @@ mod tests {
 
 		struct Test;
 		impl Test {
-			fn abc(&self, _p: crate::Params) -> crate::BoxFuture<Value> {
+			fn abc(&self, _p: crate::Params) -> crate::BoxFuture<crate::Result<Value>> {
 				Box::pin(async { Ok(5.into()) })
 			}
 		}

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -146,7 +146,7 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 	/// Adds new supported synchronous method.
 	///
 	/// A backward-compatible wrapper.
-	pub fn add_sync_method<F, X>(&mut self, name: &str, method: F)
+	pub fn add_sync_method<F>(&mut self, name: &str, method: F)
 	where
 		F: RpcMethodSync,
 	{

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -3,9 +3,10 @@ use std::collections::{
 	HashMap,
 };
 use std::ops::{Deref, DerefMut};
+use std::pin::Pin;
 use std::sync::Arc;
 
-use futures::{self, future, Future};
+use futures::{self, future, Future, FutureExt};
 use serde_json;
 
 use crate::calls::{Metadata, RemoteProcedure, RpcMethod, RpcMethodSimple, RpcNotification, RpcNotificationSimple};
@@ -14,26 +15,29 @@ use crate::types::{Call, Output, Request, Response};
 use crate::types::{Error, ErrorCode, Version};
 
 /// A type representing middleware or RPC response before serialization.
-pub type FutureResponse = Box<dyn Future<Output = Result<Option<Response>, ()> + Send>>;
+pub type FutureResponse = Pin<Box<dyn Future<Output = Option<Response>> + Send>>;
 
 /// A type representing middleware or RPC call output.
-pub type FutureOutput = Box<dyn Future<Output = Result<Option<Output>, ()> + Send>>;
+pub type FutureOutput = Pin<Box<dyn Future<Output = Option<Output>> + Send>>;
 
 /// A type representing future string response.
 pub type FutureResult<F, G> = future::Map<
-	future::Either<future::FutureResult<Option<Response>, ()>, FutureRpcResult<F, G>>,
+	future::Either<future::Ready<Option<Response>>, FutureRpcResult<F, G>>,
 	fn(Option<Response>) -> Option<String>,
 >;
 
 /// A type representing a result of a single method call.
-pub type FutureRpcOutput<F> = future::Either<F, future::Either<FutureOutput, future::FutureResult<Option<Output>, ()>>>;
+pub type FutureRpcOutput<F> = future::Either<
+	F,
+	future::Either<FutureOutput, future::Ready<Option<Output>>>
+>;
 
 /// A type representing an optional `Response` for RPC `Request`.
 pub type FutureRpcResult<F, G> = future::Either<
 	F,
 	future::Either<
 		future::Map<FutureRpcOutput<G>, fn(Option<Output>) -> Option<Response>>,
-		future::Map<future::JoinAll<Vec<FutureRpcOutput<G>>>, fn(Vec<Option<Output>>) -> Option<Response>>,
+		future::Map<future::JoinAll<FutureRpcOutput<G>>, fn(Vec<Option<Output>>) -> Option<Response>>,
 	>,
 >;
 
@@ -139,7 +143,17 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 		self.methods.insert(alias.into(), RemoteProcedure::Alias(other.into()));
 	}
 
-	/// Adds new supported asynchronous method
+	/// Adds new supported synchronous method.
+	///
+	/// A backward-compatible wrapper.
+	pub fn add_sync_method<F>(&mut self, name: &str, method: F)
+	where
+		F: Fn(crate::Params) -> crate::Result<crate::Value> + Send + Sync + 'static,
+	{
+		self.add_method(name, move |params| future::ready(method(params)))
+	}
+
+	/// Adds new supported asynchronous method.
 	pub fn add_method<F>(&mut self, name: &str, method: F)
 	where
 		F: RpcMethodSimple,
@@ -185,14 +199,12 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 	/// If you have any asynchronous methods in your RPC it is much wiser to use
 	/// `handle_request` instead and deal with asynchronous requests in a non-blocking fashion.
 	pub fn handle_request_sync(&self, request: &str, meta: T) -> Option<String> {
-		self.handle_request(request, meta)
-			.wait()
-			.expect("Handler calls can never fail.")
+		futures::executor::block_on(self.handle_request(request, meta))
 	}
 
 	/// Handle given request asynchronously.
 	pub fn handle_request(&self, request: &str, meta: T) -> FutureResult<S::Future, S::CallFuture> {
-		use self::future::Either::{A, B};
+		use self::future::Either::{Left, Right};
 		fn as_string(response: Option<Response>) -> Option<String> {
 			let res = response.map(write_response);
 			debug!(target: "rpc", "Response: {}.", match res {
@@ -205,11 +217,11 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 		trace!(target: "rpc", "Request: {}.", request);
 		let request = read_request(request);
 		let result = match request {
-			Err(error) => A(futures::finished(Some(Response::from(
+			Err(error) => Left(future::ready(Some(Response::from(
 				error,
 				self.compatibility.default_version(),
 			)))),
-			Ok(request) => B(self.handle_rpc_request(request, meta)),
+			Ok(request) => Right(self.handle_rpc_request(request, meta)),
 		};
 
 		result.map(as_string)
@@ -217,7 +229,7 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 
 	/// Handle deserialized RPC request.
 	pub fn handle_rpc_request(&self, request: Request, meta: T) -> FutureRpcResult<S::Future, S::CallFuture> {
-		use self::future::Either::{A, B};
+		use self::future::Either::{Left, Right};
 
 		fn output_as_response(output: Option<Output>) -> Option<Response> {
 			output.map(Response::Single)
@@ -234,7 +246,7 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 
 		self.middleware
 			.on_request(request, meta, |request, meta| match request {
-				Request::Single(call) => A(self
+				Request::Single(call) => Left(self
 					.handle_call(call, meta)
 					.map(output_as_response as fn(Option<Output>) -> Option<Response>)),
 				Request::Batch(calls) => {
@@ -242,7 +254,7 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 						.into_iter()
 						.map(move |call| self.handle_call(call, meta.clone()))
 						.collect();
-					B(futures::future::join_all(futures)
+					Right(future::join_all(futures)
 						.map(outputs_as_batch as fn(Vec<Option<Output>>) -> Option<Response>))
 				}
 			})
@@ -250,7 +262,7 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 
 	/// Handle single call asynchronously.
 	pub fn handle_call(&self, call: Call, meta: T) -> FutureRpcOutput<S::CallFuture> {
-		use self::future::Either::{A, B};
+		use self::future::Either::{Left, Right};
 
 		self.middleware.on_call(call, meta, |call, meta| match call {
 			Call::MethodCall(method) => {
@@ -260,8 +272,8 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 				let valid_version = self.compatibility.is_version_valid(jsonrpc);
 
 				let call_method = |method: &Arc<dyn RpcMethod<T>>| {
-					let method = method.clone();
-					futures::lazy(move || method.call(params, meta))
+					// TODO [ToDr] lazy here?
+					method.call(params, meta)
 				};
 
 				let result = match (valid_version, self.methods.get(&method.method)) {
@@ -275,17 +287,21 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 				};
 
 				match result {
-					Ok(result) => A(Box::new(
-						result.then(move |result| futures::finished(Some(Output::from(result, id, jsonrpc)))),
+					Ok(result) => Left(Box::pin(
+						result.then(move |result| future::ready(
+							Some(Output::from(result, id, jsonrpc))
+						)),
 					) as _),
-					Err(err) => B(futures::finished(Some(Output::from(Err(err), id, jsonrpc)))),
+					Err(err) => Right(future::ready(
+						Some(Output::from(Err(err), id, jsonrpc))
+					)),
 				}
 			}
 			Call::Notification(notification) => {
 				let params = notification.params;
 				let jsonrpc = notification.jsonrpc;
 				if !self.compatibility.is_version_valid(jsonrpc) {
-					return B(futures::finished(None));
+					return Right(future::ready(None));
 				}
 
 				match self.methods.get(&notification.method) {
@@ -300,12 +316,14 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 					_ => {}
 				}
 
-				B(futures::finished(None))
+				Right(future::ready(None))
 			}
-			Call::Invalid { id } => B(futures::finished(Some(Output::invalid_request(
-				id,
-				self.compatibility.default_version(),
-			)))),
+			Call::Invalid { id } => Right(future::ready(
+				Some(Output::invalid_request(
+					id,
+					self.compatibility.default_version(),
+				))
+			)),
 		})
 	}
 
@@ -475,13 +493,13 @@ fn write_response(response: Response) -> String {
 mod tests {
 	use super::{Compatibility, IoHandler};
 	use crate::types::Value;
-	use futures;
+	use futures::future;
 
 	#[test]
 	fn test_io_handler() {
 		let mut io = IoHandler::new();
 
-		io.add_method("say_hello", |_| Ok(Value::String("hello".to_string())));
+		io.add_method("say_hello", |_| async { Ok(Value::String("hello".to_string())) });
 
 		let request = r#"{"jsonrpc": "2.0", "method": "say_hello", "params": [42, 23], "id": 1}"#;
 		let response = r#"{"jsonrpc":"2.0","result":"hello","id":1}"#;
@@ -493,7 +511,7 @@ mod tests {
 	fn test_io_handler_1dot0() {
 		let mut io = IoHandler::with_compatibility(Compatibility::Both);
 
-		io.add_method("say_hello", |_| Ok(Value::String("hello".to_string())));
+		io.add_method("say_hello", |_| async { Ok(Value::String("hello".to_string())) });
 
 		let request = r#"{"method": "say_hello", "params": [42, 23], "id": 1}"#;
 		let response = r#"{"result":"hello","id":1}"#;
@@ -505,7 +523,7 @@ mod tests {
 	fn test_async_io_handler() {
 		let mut io = IoHandler::new();
 
-		io.add_method("say_hello", |_| futures::finished(Value::String("hello".to_string())));
+		io.add_method("say_hello", |_| future::ready(Ok(Value::String("hello".to_string()))));
 
 		let request = r#"{"jsonrpc": "2.0", "method": "say_hello", "params": [42, 23], "id": 1}"#;
 		let response = r#"{"jsonrpc":"2.0","result":"hello","id":1}"#;
@@ -544,7 +562,7 @@ mod tests {
 	#[test]
 	fn test_method_alias() {
 		let mut io = IoHandler::new();
-		io.add_method("say_hello", |_| Ok(Value::String("hello".to_string())));
+		io.add_method("say_hello", |_| async { Ok(Value::String("hello".to_string())) });
 		io.add_alias("say_hello_alias", "say_hello");
 
 		let request = r#"{"jsonrpc": "2.0", "method": "say_hello_alias", "params": [42, 23], "id": 1}"#;
@@ -612,8 +630,8 @@ mod tests {
 
 		struct Test;
 		impl Test {
-			fn abc(&self, _p: crate::Params) -> Result<Value, crate::Error> {
-				Ok(5.into())
+			fn abc(&self, _p: crate::Params) -> crate::BoxFuture<Value> {
+				Box::pin(async { Ok(5.into()) })
 			}
 		}
 

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -272,10 +272,7 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 				let jsonrpc = method.jsonrpc;
 				let valid_version = self.compatibility.is_version_valid(jsonrpc);
 
-				let call_method = |method: &Arc<dyn RpcMethod<T>>| {
-					// TODO [ToDr] lazy here?
-					method.call(params, meta)
-				};
+				let call_method = |method: &Arc<dyn RpcMethod<T>>| method.call(params, meta);
 
 				let result = match (valid_version, self.methods.get(&method.method)) {
 					(false, _) => Err(Error::invalid_version()),

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -14,10 +14,10 @@ use crate::types::{Call, Output, Request, Response};
 use crate::types::{Error, ErrorCode, Version};
 
 /// A type representing middleware or RPC response before serialization.
-pub type FutureResponse = Box<dyn Future<Item = Option<Response>, Error = ()> + Send>;
+pub type FutureResponse = Box<dyn Future<Output = Result<Option<Response>, ()> + Send>>;
 
 /// A type representing middleware or RPC call output.
-pub type FutureOutput = Box<dyn Future<Item = Option<Output>, Error = ()> + Send>;
+pub type FutureOutput = Box<dyn Future<Output = Result<Option<Output>, ()> + Send>>;
 
 /// A type representing future string response.
 pub type FutureResult<F, G> = future::Map<

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -47,7 +47,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// A `Future` trait object.
 pub type BoxFuture<T> = Pin<Box<dyn futures::Future<Output = T> + Send>>;
 
-pub use crate::calls::{Metadata, RemoteProcedure, RpcMethod, RpcMethodSimple, RpcNotification, RpcNotificationSimple};
+pub use crate::calls::{Metadata, RemoteProcedure, RpcMethod, RpcMethodSync, RpcMethodSimple, RpcNotification, RpcNotificationSimple, WrapFuture};
 pub use crate::delegates::IoDelegate;
 pub use crate::io::{
 	Compatibility, FutureOutput, FutureResponse, FutureResult, FutureRpcResult, IoHandler, IoHandlerExtension,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -45,7 +45,7 @@ pub mod types;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// A `Future` trait object.
-pub type BoxFuture<T> = Pin<Box<dyn futures::Future<Output = Result<T>> + Send>>;
+pub type BoxFuture<T> = Pin<Box<dyn futures::Future<Output = T> + Send>>;
 
 pub use crate::calls::{Metadata, RemoteProcedure, RpcMethod, RpcMethodSimple, RpcNotification, RpcNotificationSimple};
 pub use crate::delegates::IoDelegate;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,22 +4,23 @@
 //!
 //! ```rust
 //! use jsonrpc_core::*;
-//! use jsonrpc_core::futures::Future;
 //!
 //! fn main() {
 //! 	let mut io = IoHandler::new();
-//! 	io.add_method("say_hello", |_| {
+//! 	io.add_sync_method("say_hello", |_| {
 //!			Ok(Value::String("Hello World!".into()))
 //! 	});
 //!
 //! 	let request = r#"{"jsonrpc": "2.0", "method": "say_hello", "params": [42, 23], "id": 1}"#;
 //! 	let response = r#"{"jsonrpc":"2.0","result":"Hello World!","id":1}"#;
 //!
-//! 	assert_eq!(io.handle_request(request).wait().unwrap(), Some(response.to_string()));
+//! 	assert_eq!(io.handle_request_sync(request), Some(response.to_string()));
 //! }
 //! ```
 
 #![deny(missing_docs)]
+
+use std::pin::Pin;
 
 #[macro_use]
 extern crate log;
@@ -40,11 +41,11 @@ pub mod delegates;
 pub mod middleware;
 pub mod types;
 
-/// A `Future` trait object.
-pub type BoxFuture<T> = Box<dyn futures::Future<Output = Result<T, Error> + Send>>;
-
 /// A Result type.
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// A `Future` trait object.
+pub type BoxFuture<T> = Pin<Box<dyn futures::Future<Output = Result<T>> + Send>>;
 
 pub use crate::calls::{Metadata, RemoteProcedure, RpcMethod, RpcMethodSimple, RpcNotification, RpcNotificationSimple};
 pub use crate::delegates::IoDelegate;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -47,7 +47,10 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// A `Future` trait object.
 pub type BoxFuture<T> = Pin<Box<dyn futures::Future<Output = T> + Send>>;
 
-pub use crate::calls::{Metadata, RemoteProcedure, RpcMethod, RpcMethodSync, RpcMethodSimple, RpcNotification, RpcNotificationSimple, WrapFuture};
+pub use crate::calls::{
+	Metadata, RemoteProcedure, RpcMethod, RpcMethodSimple, RpcMethodSync, RpcNotification, RpcNotificationSimple,
+	WrapFuture,
+};
 pub use crate::delegates::IoDelegate;
 pub use crate::io::{
 	Compatibility, FutureOutput, FutureResponse, FutureResult, FutureRpcResult, IoHandler, IoHandlerExtension,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -41,7 +41,7 @@ pub mod middleware;
 pub mod types;
 
 /// A `Future` trait object.
-pub type BoxFuture<T> = Box<dyn futures::Future<Item = T, Error = Error> + Send>;
+pub type BoxFuture<T> = Box<dyn futures::Future<Output = Result<T, Error> + Send>>;
 
 /// A Result type.
 pub type Result<T> = ::std::result::Result<T, Error>;

--- a/core/src/middleware.rs
+++ b/core/src/middleware.rs
@@ -3,14 +3,15 @@
 use crate::calls::Metadata;
 use crate::types::{Call, Output, Request, Response};
 use futures::{future::Either, Future};
+use std::pin::Pin;
 
 /// RPC middleware
 pub trait Middleware<M: Metadata>: Send + Sync + 'static {
 	/// A returned request future.
-	type Future: Future<Output = Result<Option<Response>, ()>> + Send + 'static;
+	type Future: Future<Output = Option<Response>> + Send + 'static;
 
 	/// A returned call future.
-	type CallFuture: Future<Output = Result<Option<Output>, ()>> + Send + 'static;
+	type CallFuture: Future<Output = Option<Output>> + Send + 'static;
 
 	/// Method invoked on each request.
 	/// Allows you to either respond directly (without executing RPC call)
@@ -18,9 +19,9 @@ pub trait Middleware<M: Metadata>: Send + Sync + 'static {
 	fn on_request<F, X>(&self, request: Request, meta: M, next: F) -> Either<Self::Future, X>
 	where
 		F: Fn(Request, M) -> X + Send + Sync,
-		X: Future<Output = Result<Option<Response>, ()>> + Send + 'static,
+		X: Future<Output = Option<Response>> + Send + 'static,
 	{
-		Either::B(next(request, meta))
+		Either::Right(next(request, meta))
 	}
 
 	/// Method invoked on each call inside a request.
@@ -29,16 +30,16 @@ pub trait Middleware<M: Metadata>: Send + Sync + 'static {
 	fn on_call<F, X>(&self, call: Call, meta: M, next: F) -> Either<Self::CallFuture, X>
 	where
 		F: Fn(Call, M) -> X + Send + Sync,
-		X: Future<Output = Result<Option<Output>, ()>> + Send + 'static,
+		X: Future<Output = Option<Output>> + Send + 'static,
 	{
-		Either::B(next(call, meta))
+		Either::Right(next(call, meta))
 	}
 }
 
 /// Dummy future used as a noop result of middleware.
-pub type NoopFuture = Box<dyn Future<Output = Result<Option<Response>, ()> + Send>>;
+pub type NoopFuture = Pin<Box<dyn Future<Output = Option<Response>> + Send>>;
 /// Dummy future used as a noop call result of middleware.
-pub type NoopCallFuture = Box<dyn Future<Output = Result<Option<Output>, ()> + Send>>;
+pub type NoopCallFuture = Pin<Box<dyn Future<Output = Option<Output>> + Send>>;
 
 /// No-op middleware implementation
 #[derive(Clone, Debug, Default)]
@@ -55,7 +56,7 @@ impl<M: Metadata, A: Middleware<M>, B: Middleware<M>> Middleware<M> for (A, B) {
 	fn on_request<F, X>(&self, request: Request, meta: M, process: F) -> Either<Self::Future, X>
 	where
 		F: Fn(Request, M) -> X + Send + Sync,
-		X: Future<Output = Result<Option<Response>, ()>> + Send + 'static,
+		X: Future<Output = Option<Response>> + Send + 'static,
 	{
 		repack(self.0.on_request(request, meta, |request, meta| {
 			self.1.on_request(request, meta, &process)
@@ -65,7 +66,7 @@ impl<M: Metadata, A: Middleware<M>, B: Middleware<M>> Middleware<M> for (A, B) {
 	fn on_call<F, X>(&self, call: Call, meta: M, process: F) -> Either<Self::CallFuture, X>
 	where
 		F: Fn(Call, M) -> X + Send + Sync,
-		X: Future<Output = Result<Option<Output>, ()>> + Send + 'static,
+		X: Future<Output = Option<Output>> + Send + 'static,
 	{
 		repack(
 			self.0
@@ -81,7 +82,7 @@ impl<M: Metadata, A: Middleware<M>, B: Middleware<M>, C: Middleware<M>> Middlewa
 	fn on_request<F, X>(&self, request: Request, meta: M, process: F) -> Either<Self::Future, X>
 	where
 		F: Fn(Request, M) -> X + Send + Sync,
-		X: Future<Output = Result<Option<Response>, ()>> + Send + 'static,
+		X: Future<Output = Option<Response>> + Send + 'static,
 	{
 		repack(self.0.on_request(request, meta, |request, meta| {
 			repack(self.1.on_request(request, meta, |request, meta| {
@@ -93,7 +94,7 @@ impl<M: Metadata, A: Middleware<M>, B: Middleware<M>, C: Middleware<M>> Middlewa
 	fn on_call<F, X>(&self, call: Call, meta: M, process: F) -> Either<Self::CallFuture, X>
 	where
 		F: Fn(Call, M) -> X + Send + Sync,
-		X: Future<Output = Result<Option<Output>, ()>> + Send + 'static,
+		X: Future<Output = Option<Output>> + Send + 'static,
 	{
 		repack(self.0.on_call(call, meta, |call, meta| {
 			repack(
@@ -113,7 +114,7 @@ impl<M: Metadata, A: Middleware<M>, B: Middleware<M>, C: Middleware<M>, D: Middl
 	fn on_request<F, X>(&self, request: Request, meta: M, process: F) -> Either<Self::Future, X>
 	where
 		F: Fn(Request, M) -> X + Send + Sync,
-		X: Future<Output = Result<Option<Response>, ()>> + Send + 'static,
+		X: Future<Output = Option<Response>> + Send + 'static,
 	{
 		repack(self.0.on_request(request, meta, |request, meta| {
 			repack(self.1.on_request(request, meta, |request, meta| {
@@ -127,7 +128,7 @@ impl<M: Metadata, A: Middleware<M>, B: Middleware<M>, C: Middleware<M>, D: Middl
 	fn on_call<F, X>(&self, call: Call, meta: M, process: F) -> Either<Self::CallFuture, X>
 	where
 		F: Fn(Call, M) -> X + Send + Sync,
-		X: Future<Output = Result<Option<Output>, ()>> + Send + 'static,
+		X: Future<Output = Option<Output>> + Send + 'static,
 	{
 		repack(self.0.on_call(call, meta, |call, meta| {
 			repack(self.1.on_call(call, meta, |call, meta| {
@@ -143,8 +144,8 @@ impl<M: Metadata, A: Middleware<M>, B: Middleware<M>, C: Middleware<M>, D: Middl
 #[inline(always)]
 fn repack<A, B, X>(result: Either<A, Either<B, X>>) -> Either<Either<A, B>, X> {
 	match result {
-		Either::A(a) => Either::A(Either::A(a)),
-		Either::B(Either::A(b)) => Either::A(Either::B(b)),
-		Either::B(Either::B(x)) => Either::B(x),
+		Either::Left(a) => Either::Left(Either::Left(a)),
+		Either::Right(Either::Left(b)) => Either::Left(Either::Right(b)),
+		Either::Right(Either::Right(x)) => Either::Right(x),
 	}
 }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -19,12 +19,12 @@ quote = "1.0.6"
 proc-macro-crate = "0.1.4"
 
 [dev-dependencies]
+assert_matches = "1.3"
 jsonrpc-core = { version = "14.2", path = "../core" }
 jsonrpc-core-client = { version = "14.2", path = "../core-client" }
 jsonrpc-pubsub = { version = "14.2", path = "../pubsub" }
 jsonrpc-tcp-server = { version = "14.2", path = "../tcp" }
-futures = "~0.1.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = "0.1"
+tokio = "0.2"
 trybuild = "1.0"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -26,5 +26,4 @@ jsonrpc-pubsub = { version = "15.0", path = "../pubsub" }
 jsonrpc-tcp-server = { version = "15.0", path = "../tcp" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = "0.2"
 trybuild = "1.0"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-derive"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.2.1"
+version = "15.0.0"
 
 [lib]
 proc-macro = true
@@ -20,10 +20,10 @@ proc-macro-crate = "0.1.4"
 
 [dev-dependencies]
 assert_matches = "1.3"
-jsonrpc-core = { version = "14.2", path = "../core" }
-jsonrpc-core-client = { version = "14.2", path = "../core-client" }
-jsonrpc-pubsub = { version = "14.2", path = "../pubsub" }
-jsonrpc-tcp-server = { version = "14.2", path = "../tcp" }
+jsonrpc-core = { version = "15.0", path = "../core" }
+jsonrpc-core-client = { version = "15.0", path = "../core-client" }
+jsonrpc-pubsub = { version = "15.0", path = "../pubsub" }
+jsonrpc-tcp-server = { version = "15.0", path = "../tcp" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = "0.2"

--- a/derive/examples/generic-trait-bounds.rs
+++ b/derive/examples/generic-trait-bounds.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use jsonrpc_core::futures::future::{self, FutureResult};
-use jsonrpc_core::{Error, IoHandler, IoHandlerExtension, Result};
+use jsonrpc_core::{IoHandler, IoHandlerExtension, Result, BoxFuture};
 use jsonrpc_derive::rpc;
 
 // One is both parameter and a result so requires both Serialize and DeserializeOwned
@@ -22,7 +21,7 @@ pub trait Rpc<One, Two, Three> {
 
 	/// Performs asynchronous operation
 	#[rpc(name = "beFancy")]
-	fn call(&self, a: One) -> FutureResult<(One, u64), Error>;
+	fn call(&self, a: One) -> BoxFuture<Result<(One, u64)>>;
 }
 
 struct RpcImpl;
@@ -49,7 +48,7 @@ impl Rpc<InAndOut, In, Out> for RpcImpl {
 		Ok(Out {})
 	}
 
-	fn call(&self, num: InAndOut) -> FutureResult<(InAndOut, u64), Error> {
+	fn call(&self, num: InAndOut) -> BoxFuture<Result<(InAndOut, u64)>> {
 		crate::future::finished((InAndOut { foo: num.foo + 999 }, num.foo))
 	}
 }

--- a/derive/examples/generic-trait-bounds.rs
+++ b/derive/examples/generic-trait-bounds.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use jsonrpc_core::{IoHandler, IoHandlerExtension, Result, BoxFuture};
+use jsonrpc_core::{IoHandler, IoHandlerExtension, Result, BoxFuture, futures::future};
 use jsonrpc_derive::rpc;
 
 // One is both parameter and a result so requires both Serialize and DeserializeOwned
@@ -49,7 +49,7 @@ impl Rpc<InAndOut, In, Out> for RpcImpl {
 	}
 
 	fn call(&self, num: InAndOut) -> BoxFuture<Result<(InAndOut, u64)>> {
-		jsonrpc_core::futures::future::ready(Ok((InAndOut { foo: num.foo + 999 }, num.foo)))
+		Box::pin(future::ready(Ok((InAndOut { foo: num.foo + 999 }, num.foo))))
 	}
 }
 

--- a/derive/examples/generic-trait-bounds.rs
+++ b/derive/examples/generic-trait-bounds.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use jsonrpc_core::{IoHandler, IoHandlerExtension, Result, BoxFuture, futures::future};
+use jsonrpc_core::{futures::future, BoxFuture, IoHandler, IoHandlerExtension, Result};
 use jsonrpc_derive::rpc;
 
 // One is both parameter and a result so requires both Serialize and DeserializeOwned

--- a/derive/examples/generic-trait-bounds.rs
+++ b/derive/examples/generic-trait-bounds.rs
@@ -49,7 +49,7 @@ impl Rpc<InAndOut, In, Out> for RpcImpl {
 	}
 
 	fn call(&self, num: InAndOut) -> BoxFuture<Result<(InAndOut, u64)>> {
-		crate::future::finished((InAndOut { foo: num.foo + 999 }, num.foo))
+		jsonrpc_core::futures::future::ready(Ok((InAndOut { foo: num.foo + 999 }, num.foo)))
 	}
 }
 

--- a/derive/examples/generic-trait.rs
+++ b/derive/examples/generic-trait.rs
@@ -31,7 +31,7 @@ impl Rpc<u64, String> for RpcImpl {
 	}
 
 	fn call(&self, num: u64) -> BoxFuture<Result<(u64, String)>> {
-		crate::future::finished((num + 999, "hello".into()))
+		Box::pin(jsonrpc_core::futures::future::ready(Ok((num + 999, "hello".into()))))
 	}
 }
 

--- a/derive/examples/generic-trait.rs
+++ b/derive/examples/generic-trait.rs
@@ -1,7 +1,6 @@
 use jsonrpc_core;
 
-use jsonrpc_core::futures::future::{self, FutureResult};
-use jsonrpc_core::{Error, IoHandler, Result};
+use jsonrpc_core::{IoHandler, Result, BoxFuture};
 use jsonrpc_derive::rpc;
 
 #[rpc]
@@ -16,7 +15,7 @@ pub trait Rpc<One, Two> {
 
 	/// Performs asynchronous operation
 	#[rpc(name = "beFancy")]
-	fn call(&self, a: One) -> FutureResult<(One, Two), Error>;
+	fn call(&self, a: One) -> BoxFuture<Result<(One, Two)>>;
 }
 
 struct RpcImpl;
@@ -31,7 +30,7 @@ impl Rpc<u64, String> for RpcImpl {
 		Ok(())
 	}
 
-	fn call(&self, num: u64) -> FutureResult<(u64, String), Error> {
+	fn call(&self, num: u64) -> BoxFuture<Result<(u64, String)>> {
 		crate::future::finished((num + 999, "hello".into()))
 	}
 }

--- a/derive/examples/generic-trait.rs
+++ b/derive/examples/generic-trait.rs
@@ -1,6 +1,6 @@
 use jsonrpc_core;
 
-use jsonrpc_core::{IoHandler, Result, BoxFuture};
+use jsonrpc_core::{BoxFuture, IoHandler, Result};
 use jsonrpc_derive::rpc;
 
 #[rpc]

--- a/derive/examples/meta-macros.rs
+++ b/derive/examples/meta-macros.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
-use jsonrpc_core::types::params::Params;
-use jsonrpc_core::{futures, MetaIoHandler, Metadata, Result, Value, BoxFuture};
+use jsonrpc_core::futures::future;
+use jsonrpc_core::{MetaIoHandler, Metadata, Result, Value, BoxFuture, Params};
 use jsonrpc_derive::rpc;
 
 #[derive(Clone)]
@@ -62,11 +62,11 @@ impl Rpc<u64> for RpcImpl {
 	}
 
 	fn call(&self, x: u64) -> BoxFuture<Result<String>> {
-		futures::finished(format!("OK: {}", x))
+		Box::pin(future::ready(Ok(format!("OK: {}", x))))
 	}
 
 	fn call_meta(&self, meta: Self::Metadata, map: BTreeMap<String, Value>) -> BoxFuture<Result<String>> {
-		futures::finished(format!("From: {}, got: {:?}", meta.0, map))
+		Box::pin(future::ready(Ok(format!("From: {}, got: {:?}", meta.0, map))))
 	}
 
 	fn notify(&self, a: u64) {

--- a/derive/examples/meta-macros.rs
+++ b/derive/examples/meta-macros.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use jsonrpc_core::futures::future;
-use jsonrpc_core::{MetaIoHandler, Metadata, Result, Value, BoxFuture, Params};
+use jsonrpc_core::{BoxFuture, MetaIoHandler, Metadata, Params, Result, Value};
 use jsonrpc_derive::rpc;
 
 #[derive(Clone)]

--- a/derive/examples/meta-macros.rs
+++ b/derive/examples/meta-macros.rs
@@ -1,8 +1,7 @@
 use std::collections::BTreeMap;
 
-use jsonrpc_core::futures::future::FutureResult;
 use jsonrpc_core::types::params::Params;
-use jsonrpc_core::{futures, Error, MetaIoHandler, Metadata, Result, Value};
+use jsonrpc_core::{futures, MetaIoHandler, Metadata, Result, Value, BoxFuture};
 use jsonrpc_derive::rpc;
 
 #[derive(Clone)]
@@ -31,11 +30,11 @@ pub trait Rpc<One> {
 
 	/// Performs an asynchronous operation.
 	#[rpc(name = "callAsync")]
-	fn call(&self, a: u64) -> FutureResult<String, Error>;
+	fn call(&self, a: u64) -> BoxFuture<Result<String>>;
 
 	/// Performs an asynchronous operation with meta.
 	#[rpc(meta, name = "callAsyncMeta", alias("callAsyncMetaAlias"))]
-	fn call_meta(&self, a: Self::Metadata, b: BTreeMap<String, Value>) -> FutureResult<String, Error>;
+	fn call_meta(&self, a: Self::Metadata, b: BTreeMap<String, Value>) -> BoxFuture<Result<String>>;
 
 	/// Handles a notification.
 	#[rpc(name = "notify")]
@@ -62,11 +61,11 @@ impl Rpc<u64> for RpcImpl {
 		Ok(format!("Got: {:?}", params))
 	}
 
-	fn call(&self, x: u64) -> FutureResult<String, Error> {
+	fn call(&self, x: u64) -> BoxFuture<Result<String>> {
 		futures::finished(format!("OK: {}", x))
 	}
 
-	fn call_meta(&self, meta: Self::Metadata, map: BTreeMap<String, Value>) -> FutureResult<String, Error> {
+	fn call_meta(&self, meta: Self::Metadata, map: BTreeMap<String, Value>) -> BoxFuture<Result<String>> {
 		futures::finished(format!("From: {}, got: {:?}", meta.0, map))
 	}
 

--- a/derive/examples/pubsub-macros.rs
+++ b/derive/examples/pubsub-macros.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::sync::{atomic, Arc, RwLock};
 use std::thread;
 
-use jsonrpc_core::futures::Future;
 use jsonrpc_core::{Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use jsonrpc_pubsub::typed;
@@ -70,7 +69,7 @@ fn main() {
 		{
 			let subscribers = active_subscriptions.read().unwrap();
 			for sink in subscribers.values() {
-				let _ = sink.notify(Ok("Hello World!".into())).wait();
+				let _ = sink.notify(Ok("Hello World!".into()));
 			}
 		}
 		thread::sleep(::std::time::Duration::from_secs(1));

--- a/derive/examples/std.rs
+++ b/derive/examples/std.rs
@@ -1,7 +1,7 @@
 //! A simple example
 #![deny(missing_docs)]
-use jsonrpc_core::futures::future::{self, Future};
-use jsonrpc_core::{Error, IoHandler, Result};
+use jsonrpc_core::futures::{self, future, TryFutureExt};
+use jsonrpc_core::{IoHandler, Result, BoxFuture};
 use jsonrpc_core_client::transports::local;
 use jsonrpc_derive::rpc;
 
@@ -18,7 +18,7 @@ pub trait Rpc {
 
 	/// Performs asynchronous operation.
 	#[rpc(name = "callAsync")]
-	fn call(&self, a: u64) -> future::Ready<Result<String, Error>>;
+	fn call(&self, a: u64) -> BoxFuture<Result<String>>;
 
 	/// Handles a notification.
 	#[rpc(name = "notify")]
@@ -36,8 +36,8 @@ impl Rpc for RpcImpl {
 		Ok(a + b)
 	}
 
-	fn call(&self, _: u64) -> future::Ready<Result<String, Error>> {
-		future::ready(Ok("OK".to_owned()))
+	fn call(&self, _: u64) -> BoxFuture<Result<String>> {
+		Box::pin(future::ready(Ok("OK".to_owned())))
 	}
 
 	fn notify(&self, a: u64) {
@@ -49,9 +49,10 @@ fn main() {
 	let mut io = IoHandler::new();
 	io.extend_with(RpcImpl.to_delegate());
 
-	let fut = {
-		let (client, server) = local::connect::<gen_client::Client, _, _>(io);
-		client.add(5, 6).map(|res| println!("5 + 6 = {}", res)).join(server)
-	};
-	fut.wait().unwrap();
+	let (client, server) = local::connect::<RpcClient, _, _>(io);
+	let fut = client.add(5, 6).map_ok(|res| println!("5 + 6 = {}", res));
+
+	futures::executor::block_on(async move {
+		futures::join!(fut, server)
+	}).0.unwrap();
 }

--- a/derive/examples/std.rs
+++ b/derive/examples/std.rs
@@ -1,7 +1,7 @@
 //! A simple example
 #![deny(missing_docs)]
 use jsonrpc_core::futures::{self, future, TryFutureExt};
-use jsonrpc_core::{IoHandler, Result, BoxFuture};
+use jsonrpc_core::{BoxFuture, IoHandler, Result};
 use jsonrpc_core_client::transports::local;
 use jsonrpc_derive::rpc;
 
@@ -52,7 +52,7 @@ fn main() {
 	let (client, server) = local::connect::<RpcClient, _, _>(io);
 	let fut = client.add(5, 6).map_ok(|res| println!("5 + 6 = {}", res));
 
-	futures::executor::block_on(async move {
-		futures::join!(fut, server)
-	}).0.unwrap();
+	futures::executor::block_on(async move { futures::join!(fut, server) })
+		.0
+		.unwrap();
 }

--- a/derive/examples/std.rs
+++ b/derive/examples/std.rs
@@ -1,6 +1,6 @@
 //! A simple example
 #![deny(missing_docs)]
-use jsonrpc_core::futures::future::{self, Future, FutureResult};
+use jsonrpc_core::futures::future::{self, Future};
 use jsonrpc_core::{Error, IoHandler, Result};
 use jsonrpc_core_client::transports::local;
 use jsonrpc_derive::rpc;
@@ -18,7 +18,7 @@ pub trait Rpc {
 
 	/// Performs asynchronous operation.
 	#[rpc(name = "callAsync")]
-	fn call(&self, a: u64) -> FutureResult<String, Error>;
+	fn call(&self, a: u64) -> future::Ready<Result<String, Error>>;
 
 	/// Handles a notification.
 	#[rpc(name = "notify")]
@@ -36,8 +36,8 @@ impl Rpc for RpcImpl {
 		Ok(a + b)
 	}
 
-	fn call(&self, _: u64) -> FutureResult<String, Error> {
-		future::ok("OK".to_owned())
+	fn call(&self, _: u64) -> future::Ready<Result<String, Error>> {
+		future::ready(Ok("OK".to_owned()))
 	}
 
 	fn notify(&self, a: u64) {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -7,7 +7,7 @@
 //! ```
 //! use jsonrpc_derive::rpc;
 //! use jsonrpc_core::{IoHandler, Error, Result};
-//! use jsonrpc_core::futures::future::{self, FutureResult};
+//! use jsonrpc_core::futures::future;
 //!
 //! #[rpc(server)]
 //! pub trait Rpc {
@@ -18,7 +18,7 @@
 //! 	fn add(&self, a: u64, b: u64) -> Result<u64>;
 //!
 //! 	#[rpc(name = "callAsync")]
-//! 	fn call(&self, a: u64) -> FutureResult<String, Error>;
+//! 	fn call(&self, a: u64) -> future::Ready<Result<String, Error>>;
 //! }
 //!
 //! struct RpcImpl;
@@ -31,8 +31,8 @@
 //! 		Ok(a + b)
 //! 	}
 //!
-//! 	fn call(&self, _: u64) -> FutureResult<String, Error> {
-//! 		future::ok("OK".to_owned()).into()
+//! 	fn call(&self, _: u64) -> future::Ready<Result<String, Error>> {
+//! 		future::ready(Ok("OK".to_owned()).into())
 //! 	}
 //! }
 //!
@@ -56,7 +56,6 @@
 //! use std::collections::HashMap;
 //!
 //! use jsonrpc_core::{Error, ErrorCode, Result};
-//! use jsonrpc_core::futures::Future;
 //! use jsonrpc_derive::rpc;
 //! use jsonrpc_pubsub::{Session, PubSubHandler, SubscriptionId, typed::{Subscriber, Sink}};
 //!
@@ -128,7 +127,7 @@
 //!
 //! ```
 //! use jsonrpc_core_client::transports::local;
-//! use jsonrpc_core::futures::future::{self, Future, FutureResult};
+//! use jsonrpc_core::futures::future;
 //! use jsonrpc_core::{Error, IoHandler, Result};
 //! use jsonrpc_derive::rpc;
 //!
@@ -145,7 +144,7 @@
 //!
 //! 	/// Performs asynchronous operation
 //! 	#[rpc(name = "callAsync")]
-//! 	fn call(&self, a: u64) -> FutureResult<String, Error>;
+//! 	fn call(&self, a: u64) -> future::Ready<Result<String, Error>>;
 //! }
 //!
 //! struct RpcImpl;
@@ -159,8 +158,8 @@
 //! 		Ok(a + b)
 //! 	}
 //!
-//! 	fn call(&self, _: u64) -> FutureResult<String, Error> {
-//! 		future::ok("OK".to_owned())
+//! 	fn call(&self, _: u64) -> future::Ready<Result<String, Error>> {
+//! 		future::ready(Ok("OK".to_owned()))
 //! 	}
 //! }
 //!

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! ```
 //! use jsonrpc_derive::rpc;
-//! use jsonrpc_core::{IoHandler, Result};
+//! use jsonrpc_core::{IoHandler, Result, BoxFuture};
 //! use jsonrpc_core::futures::future;
 //!
 //! #[rpc(server)]
@@ -18,7 +18,7 @@
 //! 	fn add(&self, a: u64, b: u64) -> Result<u64>;
 //!
 //! 	#[rpc(name = "callAsync")]
-//! 	fn call(&self, a: u64) -> future::Ready<Result<String>>;
+//! 	fn call(&self, a: u64) -> BoxFuture<Result<String>>;
 //! }
 //!
 //! struct RpcImpl;
@@ -31,8 +31,8 @@
 //! 		Ok(a + b)
 //! 	}
 //!
-//! 	fn call(&self, _: u64) -> future::Ready<Result<String>> {
-//! 		future::ready(Ok("OK".to_owned()).into())
+//! 	fn call(&self, _: u64) -> BoxFuture<Result<String>> {
+//! 		Box::pin(future::ready(Ok("OK".to_owned()).into()))
 //! 	}
 //! }
 //!
@@ -127,8 +127,8 @@
 //!
 //! ```
 //! use jsonrpc_core_client::transports::local;
-//! use jsonrpc_core::futures::future;
-//! use jsonrpc_core::{IoHandler, Result};
+//! use jsonrpc_core::futures::{self, future};
+//! use jsonrpc_core::{IoHandler, Result, BoxFuture};
 //! use jsonrpc_derive::rpc;
 //!
 //! /// Rpc trait
@@ -144,7 +144,7 @@
 //!
 //! 	/// Performs asynchronous operation
 //! 	#[rpc(name = "callAsync")]
-//! 	fn call(&self, a: u64) -> future::Ready<Result<String>>;
+//! 	fn call(&self, a: u64) -> BoxFuture<Result<String>>;
 //! }
 //!
 //! struct RpcImpl;
@@ -158,20 +158,23 @@
 //! 		Ok(a + b)
 //! 	}
 //!
-//! 	fn call(&self, _: u64) -> future::Ready<Result<String>> {
-//! 		future::ready(Ok("OK".to_owned()))
+//! 	fn call(&self, _: u64) -> BoxFuture<Result<String>> {
+//! 		Box::pin(future::ready(Ok("OK".to_owned())))
 //! 	}
 //! }
 //!
 //! fn main() {
+//! 	let exec = futures::executor::ThreadPool::new().unwrap();
+//! 	exec.spawn_ok(run())
+//! }
+//! async fn run() {
 //! 	let mut io = IoHandler::new();
 //! 	io.extend_with(RpcImpl.to_delegate());
 //!
-//! 	let fut = {
-//! 		let (client, server) = local::connect::<gen_client::Client, _, _>(io);
-//! 		client.add(5, 6).map(|res| println!("5 + 6 = {}", res)).join(server)
-//! 	};
-//! 	fut.wait().unwrap();
+//! 	let (client, server) = local::connect::<RpcClient, _, _>(io);
+//! 	let res = client.add(5, 6).await.unwrap();
+//! 	println!("5 + 6 = {}", res);
+//! 	server.await.unwrap()
 //! }
 //!
 //! ```

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! ```
 //! use jsonrpc_derive::rpc;
-//! use jsonrpc_core::{IoHandler, Error, Result};
+//! use jsonrpc_core::{IoHandler, Result};
 //! use jsonrpc_core::futures::future;
 //!
 //! #[rpc(server)]
@@ -18,7 +18,7 @@
 //! 	fn add(&self, a: u64, b: u64) -> Result<u64>;
 //!
 //! 	#[rpc(name = "callAsync")]
-//! 	fn call(&self, a: u64) -> future::Ready<Result<String, Error>>;
+//! 	fn call(&self, a: u64) -> future::Ready<Result<String>>;
 //! }
 //!
 //! struct RpcImpl;
@@ -31,7 +31,7 @@
 //! 		Ok(a + b)
 //! 	}
 //!
-//! 	fn call(&self, _: u64) -> future::Ready<Result<String, Error>> {
+//! 	fn call(&self, _: u64) -> future::Ready<Result<String>> {
 //! 		future::ready(Ok("OK".to_owned()).into())
 //! 	}
 //! }
@@ -128,7 +128,7 @@
 //! ```
 //! use jsonrpc_core_client::transports::local;
 //! use jsonrpc_core::futures::future;
-//! use jsonrpc_core::{Error, IoHandler, Result};
+//! use jsonrpc_core::{IoHandler, Result};
 //! use jsonrpc_derive::rpc;
 //!
 //! /// Rpc trait
@@ -144,7 +144,7 @@
 //!
 //! 	/// Performs asynchronous operation
 //! 	#[rpc(name = "callAsync")]
-//! 	fn call(&self, a: u64) -> future::Ready<Result<String, Error>>;
+//! 	fn call(&self, a: u64) -> future::Ready<Result<String>>;
 //! }
 //!
 //! struct RpcImpl;
@@ -158,7 +158,7 @@
 //! 		Ok(a + b)
 //! 	}
 //!
-//! 	fn call(&self, _: u64) -> future::Ready<Result<String, Error>> {
+//! 	fn call(&self, _: u64) -> future::Ready<Result<String>> {
 //! 		future::ready(Ok("OK".to_owned()))
 //! 	}
 //! }

--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -258,8 +258,10 @@ pub fn rpc_impl(input: syn::Item, options: &DeriveOptions) -> Result<proc_macro2
 	if options.enable_client {
 		let rpc_client_module = generate_client_module(&method_registrations, &rpc_trait, options)?;
 		submodules.push(rpc_client_module);
+		let client_name = syn::Ident::new(&format!("{}Client", name), proc_macro2::Span::call_site());
 		exports.push(quote! {
 			pub use self::#mod_name_ident::gen_client;
+			pub use self::#mod_name_ident::gen_client::Client as #client_name;
 		});
 	}
 	if options.enable_server {

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -43,7 +43,7 @@ pub fn generate_client_module(
 		})
 		.unzip();
 	let client_name = crate_name("jsonrpc-core-client")?;
-	Ok(quote! {
+	let client = quote! {
 		/// The generated client module.
 		pub mod gen_client {
 			use #client_name as _jsonrpc_core_client;
@@ -53,9 +53,8 @@ pub fn generate_client_module(
 				Response, Version,
 			};
 			use _jsonrpc_core::serde_json::{self, Value};
-			use _jsonrpc_core_client::futures01::Future;
-			use _jsonrpc_core_client::futures01::channel::{mpsc, oneshot};
-			use _jsonrpc_core_client::futures03::FutureExt;
+			use _jsonrpc_core_client::futures01::sync::{mpsc, oneshot};
+			use _jsonrpc_core_client::futures03::{Future, FutureExt};
 			use _jsonrpc_core_client::{RpcChannel, RpcResult, RpcFuture, TypedClient, TypedSubscriptionStream};
 
 			/// The Client.
@@ -89,7 +88,11 @@ pub fn generate_client_module(
 				}
 			}
 		}
-	})
+	};
+
+	println!("Client: {}", client);
+
+	Ok(client)
 }
 
 fn generate_client_methods(methods: &[MethodRegistration], options: &DeriveOptions) -> Result<Vec<syn::ImplItem>> {
@@ -265,21 +268,37 @@ fn compute_returns(method: &syn::TraitItemMethod, returns: &Option<String>) -> R
 }
 
 fn try_infer_returns(output: &syn::ReturnType) -> Option<syn::Type> {
+	let extract_path_segments = |ty: &syn::Type| match ty {
+		syn::Type::Path(syn::TypePath {
+			path: syn::Path { segments, .. },
+			..
+		}) => Some(segments.clone()),
+		_ => None,
+	};
+
 	match output {
-		syn::ReturnType::Type(_, ty) => match &**ty {
-			syn::Type::Path(syn::TypePath {
-				path: syn::Path { segments, .. },
-				..
-			}) => match &segments[0] {
+		syn::ReturnType::Type(_, ty) => {
+			let segments = extract_path_segments(&**ty)?;
+			let check_segment = |seg: &syn::PathSegment| match seg {
 				syn::PathSegment { ident, arguments, .. } => {
-					if ident.to_string().ends_with("Result") {
-						get_first_type_argument(arguments)
+					let id = ident.to_string();
+					let inner = get_first_type_argument(arguments);
+					if id.ends_with("Result") {
+						Ok(inner)
 					} else {
-						None
+						Err(inner)
 					}
 				}
-			},
-			_ => None,
+			};
+			// Try out first argument (Result<X>) or nested types like:
+			// BoxFuture<Result<X>>
+			match check_segment(&segments[0]) {
+				Ok(returns) => Some(returns?),
+				Err(inner) => {
+					let segments = extract_path_segments(&inner?)?;
+					check_segment(&segments[0]).ok().flatten()
+				}
+			}
 		},
 		_ => None,
 	}
@@ -288,9 +307,9 @@ fn try_infer_returns(output: &syn::ReturnType) -> Option<syn::Type> {
 fn get_first_type_argument(args: &syn::PathArguments) -> Option<syn::Type> {
 	match args {
 		syn::PathArguments::AngleBracketed(syn::AngleBracketedGenericArguments { args, .. }) => {
-			if args.len() > 0 {
+			if !args.is_empty() {
 				match &args[0] {
-					syn::GenericArgument::Type(ty) => Some(ty.to_owned()),
+					syn::GenericArgument::Type(ty) => Some(ty.clone()),
 					_ => None,
 				}
 			} else {

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -53,8 +53,7 @@ pub fn generate_client_module(
 				Response, Version,
 			};
 			use _jsonrpc_core::serde_json::{self, Value};
-			use _jsonrpc_core_client::futures01::sync::{mpsc, oneshot};
-			use _jsonrpc_core_client::futures03::{Future, FutureExt};
+			use _jsonrpc_core_client::futures::{Future, FutureExt, channel::{mpsc, oneshot}};
 			use _jsonrpc_core_client::{RpcChannel, RpcResult, RpcFuture, TypedClient, TypedSubscriptionStream};
 
 			/// The Client.
@@ -89,8 +88,6 @@ pub fn generate_client_module(
 			}
 		}
 	};
-
-	println!("Client: {}", client);
 
 	Ok(client)
 }
@@ -154,7 +151,7 @@ fn generate_client_methods(methods: &[MethodRegistration], options: &DeriveOptio
 					let unsubscribe = unsubscribe.name();
 					let client_method = syn::parse_quote!(
 						#(#attrs)*
-						pub fn #name(&self, #args) -> impl Future<Output = RpcResult<TypedSubscriptionStream<#returns>> {
+						pub fn #name(&self, #args) -> RpcResult<TypedSubscriptionStream<#returns>> {
 							let args_tuple = (#(#arg_names,)*);
 							self.inner.subscribe(#subscribe, args_tuple, #subscription, #unsubscribe, #returns_str)
 						}
@@ -170,7 +167,7 @@ fn generate_client_methods(methods: &[MethodRegistration], options: &DeriveOptio
 				let arg_names = compute_arg_identifiers(&args)?;
 				let client_method = syn::parse_quote! {
 					#(#attrs)*
-					pub fn #name(&self, #args) -> impl Future<Output = RpcResult<()>> {
+					pub fn #name(&self, #args) -> RpcResult<()> {
 						let args_tuple = (#(#arg_names,)*);
 						self.inner.notify(#rpc_name, args_tuple)
 					}

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -296,7 +296,7 @@ fn try_infer_returns(output: &syn::ReturnType) -> Option<syn::Type> {
 					check_segment(&segments[0]).ok().flatten()
 				}
 			}
-		},
+		}
 		_ => None,
 	}
 }

--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -54,7 +54,7 @@ impl MethodRegistration {
 				let unsub_closure = quote! {
 					move |base, id, meta| {
 						use self::_futures::{Future, IntoFuture};
-						Self::#unsub_method_ident(base, meta, id).into_future()
+						Self::#unsub_method_ident(base, meta, id)
 							.map(|value| _jsonrpc_core::to_value(value)
 									.expect("Expected always-serializable type; qed"))
 							.map_err(Into::into)
@@ -280,7 +280,6 @@ impl RpcMethod {
 				Ok((#(#tuple_fields, )*)) => {
 					use self::_futures::{Future, IntoFuture};
 					let fut = (method)#method_call
-						.into_future()
 						.map(|value| _jsonrpc_core::to_value(value)
 							.expect("Expected always-serializable type; qed"))
 						.map_err(Into::into as fn(_) -> _jsonrpc_core::Error);

--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -53,7 +53,7 @@ impl MethodRegistration {
 				let unsub_method_ident = unsubscribe.ident();
 				let unsub_closure = quote! {
 					move |base, id, meta| {
-						use self::_futures::FutureExt;
+						use self::_futures::{FutureExt, TryFutureExt};
 						self::_jsonrpc_core::WrapFuture::into_future(
 							Self::#unsub_method_ident(base, meta, id)
 						)

--- a/derive/tests/client.rs
+++ b/derive/tests/client.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
-use jsonrpc_core::{IoHandler, Result};
 use jsonrpc_core::futures::{self, FutureExt, TryFutureExt};
+use jsonrpc_core::{IoHandler, Result};
 use jsonrpc_core_client::transports::local;
 use jsonrpc_derive::rpc;
 
@@ -85,9 +85,7 @@ mod named_params {
 				assert_matches!(res, Ok(Ok(x)) if x == expected);
 			});
 		let exec = futures::executor::ThreadPool::builder().pool_size(1).create().unwrap();
-		exec.spawn_ok(async move {
-			futures::join!(fut, rpc_client).1.unwrap()
-		});
+		exec.spawn_ok(async move { futures::join!(fut, rpc_client).1.unwrap() });
 	}
 }
 
@@ -125,8 +123,6 @@ mod raw_params {
 				assert_matches!(res, Ok(Ok(x)) if x == expected);
 			});
 		let exec = futures::executor::ThreadPool::builder().pool_size(1).create().unwrap();
-		exec.spawn_ok(async move {
-			futures::join!(fut, rpc_client).1.unwrap()
-		});
+		exec.spawn_ok(async move { futures::join!(fut, rpc_client).1.unwrap() });
 	}
 }

--- a/derive/tests/client.rs
+++ b/derive/tests/client.rs
@@ -64,6 +64,8 @@ mod named_params {
 
 	#[test]
 	fn client_generates_correct_named_params_payload() {
+		use jsonrpc_core::futures::{FutureExt, TryFutureExt};
+
 		let expected = json!({ // key names are derived from function parameter names in the trait
 			"number": 3,
 			"string": String::from("test string"),
@@ -73,7 +75,7 @@ mod named_params {
 		});
 
 		let mut handler = IoHandler::new();
-		handler.add_method("call_with_named", |params: Params| Ok(params.into()));
+		handler.add_sync_method("call_with_named", |params: Params| Ok(params.into()));
 
 		let (client, rpc_client) = local::connect::<gen_client::Client, _, _>(handler);
 		let fut = client
@@ -115,7 +117,7 @@ mod raw_params {
 		});
 
 		let mut handler = IoHandler::new();
-		handler.add_method("call_raw", |params: Params| Ok(params.into()));
+		handler.add_sync_method("call_raw", |params: Params| Ok(params.into()));
 
 		let (client, rpc_client) = local::connect::<gen_client::Client, _, _>(handler);
 		let fut = client

--- a/derive/tests/client.rs
+++ b/derive/tests/client.rs
@@ -1,5 +1,6 @@
-use futures::prelude::*;
+use assert_matches::assert_matches;
 use jsonrpc_core::{IoHandler, Result};
+use jsonrpc_core::futures::{self, FutureExt, TryFutureExt};
 use jsonrpc_core_client::transports::local;
 use jsonrpc_derive::rpc;
 
@@ -35,16 +36,14 @@ mod client_server {
 		let fut = client
 			.clone()
 			.add(3, 4)
-			.and_then(move |res| client.notify(res).map(move |_| res))
-			.join(rpc_client)
-			.map(|(res, ())| {
-				assert_eq!(res, 7);
-			})
-			.map_err(|err| {
-				eprintln!("{:?}", err);
-				assert!(false);
+			.map_ok(move |res| client.notify(res).map(move |_| res))
+			.map(|res| {
+				assert_matches!(res, Ok(Ok(7)));
 			});
-		tokio::run(fut);
+		let exec = futures::executor::ThreadPool::builder().pool_size(1).create().unwrap();
+		exec.spawn_ok(async move {
+			futures::join!(fut, rpc_client).1.unwrap();
+		});
 	}
 }
 
@@ -81,16 +80,14 @@ mod named_params {
 		let fut = client
 			.clone()
 			.call_with_named(3, String::from("test string"), json!({"key": ["value"]}))
-			.and_then(move |res| client.notify(res.clone()).map(move |_| res))
-			.join(rpc_client)
-			.map(move |(res, ())| {
-				assert_eq!(res, expected);
-			})
-			.map_err(|err| {
-				eprintln!("{:?}", err);
-				assert!(false);
+			.map_ok(move |res| client.notify(res.clone()).map(move |_| res))
+			.map(move |res| {
+				assert_matches!(res, Ok(Ok(x)) if x == expected);
 			});
-		tokio::run(fut);
+		let exec = futures::executor::ThreadPool::builder().pool_size(1).create().unwrap();
+		exec.spawn_ok(async move {
+			futures::join!(fut, rpc_client).1.unwrap()
+		});
 	}
 }
 
@@ -123,15 +120,13 @@ mod raw_params {
 		let fut = client
 			.clone()
 			.call_raw_single_param(expected.clone())
-			.and_then(move |res| client.notify(res.clone()).map(move |_| res))
-			.join(rpc_client)
-			.map(move |(res, ())| {
-				assert_eq!(res, expected);
-			})
-			.map_err(|err| {
-				eprintln!("{:?}", err);
-				assert!(false);
+			.map_ok(move |res| client.notify(res.clone()).map(move |_| res))
+			.map(move |res| {
+				assert_matches!(res, Ok(Ok(x)) if x == expected);
 			});
-		tokio::run(fut);
+		let exec = futures::executor::ThreadPool::builder().pool_size(1).create().unwrap();
+		exec.spawn_ok(async move {
+			futures::join!(fut, rpc_client).1.unwrap()
+		});
 	}
 }

--- a/derive/tests/pubsub-macros.rs
+++ b/derive/tests/pubsub-macros.rs
@@ -4,7 +4,7 @@ use serde_json;
 #[macro_use]
 extern crate jsonrpc_derive;
 
-use jsonrpc_core::futures::sync::mpsc;
+use jsonrpc_core::futures::channel::mpsc;
 use jsonrpc_pubsub::typed::Subscriber;
 use jsonrpc_pubsub::{PubSubHandler, PubSubMetadata, Session, SubscriptionId};
 use std::sync::Arc;

--- a/derive/tests/pubsub-macros.rs
+++ b/derive/tests/pubsub-macros.rs
@@ -75,7 +75,7 @@ struct Metadata;
 impl jsonrpc_core::Metadata for Metadata {}
 impl PubSubMetadata for Metadata {
 	fn session(&self) -> Option<Arc<Session>> {
-		let (tx, _rx) = mpsc::channel(1);
+		let (tx, _rx) = mpsc::unbounded();
 		Some(Arc::new(Session::new(tx)))
 	}
 }

--- a/derive/tests/run-pass/client_only.rs
+++ b/derive/tests/run-pass/client_only.rs
@@ -4,7 +4,7 @@ extern crate jsonrpc_core_client;
 extern crate jsonrpc_derive;
 
 use jsonrpc_core::IoHandler;
-use jsonrpc_core::futures::future::Future;
+use jsonrpc_core::futures::{self, TryFutureExt};
 use jsonrpc_core_client::transports::local;
 
 #[rpc(client)]
@@ -24,9 +24,7 @@ fn main() {
 		let (client, _rpc_client) = local::connect::<gen_client::Client, _, _>(handler);
 		client
 			.add(5, 6)
-			.map(|res| println!("5 + 6 = {}", res))
+			.map_ok(|res| println!("5 + 6 = {}", res))
 	};
-	fut
-		.wait()
-		.ok();
+	let _ = futures::executor::block_on(fut);
 }

--- a/derive/tests/run-pass/client_with_generic_trait_bounds.rs
+++ b/derive/tests/run-pass/client_with_generic_trait_bounds.rs
@@ -1,5 +1,5 @@
-use jsonrpc_core::futures::future::{self, FutureResult};
-use jsonrpc_core::{Error, IoHandler, Result};
+use jsonrpc_core::futures::future;
+use jsonrpc_core::{IoHandler, Result, BoxFuture};
 use jsonrpc_derive::rpc;
 use std::collections::BTreeMap;
 
@@ -15,7 +15,7 @@ where
 
 	/// Performs asynchronous operation
 	#[rpc(name = "beFancy")]
-	fn call(&self, a: One) -> FutureResult<(One, Two), Error>;
+	fn call(&self, a: One) -> BoxFuture<Result<(One, Two)>>;
 }
 
 struct RpcImpl;
@@ -26,8 +26,8 @@ impl Rpc<u64, String> for RpcImpl {
 		Ok(Default::default())
 	}
 
-	fn call(&self, num: u64) -> FutureResult<(u64, String), Error> {
-		crate::future::finished((num + 999, "hello".into()))
+	fn call(&self, num: u64) -> BoxFuture<Result<(u64, String)>> {
+		Box::pin(future::ready(Ok((num + 999, "hello".into()))))
 	}
 }
 

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -8,14 +8,14 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "server"]
 license = "MIT"
 name = "jsonrpc-http-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.2.0"
+version = "15.0.0"
 
 [dependencies]
 futures01 = { version = "0.1", package = "futures" }
 futures03 = { version = "0.3", package = "futures", features = ["compat"] }
 hyper = "0.12"
-jsonrpc-core = { version = "14.2", path = "../core" }
-jsonrpc-server-utils = { version = "14.2", path = "../server-utils" }
+jsonrpc-core = { version = "15.0", path = "../core" }
+jsonrpc-server-utils = { version = "15.0", path = "../server-utils" }
 log = "0.4"
 net2 = "0.2"
 parking_lot = "0.10.0"

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -11,13 +11,15 @@ repository = "https://github.com/paritytech/jsonrpc"
 version = "14.2.0"
 
 [dependencies]
+futures01 = { version = "0.1", package = "futures" }
+futures03 = { version = "0.3", package = "futures", features = ["compat"] }
 hyper = "0.12"
 jsonrpc-core = { version = "14.2", path = "../core" }
 jsonrpc-server-utils = { version = "14.2", path = "../server-utils" }
 log = "0.4"
 net2 = "0.2"
-unicase = "2.0"
 parking_lot = "0.10.0"
+unicase = "2.0"
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/http/README.md
+++ b/http/README.md
@@ -9,7 +9,7 @@ Rust http server using JSON-RPC 2.0.
 
 ```
 [dependencies]
-jsonrpc-http-server = "14.2"
+jsonrpc-http-server = "15.0"
 ```
 
 `main.rs`

--- a/http/examples/http_async.rs
+++ b/http/examples/http_async.rs
@@ -4,7 +4,7 @@ use jsonrpc_http_server::{AccessControlAllowOrigin, DomainsValidation, ServerBui
 fn main() {
 	let mut io = IoHandler::default();
 	io.add_method("say_hello", |_params| {
-		futures::finished(Value::String("hello".to_owned()))
+		futures::future::ready(Ok(Value::String("hello".to_owned())))
 	});
 
 	let server = ServerBuilder::new(io)

--- a/http/examples/http_meta.rs
+++ b/http/examples/http_meta.rs
@@ -13,13 +13,13 @@ fn main() {
 
 	io.add_method_with_meta("say_hello", |_params: Params, meta: Meta| {
 		let auth = meta.auth.unwrap_or_else(String::new);
-		if auth.as_str() == "let-me-in" {
+		futures::future::ready(if auth.as_str() == "let-me-in" {
 			Ok(Value::String("Hello World!".to_owned()))
 		} else {
 			Ok(Value::String(
 				"Please send a valid Bearer token in Authorization header.".to_owned(),
 			))
-		}
+		})
 	});
 
 	let server = ServerBuilder::new(io)

--- a/http/examples/http_middleware.rs
+++ b/http/examples/http_middleware.rs
@@ -5,7 +5,7 @@ use jsonrpc_http_server::{hyper, AccessControlAllowOrigin, DomainsValidation, Re
 fn main() {
 	let mut io = IoHandler::default();
 	io.add_method("say_hello", |_params| {
-		futures::finished(Value::String("hello".to_owned()))
+		futures::future::ready(Ok(Value::String("hello".to_owned())))
 	});
 
 	let server = ServerBuilder::new(io)

--- a/http/examples/server.rs
+++ b/http/examples/server.rs
@@ -5,7 +5,7 @@ fn main() {
 	env_logger::init();
 
 	let mut io = IoHandler::default();
-	io.add_method("say_hello", |_params: Params| Ok(Value::String("hello".to_string())));
+	io.add_sync_method("say_hello", |_params: Params| Ok(Value::String("hello".to_string())));
 
 	let server = ServerBuilder::new(io)
 		.threads(3)

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! fn main() {
 //! 	let mut io = IoHandler::new();
-//! 	io.add_method("say_hello", |_: Params| {
+//! 	io.add_sync_method("say_hello", |_: Params| {
 //! 		Ok(Value::String("hello".to_string()))
 //! 	});
 //!

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -42,10 +42,10 @@ use std::thread;
 
 use parking_lot::Mutex;
 
-use futures01::sync::oneshot;
-use futures01::{future, Future, Stream};
 use crate::jsonrpc::MetaIoHandler;
 use crate::server_utils::reactor::{Executor, UninitializedExecutor};
+use futures01::sync::oneshot;
+use futures01::{future, Future, Stream};
 use hyper::{server, Body};
 use jsonrpc_core as jsonrpc;
 
@@ -247,7 +247,8 @@ pub struct ServerBuilder<M: jsonrpc::Metadata = (), S: jsonrpc::Middleware<M> = 
 	max_request_body_size: usize,
 }
 
-impl<M: jsonrpc::Metadata + Default, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> where
+impl<M: jsonrpc::Metadata + Default, S: jsonrpc::Middleware<M>> ServerBuilder<M, S>
+where
 	S::Future: Unpin,
 	S::CallFuture: Unpin,
 {
@@ -264,7 +265,8 @@ impl<M: jsonrpc::Metadata + Default, S: jsonrpc::Middleware<M>> ServerBuilder<M,
 	}
 }
 
-impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S> where
+impl<M: jsonrpc::Metadata, S: jsonrpc::Middleware<M>> ServerBuilder<M, S>
+where
 	S::Future: Unpin,
 	S::CallFuture: Unpin,
 {

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -7,15 +7,15 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-ipc-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.2.0"
+version = "15.0.0"
 
 [dependencies]
 futures01 = { version = "0.1", package = "futures" }
 futures03 = { version = "0.3", package = "futures", features = [ "compat" ] }
 log = "0.4"
 tokio-service = "0.1"
-jsonrpc-core = { version = "14.2", path = "../core" }
-jsonrpc-server-utils = { version = "14.2", path = "../server-utils" }
+jsonrpc-core = { version = "15.0", path = "../core" }
+jsonrpc-server-utils = { version = "15.0", path = "../server-utils" }
 parity-tokio-ipc = "0.4"
 parking_lot = "0.10.0"
 

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -10,6 +10,8 @@ repository = "https://github.com/paritytech/jsonrpc"
 version = "14.2.0"
 
 [dependencies]
+futures01 = { version = "0.1", package = "futures" }
+futures03 = { version = "0.3", package = "futures", features = [ "compat" ] }
 log = "0.4"
 tokio-service = "0.1"
 jsonrpc-core = { version = "14.2", path = "../core" }

--- a/ipc/README.md
+++ b/ipc/README.md
@@ -9,7 +9,7 @@ IPC server (Windows & Linux) for JSON-RPC 2.0.
 
 ```
 [dependencies]
-jsonrpc-ipc-server = "14.2"
+jsonrpc-ipc-server = "15.0"
 ```
 
 `main.rs`

--- a/ipc/examples/ipc.rs
+++ b/ipc/examples/ipc.rs
@@ -4,7 +4,7 @@ use jsonrpc_ipc_server::jsonrpc_core::*;
 
 fn main() {
 	let mut io = MetaIoHandler::<()>::default();
-	io.add_method("say_hello", |_params| Ok(Value::String("hello".to_string())));
+	io.add_sync_method("say_hello", |_params| Ok(Value::String("hello".to_string())));
 	let _server = jsonrpc_ipc_server::ServerBuilder::new(io)
 		.start("/tmp/parity-example.ipc")
 		.expect("Server should start ok");

--- a/ipc/src/meta.rs
+++ b/ipc/src/meta.rs
@@ -1,4 +1,4 @@
-use crate::jsonrpc::futures::sync::mpsc;
+use crate::jsonrpc::futures::channel::mpsc;
 use crate::jsonrpc::Metadata;
 use crate::server_utils::session;
 
@@ -9,7 +9,7 @@ pub struct RequestContext<'a> {
 	/// Remote UDS endpoint
 	pub endpoint_addr: &'a ::parity_tokio_ipc::RemoteId,
 	/// Direct pipe sender
-	pub sender: mpsc::Sender<String>,
+	pub sender: mpsc::UnboundedSender<String>,
 }
 
 /// Metadata extractor (per session)

--- a/ipc/src/select_with_weak.rs
+++ b/ipc/src/select_with_weak.rs
@@ -1,5 +1,5 @@
-use crate::jsonrpc::futures::stream::{Fuse, Stream};
-use crate::jsonrpc::futures::{Async, Poll};
+use futures01::stream::{Fuse, Stream};
+use futures01::{Async, Poll};
 
 pub trait SelectWithWeakExt: Stream {
 	fn select_with_weak<S>(self, other: S) -> SelectWithWeak<Self, S>

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -8,11 +8,11 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "macros"]
 license = "MIT"
 name = "jsonrpc-pubsub"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.2.0"
+version = "15.0.0"
 
 [dependencies]
 futures = { version = "0.3", features = ["thread-pool"] }
-jsonrpc-core = { version = "14.2", path = "../core" }
+jsonrpc-core = { version = "15.0", path = "../core" }
 lazy_static = "1.4"
 log = "0.4"
 parking_lot = "0.11.0"
@@ -20,7 +20,7 @@ rand = "0.7"
 serde = "1.0"
 
 [dev-dependencies]
-jsonrpc-tcp-server = { version = "14.2", path = "../tcp" }
+jsonrpc-tcp-server = { version = "15.0", path = "../tcp" }
 
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -11,15 +11,16 @@ repository = "https://github.com/paritytech/jsonrpc"
 version = "14.2.0"
 
 [dependencies]
+jsonrpc-core = { version = "14.2", path = "../core" }
+lazy_static = "1.4"
 log = "0.4"
 parking_lot = "0.11.0"
-jsonrpc-core = { version = "14.2", path = "../core" }
-serde = "1.0"
 rand = "0.7"
+serde = "1.0"
 
 [dev-dependencies]
 jsonrpc-tcp-server = { version = "14.2", path = "../tcp" }
-lazy_static = "1.4"
+futures = { version = "0.3", features = ["thread-pool"] }
 
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -12,14 +12,13 @@ version = "14.2.0"
 
 [dependencies]
 log = "0.4"
-parking_lot = "0.10.0"
+parking_lot = "0.11.0"
 jsonrpc-core = { version = "14.2", path = "../core" }
 serde = "1.0"
 rand = "0.7"
 
 [dev-dependencies]
 jsonrpc-tcp-server = { version = "14.2", path = "../tcp" }
-futures = { version = "0.3", features = ["compat", "thread-pool"] }
 lazy_static = "1.4"
 
 [badges]

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/paritytech/jsonrpc"
 version = "14.2.0"
 
 [dependencies]
+futures = { version = "0.3", features = ["thread-pool"] }
 jsonrpc-core = { version = "14.2", path = "../core" }
 lazy_static = "1.4"
 log = "0.4"
@@ -20,7 +21,6 @@ serde = "1.0"
 
 [dev-dependencies]
 jsonrpc-tcp-server = { version = "14.2", path = "../tcp" }
-futures = { version = "0.3", features = ["thread-pool"] }
 
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/pubsub/examples/pubsub.rs
+++ b/pubsub/examples/pubsub.rs
@@ -5,8 +5,6 @@ use jsonrpc_core::*;
 use jsonrpc_pubsub::{PubSubHandler, Session, Subscriber, SubscriptionId};
 use jsonrpc_tcp_server::{RequestContext, ServerBuilder};
 
-use jsonrpc_core::futures::Future;
-
 /// To test the server:
 ///
 /// ```bash
@@ -16,7 +14,7 @@ use jsonrpc_core::futures::Future;
 /// ```
 fn main() {
 	let mut io = PubSubHandler::new(MetaIoHandler::default());
-	io.add_method("say_hello", |_params: Params| Ok(Value::String("hello".to_string())));
+	io.add_sync_method("say_hello", |_params: Params| Ok(Value::String("hello".to_string())));
 
 	let is_done = Arc::new(atomic::AtomicBool::default());
 	let is_done2 = is_done.clone();
@@ -36,7 +34,7 @@ fn main() {
 
 			let is_done = is_done.clone();
 			thread::spawn(move || {
-				let sink = subscriber.assign_id_async(SubscriptionId::Number(5)).wait().unwrap();
+				let sink = subscriber.assign_id(SubscriptionId::Number(5)).unwrap();
 				// or subscriber.reject(Error {} );
 				// or drop(subscriber)
 
@@ -46,7 +44,7 @@ fn main() {
 					}
 
 					thread::sleep(time::Duration::from_millis(100));
-					match sink.notify(Params::Array(vec![Value::Number(10.into())])).wait() {
+					match sink.notify(Params::Array(vec![Value::Number(10.into())])) {
 						Ok(_) => {}
 						Err(_) => {
 							println!("Subscription has ended, finishing.");

--- a/pubsub/examples/pubsub_simple.rs
+++ b/pubsub/examples/pubsub_simple.rs
@@ -5,8 +5,6 @@ use jsonrpc_core::*;
 use jsonrpc_pubsub::{PubSubHandler, Session, Subscriber, SubscriptionId};
 use jsonrpc_tcp_server::{RequestContext, ServerBuilder};
 
-use jsonrpc_core::futures::Future;
-
 /// To test the server:
 ///
 /// ```bash
@@ -18,7 +16,7 @@ use jsonrpc_core::futures::Future;
 /// ```
 fn main() {
 	let mut io = PubSubHandler::new(MetaIoHandler::default());
-	io.add_method("say_hello", |_params: Params| Ok(Value::String("hello".to_string())));
+	io.add_sync_method("say_hello", |_params: Params| Ok(Value::String("hello".to_string())));
 
 	io.add_subscription(
 		"hello",
@@ -35,13 +33,13 @@ fn main() {
 			}
 
 			thread::spawn(move || {
-				let sink = subscriber.assign_id_async(SubscriptionId::Number(5)).wait().unwrap();
+				let sink = subscriber.assign_id(SubscriptionId::Number(5)).unwrap();
 				// or subscriber.reject(Error {} );
 				// or drop(subscriber)
 
 				loop {
 					thread::sleep(time::Duration::from_millis(100));
-					match sink.notify(Params::Array(vec![Value::Number(10.into())])).wait() {
+					match sink.notify(Params::Array(vec![Value::Number(10.into())])) {
 						Ok(_) => {}
 						Err(_) => {
 							println!("Subscription has ended, finishing.");

--- a/pubsub/more-examples/Cargo.toml
+++ b/pubsub/more-examples/Cargo.toml
@@ -3,12 +3,12 @@ name = "jsonrpc-pubsub-examples"
 description = "Examples of Publish-Subscribe extension for jsonrpc."
 homepage = "https://github.com/paritytech/jsonrpc"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.2.0"
+version = "15.0.0"
 authors = ["tomusdrw <tomasz@parity.io>"]
 license = "MIT"
 
 [dependencies]
-jsonrpc-core = { version = "14.2", path = "../../core" }
-jsonrpc-pubsub = { version = "14.2", path = "../" }
-jsonrpc-ws-server = { version = "14.2", path = "../../ws" }
-jsonrpc-ipc-server = { version = "14.2", path = "../../ipc" }
+jsonrpc-core = { version = "15.0", path = "../../core" }
+jsonrpc-pubsub = { version = "15.0", path = "../" }
+jsonrpc-ws-server = { version = "15.0", path = "../../ws" }
+jsonrpc-ipc-server = { version = "15.0", path = "../../ipc" }

--- a/pubsub/more-examples/examples/pubsub_ws.rs
+++ b/pubsub/more-examples/examples/pubsub_ws.rs
@@ -67,10 +67,13 @@ fn main() {
 				}
 			});
 		}),
-		("remove_hello", |_id: SubscriptionId, _meta| -> BoxFuture<Result<Value>> {
-			println!("Closing subscription");
-			Box::pin(futures::future::ready(Ok(Value::Bool(true))))
-		}),
+		(
+			"remove_hello",
+			|_id: SubscriptionId, _meta| -> BoxFuture<Result<Value>> {
+				println!("Closing subscription");
+				Box::pin(futures::future::ready(Ok(Value::Bool(true))))
+			},
+		),
 	);
 
 	let server =

--- a/pubsub/more-examples/examples/pubsub_ws.rs
+++ b/pubsub/more-examples/examples/pubsub_ws.rs
@@ -9,8 +9,6 @@ use jsonrpc_core::*;
 use jsonrpc_pubsub::{PubSubHandler, Session, Subscriber, SubscriptionId};
 use jsonrpc_ws_server::{RequestContext, ServerBuilder};
 
-use jsonrpc_core::futures::Future;
-
 /// Use following node.js code to test:
 ///
 /// ```js
@@ -36,7 +34,7 @@ use jsonrpc_core::futures::Future;
 /// ```
 fn main() {
 	let mut io = PubSubHandler::new(MetaIoHandler::default());
-	io.add_method("say_hello", |_params: Params| Ok(Value::String("hello".to_string())));
+	io.add_sync_method("say_hello", |_params: Params| Ok(Value::String("hello".to_string())));
 
 	io.add_subscription(
 		"hello",
@@ -53,13 +51,13 @@ fn main() {
 			}
 
 			thread::spawn(move || {
-				let sink = subscriber.assign_id_async(SubscriptionId::Number(5)).wait().unwrap();
+				let sink = subscriber.assign_id(SubscriptionId::Number(5)).unwrap();
 				// or subscriber.reject(Error {} );
 				// or drop(subscriber)
 
 				loop {
 					thread::sleep(time::Duration::from_millis(1000));
-					match sink.notify(Params::Array(vec![Value::Number(10.into())])).wait() {
+					match sink.notify(Params::Array(vec![Value::Number(10.into())])) {
 						Ok(_) => {}
 						Err(_) => {
 							println!("Subscription has ended, finishing.");
@@ -69,9 +67,9 @@ fn main() {
 				}
 			});
 		}),
-		("remove_hello", |_id: SubscriptionId, _meta| -> BoxFuture<Value> {
+		("remove_hello", |_id: SubscriptionId, _meta| -> BoxFuture<Result<Value>> {
 			println!("Closing subscription");
-			Box::new(futures::future::ok(Value::Bool(true)))
+			Box::pin(futures::future::ready(Ok(Value::Bool(true))))
 		}),
 	);
 

--- a/pubsub/src/handler.rs
+++ b/pubsub/src/handler.rs
@@ -98,8 +98,8 @@ mod tests {
 	use std::sync::Arc;
 
 	use crate::core;
-	use crate::core::futures::future;
 	use crate::core::futures::channel::mpsc;
+	use crate::core::futures::future;
 	use crate::subscription::{Session, Subscriber};
 	use crate::types::{PubSubMetadata, SubscriptionId};
 

--- a/pubsub/src/handler.rs
+++ b/pubsub/src/handler.rs
@@ -99,7 +99,7 @@ mod tests {
 
 	use crate::core;
 	use crate::core::futures::future;
-	use crate::core::futures::sync::mpsc;
+	use crate::core::futures::channel::mpsc;
 	use crate::subscription::{Session, Subscriber};
 	use crate::types::{PubSubMetadata, SubscriptionId};
 
@@ -135,7 +135,7 @@ mod tests {
 		);
 
 		// when
-		let (tx, _rx) = mpsc::channel(1);
+		let (tx, _rx) = mpsc::unbounded();
 		let meta = Metadata(Arc::new(Session::new(tx)));
 		let req = r#"{"jsonrpc":"2.0","id":1,"method":"subscribe_hello","params":null}"#;
 		let res = handler.handle_request_sync(req, meta);

--- a/pubsub/src/manager.rs
+++ b/pubsub/src/manager.rs
@@ -22,7 +22,7 @@ use std::sync::{
 };
 
 use crate::core::futures::channel::oneshot;
-use crate::core::futures::{self, Future, FutureExt, TryFutureExt, task};
+use crate::core::futures::{self, task, Future, FutureExt, TryFutureExt};
 use crate::{
 	typed::{Sink, Subscriber},
 	SubscriptionId,
@@ -301,9 +301,7 @@ mod tests {
 		let subscriber = Subscriber::<u64>::new_test("test_subTest").0;
 		let stream = stream::iter(vec![Ok(Ok(1))]);
 
-		let id = manager.add(subscriber, move |sink| {
-			stream.forward(sink).map(|_| ())
-		});
+		let id = manager.add(subscriber, move |sink| stream.forward(sink).map(|_| ()));
 
 		assert!(matches!(id, SubscriptionId::String(_)))
 	}
@@ -316,9 +314,7 @@ mod tests {
 		let subscriber = Subscriber::<u64>::new_test("test_subTest").0;
 		let stream = stream::iter(vec![Ok(Ok(1))]);
 
-		let id = manager.add(subscriber, move |sink| {
-			stream.forward(sink).map(|_| ())
-		});
+		let id = manager.add(subscriber, move |sink| stream.forward(sink).map(|_| ()));
 
 		assert!(matches!(id, SubscriptionId::Number(_)))
 	}
@@ -331,9 +327,7 @@ mod tests {
 		let subscriber = Subscriber::<u64>::new_test("test_subTest").0;
 		let stream = stream::iter(vec![Ok(Ok(1))]);
 
-		let id = manager.add(subscriber, move |sink| {
-			stream.forward(sink).map(|_| ())
-		});
+		let id = manager.add(subscriber, move |sink| stream.forward(sink).map(|_| ()));
 
 		assert!(matches!(id, SubscriptionId::String(_)))
 	}

--- a/pubsub/src/oneshot.rs
+++ b/pubsub/src/oneshot.rs
@@ -1,6 +1,6 @@
 //! A futures oneshot channel that can be used for rendezvous.
 
-use crate::core::futures::{self, future, channel::oneshot, Future, FutureExt, TryFutureExt};
+use crate::core::futures::{self, channel::oneshot, future, Future, FutureExt, TryFutureExt};
 use std::ops::{Deref, DerefMut};
 
 /// Create a new future-base rendezvous channel.

--- a/pubsub/src/oneshot.rs
+++ b/pubsub/src/oneshot.rs
@@ -1,12 +1,12 @@
 //! A futures oneshot channel that can be used for rendezvous.
 
-use crate::core::futures::{self, future, sync::oneshot, Future};
+use crate::core::futures::{self, future, channel::oneshot, Future, FutureExt, TryFutureExt};
 use std::ops::{Deref, DerefMut};
 
 /// Create a new future-base rendezvous channel.
 ///
 /// The returned `Sender` and `Receiver` objects are wrapping
-/// the regular `futures::sync::oneshot` counterparts and have the same functionality.
+/// the regular `futures::channel::oneshot` counterparts and have the same functionality.
 /// Additionaly `Sender::send_and_wait` allows you to send a message to the channel
 /// and get a future that resolves when the message is consumed.
 pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
@@ -49,14 +49,14 @@ impl<T> Sender<T> {
 	/// to send the message as that happens synchronously.
 	/// The future resolves to error in case the receiving end was dropped before
 	/// being able to process the message.
-	pub fn send_and_wait(self, t: T) -> impl Future<Item = (), Error = ()> {
+	pub fn send_and_wait(self, t: T) -> impl Future<Output = Result<(), ()>> {
 		let Self { sender, receipt } = self;
 
 		if let Err(_) = sender.send(t) {
-			return future::Either::A(future::err(()));
+			return future::Either::Left(future::ready(Err(())));
 		}
 
-		future::Either::B(receipt.map_err(|_| ()))
+		future::Either::Right(receipt.map_err(|_| ()))
 	}
 }
 
@@ -88,18 +88,13 @@ pub struct Receiver<T> {
 }
 
 impl<T> Future for Receiver<T> {
-	type Item = <oneshot::Receiver<T> as Future>::Item;
-	type Error = <oneshot::Receiver<T> as Future>::Error;
+	type Output = <oneshot::Receiver<T> as Future>::Output;
 
-	fn poll(&mut self) -> futures::Poll<Self::Item, Self::Error> {
-		match self.receiver.poll() {
-			Ok(futures::Async::Ready(r)) => {
-				if let Some(receipt) = self.receipt.take() {
-					let _ = receipt.send(());
-				}
-				Ok(futures::Async::Ready(r))
-			}
-			e => e,
+	fn poll(mut self: std::pin::Pin<&mut Self>, cx: &mut futures::task::Context) -> futures::task::Poll<Self::Output> {
+		let r = futures::ready!(self.receiver.poll_unpin(cx))?;
+		if let Some(receipt) = self.receipt.take() {
+			let _ = receipt.send(());
 		}
+		Ok(r).into()
 	}
 }

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -276,7 +276,7 @@ where
 	F: SubscribeRpcMethod<M>,
 	G: UnsubscribeRpcMethod<M>,
 {
-	fn call(&self, params: core::Params, meta: M) -> BoxFuture<core::Value> {
+	fn call(&self, params: core::Params, meta: M) -> BoxFuture<core::Result<core::Value>> {
 		match meta.session() {
 			Some(session) => {
 				let (tx, rx) = crate::oneshot::channel();
@@ -326,7 +326,7 @@ where
 	M: PubSubMetadata,
 	G: UnsubscribeRpcMethod<M>,
 {
-	fn call(&self, params: core::Params, meta: M) -> BoxFuture<core::Value> {
+	fn call(&self, params: core::Params, meta: M) -> BoxFuture<core::Result<core::Value>> {
 		let id = match params {
 			core::Params::Array(ref vec) if vec.len() == 1 => SubscriptionId::parse_value(&vec[0]),
 			_ => None,

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -3,11 +3,15 @@
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::Arc;
 use std::pin::Pin;
+use std::sync::Arc;
 
 use crate::core::futures::channel::mpsc;
-use crate::core::futures::{self, future, Future, Sink as FuturesSink, task::{Poll, Context}, TryFutureExt};
+use crate::core::futures::{
+	self, future,
+	task::{Context, Poll},
+	Future, Sink as FuturesSink, TryFutureExt,
+};
 use crate::core::{self, BoxFuture};
 
 use crate::handler::{SubscribeRpcMethod, UnsubscribeRpcMethod};
@@ -123,7 +127,7 @@ impl Sink {
 impl FuturesSink<core::Params> for Sink {
 	type Error = TransportError;
 
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+	fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
 		Pin::new(&mut self.transport).poll_ready(cx)
 	}
 
@@ -132,11 +136,11 @@ impl FuturesSink<core::Params> for Sink {
 		Pin::new(&mut self.transport).start_send(val)
 	}
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+	fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
 		Pin::new(&mut self.transport).poll_flush(cx)
 	}
 
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+	fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
 		Pin::new(&mut self.transport).poll_close(cx)
 	}
 }
@@ -201,12 +205,10 @@ impl Subscriber {
 			transport,
 			sender,
 		} = self;
-		sender
-			.send_and_wait(Ok(id))
-			.map_ok(|_| Sink {
-				notification,
-				transport,
-			})
+		sender.send_and_wait(Ok(id)).map_ok(|_| Sink {
+			notification,
+			transport,
+		})
 	}
 
 	/// Rejects this subscription request with given error.
@@ -431,10 +433,7 @@ mod tests {
 
 		let val = rx.try_next().unwrap();
 		// then
-		assert_eq!(
-			val,
-			Some(r#"{"jsonrpc":"2.0","method":"test","params":[10]}"#.into())
-		);
+		assert_eq!(val, Some(r#"{"jsonrpc":"2.0","method":"test","params":[10]}"#.into()));
 	}
 
 	#[test]

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -297,7 +297,7 @@ where
 					futures::future::ready(match result {
 						Ok(id) => {
 							session.add_subscription(&notification, &id, move |id| {
-								// TODO [ToDr] We currently run unsubscribe tasks on a shared thread pool.
+								// TODO [#570] [ToDr] We currently run unsubscribe tasks on a shared thread pool.
 								// In the future we should use some kind of `::spawn` method
 								// that spawns a task on an existing executor or pass the spawner handle here.
 								let f = unsub.call(id, None);

--- a/pubsub/src/typed.rs
+++ b/pubsub/src/typed.rs
@@ -7,8 +7,8 @@ use crate::subscription;
 use crate::types::{SinkResult, SubscriptionId, TransportError};
 use serde;
 
-use crate::core::futures::{self, channel};
 use crate::core::futures::task::{Context, Poll};
+use crate::core::futures::{self, channel};
 use crate::core::{self, Error, Params, Value};
 
 /// New PUB-SUB subscriber.
@@ -118,20 +118,20 @@ impl<T: serde::Serialize, E: serde::Serialize> Sink<T, E> {
 impl<T: serde::Serialize + Unpin, E: serde::Serialize + Unpin> futures::sink::Sink<Result<T, E>> for Sink<T, E> {
 	type Error = TransportError;
 
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+	fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
 		Pin::new(&mut self.sink).poll_ready(cx)
 	}
 
-    fn start_send(mut self: Pin<&mut Self>, item: Result<T, E>) -> Result<(), Self::Error> {
+	fn start_send(mut self: Pin<&mut Self>, item: Result<T, E>) -> Result<(), Self::Error> {
 		let val = self.val_to_params(item);
 		Pin::new(&mut self.sink).start_send(val)
 	}
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+	fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
 		Pin::new(&mut self.sink).poll_flush(cx)
 	}
 
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+	fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
 		Pin::new(&mut self.sink).poll_close(cx)
 	}
 }

--- a/pubsub/src/typed.rs
+++ b/pubsub/src/typed.rs
@@ -1,12 +1,14 @@
 //! PUB-SUB auto-serializing structures.
 
 use std::marker::PhantomData;
+use std::pin::Pin;
 
 use crate::subscription;
 use crate::types::{SinkResult, SubscriptionId, TransportError};
 use serde;
 
-use crate::core::futures::{self, sync, Future, Sink as FuturesSink};
+use crate::core::futures::{self, channel};
+use crate::core::futures::task::{Context, Poll};
 use crate::core::{self, Error, Params, Value};
 
 /// New PUB-SUB subscriber.
@@ -31,7 +33,7 @@ impl<T, E> Subscriber<T, E> {
 	) -> (
 		Self,
 		crate::oneshot::Receiver<Result<SubscriptionId, Error>>,
-		sync::mpsc::Receiver<String>,
+		channel::mpsc::UnboundedReceiver<String>,
 	) {
 		let (subscriber, id, subscription) = subscription::Subscriber::new_test(method);
 		(Subscriber::new(subscriber), id, subscription)
@@ -45,18 +47,18 @@ impl<T, E> Subscriber<T, E> {
 	/// Reject subscription with given error.
 	///
 	/// The returned future will resolve when the response is sent to the client.
-	pub fn reject_async(self, error: Error) -> impl Future<Item = (), Error = ()> {
-		self.subscriber.reject_async(error)
+	pub async fn reject_async(self, error: Error) -> Result<(), ()> {
+		self.subscriber.reject_async(error).await
 	}
 
 	/// Assign id to this subscriber.
 	/// This method consumes `Subscriber` and returns `Sink`
 	/// if the connection is still open or error otherwise.
 	pub fn assign_id(self, id: SubscriptionId) -> Result<Sink<T, E>, ()> {
-		self.subscriber.assign_id(id.clone()).map(|sink| Sink {
+		let sink = self.subscriber.assign_id(id.clone())?;
+		Ok(Sink {
 			id,
 			sink,
-			buffered: None,
 			_data: PhantomData,
 		})
 	}
@@ -64,11 +66,11 @@ impl<T, E> Subscriber<T, E> {
 	/// Assign id to this subscriber.
 	/// This method consumes `Subscriber` and resolves to `Sink`
 	/// if the connection is still open and the id has been sent or to error otherwise.
-	pub fn assign_id_async(self, id: SubscriptionId) -> impl Future<Item = Sink<T, E>, Error = ()> {
-		self.subscriber.assign_id_async(id.clone()).map(|sink| Sink {
+	pub async fn assign_id_async(self, id: SubscriptionId) -> Result<Sink<T, E>, ()> {
+		let sink = self.subscriber.assign_id_async(id.clone()).await?;
+		Ok(Sink {
 			id,
 			sink,
-			buffered: None,
 			_data: PhantomData,
 		})
 	}
@@ -79,7 +81,6 @@ impl<T, E> Subscriber<T, E> {
 pub struct Sink<T, E = Error> {
 	sink: subscription::Sink,
 	id: SubscriptionId,
-	buffered: Option<Params>,
 	_data: PhantomData<(T, E)>,
 }
 
@@ -112,49 +113,25 @@ impl<T: serde::Serialize, E: serde::Serialize> Sink<T, E> {
 			.collect(),
 		)
 	}
-
-	fn poll(&mut self) -> futures::Poll<(), TransportError> {
-		if let Some(item) = self.buffered.take() {
-			let result = self.sink.start_send(item)?;
-			if let futures::AsyncSink::NotReady(item) = result {
-				self.buffered = Some(item);
-			}
-		}
-
-		if self.buffered.is_some() {
-			Ok(futures::Async::NotReady)
-		} else {
-			Ok(futures::Async::Ready(()))
-		}
-	}
 }
 
-impl<T: serde::Serialize, E: serde::Serialize> futures::sink::Sink for Sink<T, E> {
-	type SinkItem = Result<T, E>;
-	type SinkError = TransportError;
+impl<T: serde::Serialize + Unpin, E: serde::Serialize + Unpin> futures::sink::Sink<Result<T, E>> for Sink<T, E> {
+	type Error = TransportError;
 
-	fn start_send(&mut self, item: Self::SinkItem) -> futures::StartSend<Self::SinkItem, Self::SinkError> {
-		// Make sure to always try to process the buffered entry.
-		// Since we're just a proxy to real `Sink` we don't need
-		// to schedule a `Task` wakeup. It will be done downstream.
-		if self.poll()?.is_not_ready() {
-			return Ok(futures::AsyncSink::NotReady(item));
-		}
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		Pin::new(&mut self.sink).poll_ready(cx)
+	}
 
+    fn start_send(mut self: Pin<&mut Self>, item: Result<T, E>) -> Result<(), Self::Error> {
 		let val = self.val_to_params(item);
-		self.buffered = Some(val);
-		self.poll()?;
-
-		Ok(futures::AsyncSink::Ready)
+		Pin::new(&mut self.sink).start_send(val)
 	}
 
-	fn poll_complete(&mut self) -> futures::Poll<(), Self::SinkError> {
-		self.poll()?;
-		self.sink.poll_complete()
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		Pin::new(&mut self.sink).poll_flush(cx)
 	}
 
-	fn close(&mut self) -> futures::Poll<(), Self::SinkError> {
-		self.poll()?;
-		self.sink.close()
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		Pin::new(&mut self.sink).poll_close(cx)
 	}
 }

--- a/pubsub/src/types.rs
+++ b/pubsub/src/types.rs
@@ -1,15 +1,15 @@
 use crate::core;
-use crate::core::futures::sync::mpsc;
+use crate::core::futures::channel::mpsc;
 use std::sync::Arc;
 
 use crate::subscription::Session;
 
 /// Raw transport sink for specific client.
-pub type TransportSender = mpsc::Sender<String>;
+pub type TransportSender = mpsc::UnboundedSender<String>;
 /// Raw transport error.
-pub type TransportError = mpsc::SendError<String>;
+pub type TransportError = mpsc::SendError;
 /// Subscription send result.
-pub type SinkResult = core::futures::sink::Send<TransportSender>;
+pub type SinkResult = Result<(), mpsc::TrySendError<String>>;
 
 /// Metadata extension for pub-sub method handling.
 ///

--- a/server-utils/Cargo.toml
+++ b/server-utils/Cargo.toml
@@ -12,7 +12,7 @@ version = "15.0.0"
 
 [dependencies]
 bytes = "0.4"
-futures = "0.1"
+futures01 = { version = "0.1", package = "futures" }
 globset = "0.4"
 jsonrpc-core = { version = "15.0", path = "../core" }
 lazy_static = "1.1.0"

--- a/server-utils/Cargo.toml
+++ b/server-utils/Cargo.toml
@@ -12,6 +12,7 @@ version = "14.2.0"
 
 [dependencies]
 bytes = "0.4"
+futures = "0.1"
 globset = "0.4"
 jsonrpc-core = { version = "14.2", path = "../core" }
 lazy_static = "1.1.0"

--- a/server-utils/Cargo.toml
+++ b/server-utils/Cargo.toml
@@ -8,13 +8,13 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
 name = "jsonrpc-server-utils"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.2.0"
+version = "15.0.0"
 
 [dependencies]
 bytes = "0.4"
 futures = "0.1"
 globset = "0.4"
-jsonrpc-core = { version = "14.2", path = "../core" }
+jsonrpc-core = { version = "15.0", path = "../core" }
 lazy_static = "1.1.0"
 log = "0.4"
 tokio = { version = "0.1.15" }

--- a/server-utils/src/lib.rs
+++ b/server-utils/src/lib.rs
@@ -8,8 +8,6 @@ extern crate log;
 #[macro_use]
 extern crate lazy_static;
 
-use jsonrpc_core as core;
-
 pub use tokio;
 pub use tokio_codec;
 

--- a/server-utils/src/reactor.rs
+++ b/server-utils/src/reactor.rs
@@ -8,7 +8,7 @@
 use std::io;
 use tokio;
 
-use crate::core::futures::{self, Future};
+use futures::{self, Future};
 
 /// Possibly uninitialized event loop executor.
 #[derive(Debug)]

--- a/server-utils/src/reactor.rs
+++ b/server-utils/src/reactor.rs
@@ -8,7 +8,7 @@
 use std::io;
 use tokio;
 
-use futures::{self, Future};
+use futures01::Future;
 
 /// Possibly uninitialized event loop executor.
 #[derive(Debug)]
@@ -83,7 +83,7 @@ impl Executor {
 #[derive(Debug)]
 pub struct RpcEventLoop {
 	executor: tokio::runtime::TaskExecutor,
-	close: Option<futures::Complete<()>>,
+	close: Option<futures01::Complete<()>>,
 	handle: Option<tokio::runtime::Shutdown>,
 }
 
@@ -101,7 +101,7 @@ impl RpcEventLoop {
 
 	/// Spawns a new named thread with the `EventLoop`.
 	pub fn with_name(name: Option<String>) -> io::Result<Self> {
-		let (stop, stopped) = futures::oneshot();
+		let (stop, stopped) = futures01::oneshot();
 
 		let mut tb = tokio::runtime::Builder::new();
 		tb.core_threads(1);
@@ -112,7 +112,7 @@ impl RpcEventLoop {
 
 		let mut runtime = tb.build()?;
 		let executor = runtime.executor();
-		let terminate = futures::empty().select(stopped).map(|_| ()).map_err(|_| ());
+		let terminate = futures01::empty().select(stopped).map(|_| ()).map_err(|_| ());
 		runtime.spawn(terminate);
 		let handle = runtime.shutdown_on_idle();
 

--- a/stdio/Cargo.toml
+++ b/stdio/Cargo.toml
@@ -7,11 +7,11 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-stdio-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.2.0"
+version = "15.0.0"
 
 [dependencies]
 futures = { version = "0.3", features = [ "compat" ] }
-jsonrpc-core = { version = "14.2", path = "../core" }
+jsonrpc-core = { version = "15.0", path = "../core" }
 log = "0.4"
 tokio = "0.1.7"
 tokio-codec = "0.1.0"

--- a/stdio/Cargo.toml
+++ b/stdio/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/paritytech/jsonrpc"
 version = "14.2.0"
 
 [dependencies]
-futures = "0.1.23"
+futures = { version = "0.3", features = [ "compat" ] }
 jsonrpc-core = { version = "14.2", path = "../core" }
 log = "0.4"
 tokio = "0.1.7"

--- a/stdio/README.md
+++ b/stdio/README.md
@@ -10,7 +10,7 @@ Takes one request per line and outputs each response on a new line.
 
 ```
 [dependencies]
-jsonrpc-stdio-server = "14.2"
+jsonrpc-stdio-server = "15.0"
 ```
 
 `main.rs`

--- a/stdio/examples/stdio.rs
+++ b/stdio/examples/stdio.rs
@@ -3,7 +3,7 @@ use jsonrpc_stdio_server::ServerBuilder;
 
 fn main() {
 	let mut io = IoHandler::default();
-	io.add_method("say_hello", |_params| Ok(Value::String("hello".to_owned())));
+	io.add_sync_method("say_hello", |_params| Ok(Value::String("hello".to_owned())));
 
 	ServerBuilder::new(io).build();
 }

--- a/stdio/src/lib.rs
+++ b/stdio/src/lib.rs
@@ -68,9 +68,10 @@ impl<M: Metadata, T: Middleware<M>> ServerBuilder<M, T> where
 
 	/// Process a request asynchronously
 	fn process(io: &Arc<MetaIoHandler<M, T>>, input: String) -> impl Future<Item = String, Error = ()> + Send {
-		use jsonrpc_core::futures::FutureExt;
+		use jsonrpc_core::futures::{FutureExt, TryFutureExt};
 		let f = io.handle_request(&input, Default::default());
-		futures::compat::Compat::new(f.map(Ok))
+		f.map(Ok)
+			.compat()
 			.map(move |result| match result {
 				Some(res) => res,
 				None => {

--- a/stdio/src/lib.rs
+++ b/stdio/src/lib.rs
@@ -24,7 +24,7 @@ extern crate log;
 
 pub use jsonrpc_core;
 
-use jsonrpc_core::{MetaIoHandler, Middleware, Metadata};
+use jsonrpc_core::{MetaIoHandler, Metadata, Middleware};
 use std::sync::Arc;
 use tokio::prelude::{Future, Stream};
 use tokio_codec::{FramedRead, FramedWrite, LinesCodec};
@@ -34,7 +34,8 @@ pub struct ServerBuilder<M: Metadata = (), T: Middleware<M> = jsonrpc_core::Noop
 	handler: Arc<MetaIoHandler<M, T>>,
 }
 
-impl<M: Metadata, T: Middleware<M>> ServerBuilder<M, T> where
+impl<M: Metadata, T: Middleware<M>> ServerBuilder<M, T>
+where
 	M: Default,
 	T::Future: Unpin,
 	T::CallFuture: Unpin,
@@ -70,14 +71,12 @@ impl<M: Metadata, T: Middleware<M>> ServerBuilder<M, T> where
 	fn process(io: &Arc<MetaIoHandler<M, T>>, input: String) -> impl Future<Item = String, Error = ()> + Send {
 		use jsonrpc_core::futures::{FutureExt, TryFutureExt};
 		let f = io.handle_request(&input, Default::default());
-		f.map(Ok)
-			.compat()
-			.map(move |result| match result {
-				Some(res) => res,
-				None => {
-					info!("JSON RPC request produced no response: {:?}", input);
-					String::from("")
-				}
-			})
+		f.map(Ok).compat().map(move |result| match result {
+			Some(res) => res,
+			None => {
+				info!("JSON RPC request produced no response: {:?}", input);
+				String::from("")
+			}
+		})
 	}
 }

--- a/stdio/src/lib.rs
+++ b/stdio/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! fn main() {
 //! 	let mut io = IoHandler::default();
-//! 	io.add_method("say_hello", |_params| {
+//! 	io.add_sync_method("say_hello", |_params| {
 //! 		Ok(Value::String("hello".to_owned()))
 //! 	});
 //!
@@ -24,22 +24,23 @@ extern crate log;
 
 pub use jsonrpc_core;
 
-use jsonrpc_core::IoHandler;
+use jsonrpc_core::{MetaIoHandler, Middleware, Metadata};
 use std::sync::Arc;
 use tokio::prelude::{Future, Stream};
 use tokio_codec::{FramedRead, FramedWrite, LinesCodec};
 
 /// Stdio server builder
-pub struct ServerBuilder {
-	handler: Arc<IoHandler>,
+pub struct ServerBuilder<M: Metadata = (), T: Middleware<M> = jsonrpc_core::NoopMiddleware> {
+	handler: Arc<MetaIoHandler<M, T>>,
 }
 
-impl ServerBuilder {
+impl<M: Metadata, T: Middleware<M>> ServerBuilder<M, T> where
+	M: Default,
+	T::Future: Unpin,
+	T::CallFuture: Unpin,
+{
 	/// Returns a new server instance
-	pub fn new<T>(handler: T) -> Self
-	where
-		T: Into<IoHandler>,
-	{
+	pub fn new(handler: impl Into<MetaIoHandler<M, T>>) -> Self {
 		ServerBuilder {
 			handler: Arc::new(handler.into()),
 		}
@@ -57,22 +58,25 @@ impl ServerBuilder {
 
 		let handler = self.handler.clone();
 		let future = framed_stdin
-			.and_then(move |line| process(&handler, line).map_err(|_| unreachable!()))
+			.and_then(move |line| Self::process(&handler, line).map_err(|_| unreachable!()))
 			.forward(framed_stdout)
 			.map(|_| ())
 			.map_err(|e| panic!("{:?}", e));
 
 		tokio::run(future);
 	}
-}
 
-/// Process a request asynchronously
-fn process(io: &Arc<IoHandler>, input: String) -> impl Future<Item = String, Error = ()> + Send {
-	io.handle_request(&input).map(move |result| match result {
-		Some(res) => res,
-		None => {
-			info!("JSON RPC request produced no response: {:?}", input);
-			String::from("")
-		}
-	})
+	/// Process a request asynchronously
+	fn process(io: &Arc<MetaIoHandler<M, T>>, input: String) -> impl Future<Item = String, Error = ()> + Send {
+		use jsonrpc_core::futures::FutureExt;
+		let f = io.handle_request(&input, Default::default());
+		futures::compat::Compat::new(f.map(Ok))
+			.map(move |result| match result {
+				Some(res) => res,
+				None => {
+					info!("JSON RPC request produced no response: {:?}", input);
+					String::from("")
+				}
+			})
+	}
 }

--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/paritytech/jsonrpc"
 version = "15.0.0"
 
 [dependencies]
-futures = "0.1"
+futures01 = { version = "0.1", package = "futures" }
+# TODO remove when we no longer need compat (use jsonrpc-core re-export instead)
 futures03 = { version = "0.3", features = ["compat"], package = "futures" }
 jsonrpc-core = { version = "15.0", path = "../core" }
 jsonrpc-server-utils = { version = "15.0", path = "../server-utils" }

--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -7,13 +7,13 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-tcp-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.2.0"
+version = "15.0.0"
 
 [dependencies]
 futures = "0.1"
 futures03 = { version = "0.3", features = ["compat"], package = "futures" }
-jsonrpc-core = { version = "14.2", path = "../core" }
-jsonrpc-server-utils = { version = "14.2", path = "../server-utils" }
+jsonrpc-core = { version = "15.0", path = "../core" }
+jsonrpc-server-utils = { version = "15.0", path = "../server-utils" }
 log = "0.4"
 parking_lot = "0.10.0"
 tokio-service = "0.1"

--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -10,11 +10,13 @@ repository = "https://github.com/paritytech/jsonrpc"
 version = "14.2.0"
 
 [dependencies]
+futures = "0.1"
+futures03 = { version = "0.3", features = ["compat"], package = "futures" }
+jsonrpc-core = { version = "14.2", path = "../core" }
+jsonrpc-server-utils = { version = "14.2", path = "../server-utils" }
 log = "0.4"
 parking_lot = "0.10.0"
 tokio-service = "0.1"
-jsonrpc-core = { version = "14.2", path = "../core" }
-jsonrpc-server-utils = { version = "14.2", path = "../server-utils" }
 
 [dev-dependencies]
 lazy_static = "1.0"

--- a/tcp/README.md
+++ b/tcp/README.md
@@ -9,7 +9,7 @@ TCP server for JSON-RPC 2.0.
 
 ```
 [dependencies]
-jsonrpc-tcp-server = "14.2"
+jsonrpc-tcp-server = "15.0"
 ```
 
 `main.rs`

--- a/tcp/examples/tcp.rs
+++ b/tcp/examples/tcp.rs
@@ -5,7 +5,7 @@ use jsonrpc_tcp_server::ServerBuilder;
 fn main() {
 	env_logger::init();
 	let mut io = IoHandler::default();
-	io.add_method("say_hello", |_params| {
+	io.add_sync_method("say_hello", |_params| {
 		println!("Processing");
 		Ok(Value::String("hello".to_owned()))
 	});

--- a/tcp/src/dispatch.rs
+++ b/tcp/src/dispatch.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use crate::jsonrpc::futures::{self as futures03, channel::mpsc, StreamExt};
-use futures::{Async, Poll, Stream};
+use futures01::{Async, Poll, Stream};
 
 use parking_lot::Mutex;
 

--- a/tcp/src/lib.rs
+++ b/tcp/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! fn main() {
 //! 	let mut io = IoHandler::default();
-//! 	io.add_method("say_hello", |_params| {
+//! 	io.add_sync_method("say_hello", |_params| {
 //! 		Ok(Value::String("hello".to_string()))
 //! 	});
 //! 	let server = ServerBuilder::new(io)

--- a/tcp/src/meta.rs
+++ b/tcp/src/meta.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use crate::jsonrpc::{Metadata, futures::channel::mpsc};
+use crate::jsonrpc::{futures::channel::mpsc, Metadata};
 
 /// Request context
 pub struct RequestContext {

--- a/tcp/src/meta.rs
+++ b/tcp/src/meta.rs
@@ -1,14 +1,13 @@
 use std::net::SocketAddr;
 
-use crate::jsonrpc::futures::sync::mpsc;
-use crate::jsonrpc::Metadata;
+use crate::jsonrpc::{Metadata, futures::channel::mpsc};
 
 /// Request context
 pub struct RequestContext {
 	/// Peer Address
 	pub peer_addr: SocketAddr,
 	/// Peer Sender channel
-	pub sender: mpsc::Sender<String>,
+	pub sender: mpsc::UnboundedSender<String>,
 }
 
 /// Metadata extractor (per session)

--- a/tcp/src/server.rs
+++ b/tcp/src/server.rs
@@ -24,7 +24,8 @@ pub struct ServerBuilder<M: Metadata = (), S: Middleware<M> = middleware::Noop> 
 	outgoing_separator: codecs::Separator,
 }
 
-impl<M: Metadata + Default, S: Middleware<M> + 'static> ServerBuilder<M, S> where
+impl<M: Metadata + Default, S: Middleware<M> + 'static> ServerBuilder<M, S>
+where
 	S::Future: Unpin,
 	S::CallFuture: Unpin,
 {
@@ -37,7 +38,8 @@ impl<M: Metadata + Default, S: Middleware<M> + 'static> ServerBuilder<M, S> wher
 	}
 }
 
-impl<M: Metadata, S: Middleware<M> + 'static> ServerBuilder<M, S> where
+impl<M: Metadata, S: Middleware<M> + 'static> ServerBuilder<M, S>
+where
 	S::Future: Unpin,
 	S::CallFuture: Unpin,
 {

--- a/tcp/src/server.rs
+++ b/tcp/src/server.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use tokio_service::Service as TokioService;
 
-use futures::sync::oneshot;
-use futures::{future, Future, Sink, Stream};
+use futures01::sync::oneshot;
+use futures01::{future, Future, Sink, Stream};
 
 use crate::jsonrpc::{middleware, MetaIoHandler, Metadata, Middleware};
 use crate::server_utils::{codecs, reactor, tokio, tokio_codec::Framed, SuspendableStream};

--- a/tcp/src/service.rs
+++ b/tcp/src/service.rs
@@ -1,8 +1,8 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use crate::jsonrpc::{middleware, MetaIoHandler, Metadata, Middleware};
 use crate::jsonrpc::futures::FutureExt;
+use crate::jsonrpc::{middleware, MetaIoHandler, Metadata, Middleware};
 use futures::Future;
 
 pub struct Service<M: Metadata = (), S: Middleware<M> = middleware::Noop> {
@@ -21,7 +21,8 @@ impl<M: Metadata, S: Middleware<M>> Service<M, S> {
 	}
 }
 
-impl<M: Metadata, S: Middleware<M>> tokio_service::Service for Service<M, S> where
+impl<M: Metadata, S: Middleware<M>> tokio_service::Service for Service<M, S>
+where
 	S::Future: Unpin,
 	S::CallFuture: Unpin,
 {
@@ -39,7 +40,7 @@ impl<M: Metadata, S: Middleware<M>> tokio_service::Service for Service<M, S> whe
 	fn call(&self, req: Self::Request) -> Self::Future {
 		trace!(target: "tcp", "Accepted request from peer {}: {}", &self.peer_addr, req);
 		Box::new(futures03::compat::Compat::new(
-			self.handler.handle_request(&req, self.meta.clone()).map(|v| Ok(v))
+			self.handler.handle_request(&req, self.meta.clone()).map(|v| Ok(v)),
 		))
 	}
 }

--- a/tcp/src/service.rs
+++ b/tcp/src/service.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::jsonrpc::futures::FutureExt;
 use crate::jsonrpc::{middleware, MetaIoHandler, Metadata, Middleware};
-use futures::Future;
+use futures01::Future;
 
 pub struct Service<M: Metadata = (), S: Middleware<M> = middleware::Noop> {
 	handler: Arc<MetaIoHandler<M, S>>,

--- a/tcp/src/service.rs
+++ b/tcp/src/service.rs
@@ -1,9 +1,9 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use tokio_service;
-
-use crate::jsonrpc::{middleware, FutureResult, MetaIoHandler, Metadata, Middleware};
+use crate::jsonrpc::{middleware, MetaIoHandler, Metadata, Middleware};
+use crate::jsonrpc::futures::FutureExt;
+use futures::Future;
 
 pub struct Service<M: Metadata = (), S: Middleware<M> = middleware::Noop> {
 	handler: Arc<MetaIoHandler<M, S>>,
@@ -21,7 +21,10 @@ impl<M: Metadata, S: Middleware<M>> Service<M, S> {
 	}
 }
 
-impl<M: Metadata, S: Middleware<M>> tokio_service::Service for Service<M, S> {
+impl<M: Metadata, S: Middleware<M>> tokio_service::Service for Service<M, S> where
+	S::Future: Unpin,
+	S::CallFuture: Unpin,
+{
 	// These types must match the corresponding protocol types:
 	type Request = String;
 	type Response = Option<String>;
@@ -30,11 +33,13 @@ impl<M: Metadata, S: Middleware<M>> tokio_service::Service for Service<M, S> {
 	type Error = ();
 
 	// The future for computing the response; box it for simplicity.
-	type Future = FutureResult<S::Future, S::CallFuture>;
+	type Future = Box<dyn Future<Item = Option<String>, Error = ()> + Send>;
 
 	// Produce a future for computing a response from a request.
 	fn call(&self, req: Self::Request) -> Self::Future {
 		trace!(target: "tcp", "Accepted request from peer {}: {}", &self.peer_addr, req);
-		self.handler.handle_request(&req, self.meta.clone())
+		Box::new(futures03::compat::Compat::new(
+			self.handler.handle_request(&req, self.meta.clone()).map(|v| Ok(v))
+		))
 	}
 }

--- a/tcp/src/tests.rs
+++ b/tcp/src/tests.rs
@@ -3,8 +3,8 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use crate::jsonrpc::futures::{self, future, Future};
-use crate::jsonrpc::{MetaIoHandler, Metadata, Value};
+use futures::{future, Future};
+use jsonrpc_core::{MetaIoHandler, Metadata, Value};
 
 use crate::server_utils::tokio::{self, io, net::TcpStream, timer::Delay};
 
@@ -16,7 +16,7 @@ use crate::ServerBuilder;
 
 fn casual_server() -> ServerBuilder {
 	let mut io = MetaIoHandler::<()>::default();
-	io.add_method("say_hello", |_params| Ok(Value::String("hello".to_string())));
+	io.add_sync_method("say_hello", |_params| Ok(Value::String("hello".to_string())));
 	ServerBuilder::new(io)
 }
 
@@ -25,7 +25,7 @@ fn doc_test() {
 	crate::logger::init_log();
 
 	let mut io = MetaIoHandler::<()>::default();
-	io.add_method("say_hello", |_params| Ok(Value::String("hello".to_string())));
+	io.add_sync_method("say_hello", |_params| Ok(Value::String("hello".to_string())));
 	let server = ServerBuilder::new(io);
 
 	server
@@ -180,7 +180,7 @@ impl MetaExtractor<SocketMetadata> for PeerMetaExtractor {
 fn meta_server() -> ServerBuilder<SocketMetadata> {
 	let mut io = MetaIoHandler::<SocketMetadata>::default();
 	io.add_method_with_meta("say_hello", |_params, meta: SocketMetadata| {
-		future::ok(Value::String(format!("hello, {}", meta.addr())))
+		jsonrpc_core::futures::future::ready(Ok(Value::String(format!("hello, {}", meta.addr()))))
 	});
 	ServerBuilder::new(io).session_meta_extractor(PeerMetaExtractor)
 }
@@ -223,7 +223,7 @@ fn message() {
 	let addr: SocketAddr = "127.0.0.1:17790".parse().unwrap();
 	let mut io = MetaIoHandler::<SocketMetadata>::default();
 	io.add_method_with_meta("say_hello", |_params, _: SocketMetadata| {
-		future::ok(Value::String("hello".to_owned()))
+		jsonrpc_core::futures::future::ready(Ok(Value::String("hello".to_owned())))
 	});
 	let extractor = PeerListMetaExtractor::default();
 	let peer_list = extractor.peers.clone();

--- a/tcp/src/tests.rs
+++ b/tcp/src/tests.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use futures::{future, Future};
+use futures01::{future, Future};
 use jsonrpc_core::{MetaIoHandler, Metadata, Value};
 
 use crate::server_utils::tokio::{self, io, net::TcpStream, timer::Delay};
@@ -71,7 +71,7 @@ fn disconnect() {
 }
 
 fn dummy_request(addr: &SocketAddr, data: Vec<u8>) -> Vec<u8> {
-	let (ret_tx, ret_rx) = futures::sync::oneshot::channel();
+	let (ret_tx, ret_rx) = futures01::sync::oneshot::channel();
 
 	let stream = TcpStream::connect(addr)
 		.and_then(move |stream| io::write_all(stream, data))

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsonrpc-test"
 description = "Simple test framework for JSON-RPC."
-version = "14.2.0"
+version = "15.0.0"
 authors = ["Tomasz Drwięga <tomasz@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/jsonrpc"
@@ -10,9 +10,9 @@ documentation = "https://docs.rs/jsonrpc-test/"
 edition = "2018"
 
 [dependencies]
-jsonrpc-core = { version = "14.2", path = "../core" }
-jsonrpc-core-client = { version = "14.2", path = "../core-client" }
-jsonrpc-pubsub = { version = "14.2", path = "../pubsub" }
+jsonrpc-core = { version = "15.0", path = "../core" }
+jsonrpc-core-client = { version = "15.0", path = "../core-client" }
+jsonrpc-pubsub = { version = "15.0", path = "../pubsub" }
 log = "0.4"
 serde = "1.0"
 serde_json = "1.0"
@@ -21,5 +21,5 @@ serde_json = "1.0"
 arbitrary_precision = ["jsonrpc-core-client/arbitrary_precision", "serde_json/arbitrary_precision", "jsonrpc-core/arbitrary_precision"]
 
 [dev-dependencies]
-jsonrpc-derive = { version = "14.2", path = "../derive" }
+jsonrpc-derive = { version = "15.0", path = "../derive" }
 

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -30,7 +30,7 @@
 //!   // You can also test RPC created without macros:
 //!   let rpc = {
 //!     let mut io = IoHandler::new();
-//!     io.add_method("rpc_test_method", |_| {
+//!     io.add_sync_method("rpc_test_method", |_| {
 //!         Err(Error::internal_error())
 //!     });
 //!     test::Rpc::from(io)
@@ -147,7 +147,7 @@ mod tests {
 		// given
 		let rpc = {
 			let mut io = rpc::IoHandler::new();
-			io.add_method("test_method", |_| Ok(rpc::Value::Array(vec![5.into(), 10.into()])));
+			io.add_sync_method("test_method", |_| Ok(rpc::Value::Array(vec![5.into(), 10.into()])));
 			Rpc::from(io)
 		};
 
@@ -160,7 +160,7 @@ mod tests {
 		// given
 		let rpc = {
 			let mut io = rpc::IoHandler::new();
-			io.add_method("test_method", |_| Ok(rpc::Value::Array(vec![5.into(), 10.into()])));
+			io.add_sync_method("test_method", |_| Ok(rpc::Value::Array(vec![5.into(), 10.into()])));
 			Rpc::from(io)
 		};
 

--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -7,13 +7,13 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-ws-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "14.2.0"
+version = "15.0.0"
 
 [dependencies]
 futures01 = { version = "0.1", package = "futures" }
 futures03 = { version = "0.3", package = "futures", features = [ "compat" ] }
-jsonrpc-core = { version = "14.2", path = "../core" }
-jsonrpc-server-utils = { version = "14.2", path = "../server-utils" }
+jsonrpc-core = { version = "15.0", path = "../core" }
+jsonrpc-server-utils = { version = "15.0", path = "../server-utils" }
 log = "0.4"
 parking_lot = "0.10.0"
 slab = "0.4"

--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -11,7 +11,7 @@ version = "14.2.0"
 
 [dependencies]
 futures01 = { version = "0.1", package = "futures" }
-futures03 = { version = "0.3", package = "futures" }
+futures03 = { version = "0.3", package = "futures", features = [ "compat" ] }
 jsonrpc-core = { version = "14.2", path = "../core" }
 jsonrpc-server-utils = { version = "14.2", path = "../server-utils" }
 log = "0.4"

--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -10,6 +10,8 @@ repository = "https://github.com/paritytech/jsonrpc"
 version = "14.2.0"
 
 [dependencies]
+futures01 = { version = "0.1", package = "futures" }
+futures03 = { version = "0.3", package = "futures" }
 jsonrpc-core = { version = "14.2", path = "../core" }
 jsonrpc-server-utils = { version = "14.2", path = "../server-utils" }
 log = "0.4"

--- a/ws/README.md
+++ b/ws/README.md
@@ -9,7 +9,7 @@ WebSockets server for JSON-RPC 2.0.
 
 ```
 [dependencies]
-jsonrpc-ws-server = "14.2"
+jsonrpc-ws-server = "15.0"
 ```
 
 `main.rs`

--- a/ws/examples/ws.rs
+++ b/ws/examples/ws.rs
@@ -3,7 +3,7 @@ use jsonrpc_ws_server::ServerBuilder;
 
 fn main() {
 	let mut io = IoHandler::default();
-	io.add_method("say_hello", |_params| {
+	io.add_sync_method("say_hello", |_params| {
 		println!("Processing");
 		Ok(Value::String("hello".to_owned()))
 	});

--- a/ws/src/metadata.rs
+++ b/ws/src/metadata.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 use std::sync::{atomic, Arc};
 
-use crate::core::futures::sync::mpsc;
-use crate::core::{self, futures};
+use crate::core;
+use crate::core::futures::channel::mpsc;
 use crate::server_utils::{session, tokio::runtime::TaskExecutor};
 use crate::ws;
 
@@ -78,10 +78,11 @@ pub struct RequestContext {
 impl RequestContext {
 	/// Get this session as a `Sink` spawning a new future
 	/// in the underlying event loop.
-	pub fn sender(&self) -> mpsc::Sender<String> {
+	pub fn sender(&self) -> mpsc::UnboundedSender<String> {
+		futures03::{FutureExt, TryFutureExt};
 		let out = self.out.clone();
-		let (sender, receiver) = mpsc::channel(1);
-		self.executor.spawn(SenderFuture(out, receiver));
+		let (sender, receiver) = mpsc::unbounded();
+		self.executor.spawn(SenderFuture(out, receiver.map(Ok).compat()));
 		sender
 	}
 }
@@ -121,27 +122,27 @@ impl<M: core::Metadata + Default> MetaExtractor<M> for NoopExtractor {
 	}
 }
 
-struct SenderFuture(Sender, mpsc::Receiver<String>);
-impl futures::Future for SenderFuture {
+struct SenderFuture(Sender, Box<dyn futures01::Stream<Item = String> + Send>);
+impl futures01::Future for SenderFuture {
 	type Item = ();
 	type Error = ();
 
-	fn poll(&mut self) -> futures::Poll<Self::Item, Self::Error> {
-		use self::futures::Stream;
+	fn poll(&mut self) -> futures01::Poll<Self::Item, Self::Error> {
+		use futures01::Stream;
 
 		loop {
 			let item = self.1.poll()?;
 			match item {
-				futures::Async::NotReady => {
-					return Ok(futures::Async::NotReady);
+				futures01::Async::NotReady => {
+					return Ok(futures01::Async::NotReady);
 				}
-				futures::Async::Ready(None) => {
-					return Ok(futures::Async::Ready(()));
+				futures01::Async::Ready(None) => {
+					return Ok(futures01::Async::Ready(()));
 				}
-				futures::Async::Ready(Some(val)) => {
+				futures01::Async::Ready(Some(val)) => {
 					if let Err(e) = self.0.send(val) {
 						warn!("Error sending a subscription update: {:?}", e);
-						return Ok(futures::Async::Ready(()));
+						return Ok(futures01::Async::Ready(()));
 					}
 				}
 			}

--- a/ws/src/server.rs
+++ b/ws/src/server.rs
@@ -58,7 +58,10 @@ impl Server {
 		executor: UninitializedExecutor,
 		max_connections: usize,
 		max_payload_bytes: usize,
-	) -> Result<Server> {
+	) -> Result<Server> where
+		S::Future: Unpin,
+		S::CallFuture: Unpin,
+	{
 		let config = {
 			let mut config = ws::Settings::default();
 			config.max_connections = max_connections;

--- a/ws/src/server.rs
+++ b/ws/src/server.rs
@@ -58,7 +58,8 @@ impl Server {
 		executor: UninitializedExecutor,
 		max_connections: usize,
 		max_payload_bytes: usize,
-	) -> Result<Server> where
+	) -> Result<Server>
+	where
 		S::Future: Unpin,
 		S::CallFuture: Unpin,
 	{

--- a/ws/src/server_builder.rs
+++ b/ws/src/server_builder.rs
@@ -26,7 +26,10 @@ pub struct ServerBuilder<M: core::Metadata, S: core::Middleware<M>> {
 	max_payload_bytes: usize,
 }
 
-impl<M: core::Metadata + Default, S: core::Middleware<M>> ServerBuilder<M, S> {
+impl<M: core::Metadata + Default, S: core::Middleware<M>> ServerBuilder<M, S> where
+	S::Future: Unpin,
+	S::CallFuture: Unpin,
+{
 	/// Creates new `ServerBuilder`
 	pub fn new<T>(handler: T) -> Self
 	where
@@ -36,7 +39,10 @@ impl<M: core::Metadata + Default, S: core::Middleware<M>> ServerBuilder<M, S> {
 	}
 }
 
-impl<M: core::Metadata, S: core::Middleware<M>> ServerBuilder<M, S> {
+impl<M: core::Metadata, S: core::Middleware<M>> ServerBuilder<M, S> where
+	S::Future: Unpin,
+	S::CallFuture: Unpin,
+{
 	/// Creates new `ServerBuilder`
 	pub fn with_meta_extractor<T, E>(handler: T, extractor: E) -> Self
 	where

--- a/ws/src/server_builder.rs
+++ b/ws/src/server_builder.rs
@@ -26,7 +26,8 @@ pub struct ServerBuilder<M: core::Metadata, S: core::Middleware<M>> {
 	max_payload_bytes: usize,
 }
 
-impl<M: core::Metadata + Default, S: core::Middleware<M>> ServerBuilder<M, S> where
+impl<M: core::Metadata + Default, S: core::Middleware<M>> ServerBuilder<M, S>
+where
 	S::Future: Unpin,
 	S::CallFuture: Unpin,
 {
@@ -39,7 +40,8 @@ impl<M: core::Metadata + Default, S: core::Middleware<M>> ServerBuilder<M, S> wh
 	}
 }
 
-impl<M: core::Metadata, S: core::Middleware<M>> ServerBuilder<M, S> where
+impl<M: core::Metadata, S: core::Middleware<M>> ServerBuilder<M, S>
+where
 	S::Future: Unpin,
 	S::CallFuture: Unpin,
 {

--- a/ws/src/session.rs
+++ b/ws/src/session.rs
@@ -205,7 +205,8 @@ impl<M: core::Metadata, S: core::Middleware<M>> Session<M, S> {
 	}
 }
 
-impl<M: core::Metadata, S: core::Middleware<M>> ws::Handler for Session<M, S> where
+impl<M: core::Metadata, S: core::Middleware<M>> ws::Handler for Session<M, S>
+where
 	S::Future: Unpin,
 	S::CallFuture: Unpin,
 {
@@ -267,9 +268,7 @@ impl<M: core::Metadata, S: core::Middleware<M>> ws::Handler for Session<M, S> wh
 		let poll_liveness = LivenessPoll::create(self.task_slab.clone());
 
 		let active_lock = self.active.clone();
-		let response = self
-			.handler
-			.handle_request(req, metadata);
+		let response = self.handler.handle_request(req, metadata);
 
 		use futures03::{FutureExt, TryFutureExt};
 		let response = response.map(Ok).compat();
@@ -335,7 +334,8 @@ impl<M: core::Metadata, S: core::Middleware<M>> Factory<M, S> {
 	}
 }
 
-impl<M: core::Metadata, S: core::Middleware<M>> ws::Factory for Factory<M, S> where
+impl<M: core::Metadata, S: core::Middleware<M>> ws::Factory for Factory<M, S>
+where
 	S::Future: Unpin,
 	S::CallFuture: Unpin,
 {

--- a/ws/src/tests.rs
+++ b/ws/src/tests.rs
@@ -60,7 +60,7 @@ fn request(server: Server, request: &str) -> Response {
 }
 
 fn serve(port: u16) -> (Server, Arc<AtomicUsize>) {
-	use futures03::{FutureExt, channel::oneshot, future};
+	use futures03::{channel::oneshot, future, FutureExt};
 	let pending = Arc::new(AtomicUsize::new(0));
 
 	let counter = pending.clone();


### PR DESCRIPTION
This is the first step towards #485 (also see #422). The PR rewrites `jsonrpc-core` & `jsonrpc-derive` & `jsonrpc-core-client` (but not transports) to be compatible with `futures=0.3`.

`jsonrpc-derive` is limited to return either `Result<_>` or `BoxFuture<Result<_>>` (see `WrapFuture` trait), supporting custom future types would require a bit more work. Actually it would be best to check out if we can integrate it with `async_trait`, so that the implementations can simply define `async` functions.

The transports (servers) currently run the futures in `compat` mode, they should be updated as well.