### PR TITLE
 Add missing user specified trait bounds in [rpc] macro

### DIFF
--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -7,7 +7,7 @@ use syn::{
 	parse_quote,
 	punctuated::Punctuated,
 	visit::{self, Visit},
-	Result, Token, WherePredicate,
+	Result, Token,
 };
 
 pub enum MethodRegistration {
@@ -489,7 +489,7 @@ pub fn generate_where_clause_serialization_predicates(
 			// add the trait bounds specified by the user in where clause.
 			if let Some(ref where_clause) = additional_where_clause {
 				for predicate in where_clause.predicates.iter() {
-					if let WherePredicate::Type(where_ty) = predicate {
+					if let syn::WherePredicate::Type(where_ty) = predicate {
 						if let syn::Type::Path(ref predicate) = where_ty.bounded_ty {
 							if *predicate == ty_path {
 								bounds.extend(where_ty.bounds.clone().into_iter());

--- a/derive/tests/run-pass/client_with_generic_trait_bounds.rs
+++ b/derive/tests/run-pass/client_with_generic_trait_bounds.rs
@@ -1,0 +1,39 @@
+use jsonrpc_core::futures::future::{self, FutureResult};
+use jsonrpc_core::{Error, IoHandler, Result};
+use jsonrpc_derive::rpc;
+use std::collections::BTreeMap;
+
+#[rpc]
+pub trait Rpc<One, Two>
+where
+	One: Ord,
+	Two: Ord + Eq,
+{
+	/// Adds two numbers and returns a result
+	#[rpc(name = "setTwo")]
+	fn set_two(&self, a: Two) -> Result<BTreeMap<One, ()>>;
+
+	/// Performs asynchronous operation
+	#[rpc(name = "beFancy")]
+	fn call(&self, a: One) -> FutureResult<(One, Two), Error>;
+}
+
+struct RpcImpl;
+
+impl Rpc<u64, String> for RpcImpl {
+	fn set_two(&self, x: String) -> Result<BTreeMap<u64, ()>> {
+		println!("{}", x);
+		Ok(Default::default())
+	}
+
+	fn call(&self, num: u64) -> FutureResult<(u64, String), Error> {
+		crate::future::finished((num + 999, "hello".into()))
+	}
+}
+
+fn main() {
+	let mut io = IoHandler::new();
+	let rpc = RpcImpl;
+
+	io.extend_with(rpc.to_delegate())
+}


### PR DESCRIPTION
Fix #567