### PR TITLE
core: Allow for using only futures-util dependency

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,7 @@ categories = [
 
 [dependencies]
 log = "0.4"
-futures = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 futures-executor = { version = "0.3", optional = true }
 serde = "1.0"
 serde_json = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,12 +20,14 @@ categories = [
 
 [dependencies]
 log = "0.4"
-futures = "0.3"
+futures = { version = "0.3", default-features = false, features = ["std"] }
+futures-executor = { version = "0.3", optional = true }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 
 [features]
+default = ["futures-executor"]
 arbitrary_precision = ["serde_json/arbitrary_precision"]
 
 [badges]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,10 @@ categories = [
 
 [dependencies]
 log = "0.4"
+# FIXME: Currently a lot of jsonrpc-* crates depend on entire `futures` being
+# re-exported but it's not strictly required for this crate. Either adapt the
+# remaining crates or settle for this re-export to be a single, common dependency
+futures = { version = "0.3", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 futures-executor = { version = "0.3", optional = true }
 serde = "1.0"
@@ -27,7 +31,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 
 [features]
-default = ["futures-executor"]
+default = ["futures-executor", "futures"]
 arbitrary_precision = ["serde_json/arbitrary_precision"]
 
 [badges]

--- a/core/examples/async.rs
+++ b/core/examples/async.rs
@@ -1,7 +1,7 @@
 use jsonrpc_core::*;
 
 fn main() {
-	futures::executor::block_on(async {
+	futures_executor::block_on(async {
 		let mut io = IoHandler::new();
 
 		io.add_method("say_hello", |_: Params| async {

--- a/core/examples/middlewares.rs
+++ b/core/examples/middlewares.rs
@@ -1,4 +1,4 @@
-use jsonrpc_core::futures::{future::Either, FutureExt};
+use jsonrpc_core::futures_util::{future::Either, FutureExt};
 use jsonrpc_core::*;
 use std::future::Future;
 use std::sync::atomic::{self, AtomicUsize};

--- a/core/examples/middlewares.rs
+++ b/core/examples/middlewares.rs
@@ -1,6 +1,6 @@
-use jsonrpc_core::futures::future::Either;
-use jsonrpc_core::futures::{Future, FutureExt};
+use jsonrpc_core::futures::{future::Either, FutureExt};
 use jsonrpc_core::*;
+use std::future::Future;
 use std::sync::atomic::{self, AtomicUsize};
 use std::time::Instant;
 

--- a/core/src/calls.rs
+++ b/core/src/calls.rs
@@ -1,7 +1,7 @@
 use crate::types::{Error, Params, Value};
 use crate::BoxFuture;
-use futures::Future;
 use std::fmt;
+use std::future::Future;
 use std::sync::Arc;
 
 /// Metadata trait
@@ -19,7 +19,7 @@ pub trait WrapFuture<T, E> {
 
 impl<T: Send + 'static, E: Send + 'static> WrapFuture<T, E> for Result<T, E> {
 	fn into_future(self) -> BoxFuture<Result<T, E>> {
-		Box::pin(futures::future::ready(self))
+		Box::pin(async { self })
 	}
 }
 

--- a/core/src/delegates.rs
+++ b/core/src/delegates.rs
@@ -1,12 +1,12 @@
 //! Delegate rpc calls
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 
 use crate::calls::{Metadata, RemoteProcedure, RpcMethod, RpcNotification};
 use crate::types::{Error, Params, Value};
 use crate::BoxFuture;
-use futures::Future;
 
 struct DelegateAsyncMethod<T, F> {
 	delegate: Arc<T>,

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -2,11 +2,12 @@ use std::collections::{
 	hash_map::{IntoIter, Iter},
 	HashMap,
 };
+use std::future::Future;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::sync::Arc;
 
-use futures::{self, future, Future, FutureExt};
+use futures::{self, future, FutureExt};
 use serde_json;
 
 use crate::calls::{
@@ -485,7 +486,6 @@ fn write_response(response: Response) -> String {
 mod tests {
 	use super::{Compatibility, IoHandler};
 	use crate::types::Value;
-	use futures::future;
 
 	#[test]
 	fn test_io_handler() {
@@ -515,7 +515,7 @@ mod tests {
 	fn test_async_io_handler() {
 		let mut io = IoHandler::new();
 
-		io.add_method("say_hello", |_| future::ready(Ok(Value::String("hello".to_string()))));
+		io.add_method("say_hello", |_| async { Ok(Value::String("hello".to_string())) });
 
 		let request = r#"{"jsonrpc": "2.0", "method": "say_hello", "params": [42, 23], "id": 1}"#;
 		let response = r#"{"jsonrpc":"2.0","result":"hello","id":1}"#;

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -198,8 +198,9 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 	/// Handle given request synchronously - will block until response is available.
 	/// If you have any asynchronous methods in your RPC it is much wiser to use
 	/// `handle_request` instead and deal with asynchronous requests in a non-blocking fashion.
+	#[cfg(feature = "futures-executor")]
 	pub fn handle_request_sync(&self, request: &str, meta: T) -> Option<String> {
-		futures::executor::block_on(self.handle_request(request, meta))
+		futures_executor::block_on(self.handle_request(request, meta))
 	}
 
 	/// Handle given request asynchronously.
@@ -442,6 +443,7 @@ impl<M: Metadata + Default> IoHandler<M> {
 	/// Handle given request synchronously - will block until response is available.
 	/// If you have any asynchronous methods in your RPC it is much wiser to use
 	/// `handle_request` instead and deal with asynchronous requests in a non-blocking fashion.
+	#[cfg(feature = "futures-executor")]
 	pub fn handle_request_sync(&self, request: &str) -> Option<String> {
 		self.0.handle_request_sync(request, M::default())
 	}

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -7,7 +7,7 @@ use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::sync::Arc;
 
-use futures::{self, future, FutureExt};
+use futures_util::{self, future, FutureExt};
 use serde_json;
 
 use crate::calls::{

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -29,7 +29,7 @@ extern crate serde_derive;
 
 #[cfg(feature = "futures-executor")]
 pub use futures_executor;
-pub use futures;
+pub use futures_util;
 
 #[doc(hidden)]
 pub extern crate serde;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -27,6 +27,8 @@ extern crate log;
 #[macro_use]
 extern crate serde_derive;
 
+#[cfg(feature = "futures")]
+pub use futures;
 #[cfg(feature = "futures-executor")]
 pub use futures_executor;
 pub use futures_util;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -45,7 +45,7 @@ pub mod types;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// A `Future` trait object.
-pub type BoxFuture<T> = Pin<Box<dyn futures::Future<Output = T> + Send>>;
+pub type BoxFuture<T> = Pin<Box<dyn std::future::Future<Output = T> + Send>>;
 
 pub use crate::calls::{
 	Metadata, RemoteProcedure, RpcMethod, RpcMethodSimple, RpcMethodSync, RpcNotification, RpcNotificationSimple,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -27,6 +27,8 @@ extern crate log;
 #[macro_use]
 extern crate serde_derive;
 
+#[cfg(feature = "futures-executor")]
+pub use futures_executor;
 pub use futures;
 
 #[doc(hidden)]

--- a/core/src/middleware.rs
+++ b/core/src/middleware.rs
@@ -2,7 +2,8 @@
 
 use crate::calls::Metadata;
 use crate::types::{Call, Output, Request, Response};
-use futures::{future::Either, Future};
+use futures::future::Either;
+use std::future::Future;
 use std::pin::Pin;
 
 /// RPC middleware

--- a/core/src/middleware.rs
+++ b/core/src/middleware.rs
@@ -2,7 +2,7 @@
 
 use crate::calls::Metadata;
 use crate::types::{Call, Output, Request, Response};
-use futures::future::Either;
+use futures_util::future::Either;
 use std::future::Future;
 use std::pin::Pin;
 


### PR DESCRIPTION
Fixes #604

This makes `cargo build --no-default-features` work by pulling only `futures-util` (and transitively `futures-task`). It's worth noting that:
1. the convenience `handle_request_sync` function is only available when using `futures-executor` feature,
2. ...and so `cargo test` only works with default feature set (no idea how to cleanly enable the crate features for unit tests).