### PR TITLE
Fix publishing script.

### DIFF
--- a/_automate/publish.sh
+++ b/_automate/publish.sh
@@ -66,6 +66,8 @@ for CRATE_DIR in ${ORDER[@]}; do
 			if [ "$CHOICE" = "s" ]; then
 				break
 			fi
+		else
+			break
 		fi
 	done
 


### PR DESCRIPTION
We kept retrying `cargo publish` even on success, so the only way to go to the next crate was to actually have it failed and then `s` to skip re-trying.