### PR TITLE
Resolve possible trait import conflict.

### DIFF
--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -52,7 +52,7 @@ pub fn generate_client_module(
 				Call, Error, ErrorCode, Id, MethodCall, Params, Request,
 				Response, Version,
 			};
-			use _jsonrpc_core::futures::prelude::*;
+			use _jsonrpc_core::futures::prelude::Future;
 			use _jsonrpc_core::futures::sync::{mpsc, oneshot};
 			use _jsonrpc_core::serde_json::{self, Value};
 			use _jsonrpc_core_client::{RpcChannel, RpcError, RpcFuture, TypedClient, TypedSubscriptionStream};


### PR DESCRIPTION
Since we do two glob imports, if there is `Future` trait imported (from `futures03`) in the upper scope the client generation breaks.