### PR TITLE
Fix link to documentation

### DIFF
--- a/core-client/src/lib.rs
+++ b/core-client/src/lib.rs
@@ -3,7 +3,7 @@
 //! By default this crate does not implement any transports,
 //! use corresponding features (`tls`, `http` or `ws`) to opt-in for them.
 //!
-//! See documentation of [`jsonrpc-client-transports`](../jsonrpc_client_transports/) for more details.
+//! See documentation of [`jsonrpc-client-transports`](https://docs.rs/jsonrpc-client-transports) for more details.
 
 #![deny(missing_docs)]
 


### PR DESCRIPTION
The link to `jsonrpc-client-transports` documentation in [jsonrpc-core-client documentation](https://docs.rs/jsonrpc-core-client/17.0.0/jsonrpc_core_client/) currently points [unexist crate](https://docs.rs/jsonrpc-core-client/17.0.0/jsonrpc_client_transports/).