### PR TITLE
Added support for output with both result and error in it

### DIFF
--- a/core/src/types/mod.rs
+++ b/core/src/types/mod.rs
@@ -15,5 +15,5 @@ pub use self::error::{Error, ErrorCode};
 pub use self::id::Id;
 pub use self::params::Params;
 pub use self::request::{Call, MethodCall, Notification, Request};
-pub use self::response::{Failure, Output, Response, Success};
+pub use self::response::{Failure, Output, OutputVersionOne, Response, Success};
 pub use self::version::Version;


### PR DESCRIPTION
Partially closes #616, allowing clients to receive responses with both `result` and `error`