### PR TITLE
Alter headers

### DIFF
--- a/http/src/handler.rs
+++ b/http/src/handler.rs
@@ -544,6 +544,7 @@ where
 		if is_options {
 			headers.append(header::ALLOW, allowed.clone());
 			headers.append(header::ACCEPT, HeaderValue::from_static("application/json"));
+			headers.append(header::ACCEPT, HeaderValue::from_static("text/json"));
 		}
 
 		if let Some(cors_allow_origin) = cors_allow_origin {
@@ -577,7 +578,10 @@ where
 			Some(ref content)
 				if content.eq_ignore_ascii_case("application/json")
 					|| content.eq_ignore_ascii_case("application/json; charset=utf-8")
-					|| content.eq_ignore_ascii_case("application/json;charset=utf-8") =>
+					|| content.eq_ignore_ascii_case("application/json;charset=utf-8")
+					|| content.eq_ignore_ascii_case("text/json")
+					|| content.eq_ignore_ascii_case("text/json; charset=utf-8")
+					|| content.eq_ignore_ascii_case("text/json;charset=utf-8") =>
 			{
 				true
 			}


### PR DESCRIPTION
This PR alters headers `ACCEPT` and content type for `text/json`.

The ideal solution is to provide a method to change it via lib API but as a workaround - this will help https://github.com/adoriasoft/polkadot_cosmos_integration.