### PR TITLE
Return error when unsubscribing from invalid subscription id

### DIFF
--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -21,6 +21,7 @@ serde = "1.0"
 
 [dev-dependencies]
 jsonrpc-tcp-server = { version = "17.0", path = "../tcp" }
+serde_json = "1.0"
 
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}


### PR DESCRIPTION
#### Problem
When processing an unsubscribe request, the unsubscribe callback is called even if there was no active subscription for that id.

#### Changes
- Return an error for invalid unsubscribe requests
- Don't call unsubscribe callback for invalid unsubscribes

cc @tomusdrw 