### PR TITLE
Bump minor version.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,13 +56,6 @@ test-linux-stable:
   <<:                              *only
   <<:                              *test_and_build
 
-test-windows-stable:
-  stage:                           test
-  <<:                              *test_and_build
-  <<:                              *only
-  tags:
-    - rust-windows
-
 test-mac-stable:
   stage:                           test
   <<:                              *test_and_build

--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
 name = "jsonrpc-core-client"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.0.0"
+version = "17.1.0"
 
 categories = [
 	"asynchronous",
@@ -26,7 +26,7 @@ ipc = ["jsonrpc-client-transports/ipc"]
 arbitrary_precision = ["jsonrpc-client-transports/arbitrary_precision"]
 
 [dependencies]
-jsonrpc-client-transports = { version = "17.0", path = "./transports", default-features = false }
+jsonrpc-client-transports = { version = "17.1", path = "./transports", default-features = false }
 futures = { version = "0.3", features = [ "compat" ] }
 
 [badges]

--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
 name = "jsonrpc-client-transports"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.0.0"
+version = "17.1.0"
 
 categories = [
 	"asynchronous",
@@ -37,8 +37,8 @@ arbitrary_precision = ["serde_json/arbitrary_precision", "jsonrpc-core/arbitrary
 [dependencies]
 derive_more = "0.99"
 futures = "0.3"
-jsonrpc-core = { version = "17.0", path = "../../core" }
-jsonrpc-pubsub = { version = "17.0", path = "../../pubsub" }
+jsonrpc-core = { version = "17.1", path = "../../core" }
+jsonrpc-pubsub = { version = "17.1", path = "../../pubsub" }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -46,15 +46,15 @@ url = "1.7"
 
 hyper = { version = "0.13", optional = true }
 hyper-tls = { version = "0.4", optional = true }
-jsonrpc-server-utils = { version = "17.0", path = "../../server-utils", optional = true }
+jsonrpc-server-utils = { version = "17.1", path = "../../server-utils", optional = true }
 parity-tokio-ipc = { version = "0.8", optional = true }
 tokio = { version = "0.2", optional = true }
 websocket = { version = "0.24", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.1"
-jsonrpc-http-server = { version = "17.0", path = "../../http" }
-jsonrpc-ipc-server = { version = "17.0", path = "../../ipc" }
+jsonrpc-http-server = { version = "17.1", path = "../../http" }
+jsonrpc-ipc-server = { version = "17.1", path = "../../ipc" }
 lazy_static = "1.0"
 env_logger = "0.7"
 

--- a/core-client/transports/src/transports/http.rs
+++ b/core-client/transports/src/transports/http.rs
@@ -273,7 +273,7 @@ mod tests {
 
 			if let Err(RpcError::Other(err)) = res {
 				if let Some(err) = err.downcast_ref::<hyper::Error>() {
-					assert!(err.is_connect(), format!("Expected Connection Error, got {:?}", err))
+					assert!(err.is_connect(), "Expected Connection Error, got {:?}", err)
 				} else {
 					panic!("Expected a hyper::Error")
 				}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
 name = "jsonrpc-core"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.0.0"
+version = "17.1.0"
 
 categories = [
 	"asynchronous",

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-derive"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.0.0"
+version = "17.1.0"
 
 [lib]
 proc-macro = true
@@ -20,10 +20,10 @@ proc-macro-crate = "0.1.4"
 
 [dev-dependencies]
 assert_matches = "1.3"
-jsonrpc-core = { version = "17.0", path = "../core" }
-jsonrpc-core-client = { version = "17.0", path = "../core-client" }
-jsonrpc-pubsub = { version = "17.0", path = "../pubsub" }
-jsonrpc-tcp-server = { version = "17.0", path = "../tcp" }
+jsonrpc-core = { version = "17.1", path = "../core" }
+jsonrpc-core-client = { version = "17.1", path = "../core-client" }
+jsonrpc-pubsub = { version = "17.1", path = "../pubsub" }
+jsonrpc-tcp-server = { version = "17.1", path = "../tcp" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 trybuild = "1.0"

--- a/derive/tests/ui/attr-invalid-meta-list-names.stderr
+++ b/derive/tests/ui/attr-invalid-meta-list-names.stderr
@@ -1,8 +1,7 @@
 error: Invalid attribute parameter(s): 'Xalias'. Expected 'alias'
  --> $DIR/attr-invalid-meta-list-names.rs:5:2
   |
-5 |       /// Returns a protocol version
-  |  _____^
+5 | /     /// Returns a protocol version
 6 | |     #[rpc(name = "protocolVersion", Xalias("alias"))]
 7 | |     fn protocol_version(&self) -> Result<String>;
   | |_________________________________________________^

--- a/derive/tests/ui/attr-invalid-meta-words.stderr
+++ b/derive/tests/ui/attr-invalid-meta-words.stderr
@@ -1,8 +1,7 @@
 error: Invalid attribute parameter(s): 'Xmeta'. Expected 'meta, raw_params'
  --> $DIR/attr-invalid-meta-words.rs:5:2
   |
-5 |       /// Returns a protocol version
-  |  _____^
+5 | /     /// Returns a protocol version
 6 | |     #[rpc(name = "protocolVersion", Xmeta)]
 7 | |     fn protocol_version(&self) -> Result<String>;
   | |_________________________________________________^

--- a/derive/tests/ui/attr-invalid-name-values.stderr
+++ b/derive/tests/ui/attr-invalid-name-values.stderr
@@ -1,8 +1,7 @@
 error: Invalid attribute parameter(s): 'Xname'. Expected 'name, returns, params'
  --> $DIR/attr-invalid-name-values.rs:5:2
   |
-5 |       /// Returns a protocol version
-  |  _____^
+5 | /     /// Returns a protocol version
 6 | |     #[rpc(Xname = "protocolVersion")]
 7 | |     fn protocol_version(&self) -> Result<String>;
   | |_________________________________________________^

--- a/derive/tests/ui/attr-missing-rpc-name.stderr
+++ b/derive/tests/ui/attr-missing-rpc-name.stderr
@@ -1,8 +1,7 @@
 error: rpc attribute should have a name e.g. `name = "method_name"`
  --> $DIR/attr-missing-rpc-name.rs:5:2
   |
-5 |       /// Returns a protocol version
-  |  _____^
+5 | /     /// Returns a protocol version
 6 | |     #[rpc]
 7 | |     fn protocol_version(&self) -> Result<String>;
   | |_________________________________________________^

--- a/derive/tests/ui/multiple-rpc-attributes.stderr
+++ b/derive/tests/ui/multiple-rpc-attributes.stderr
@@ -1,8 +1,7 @@
 error: Expected only a single rpc attribute per method
  --> $DIR/multiple-rpc-attributes.rs:5:2
   |
-5 |       /// Returns a protocol version
-  |  _____^
+5 | /     /// Returns a protocol version
 6 | |     #[rpc(name = "protocolVersion")]
 7 | |     #[rpc(name = "protocolVersionAgain")]
 8 | |     fn protocol_version(&self) -> Result<String>;

--- a/derive/tests/ui/too-many-params.stderr
+++ b/derive/tests/ui/too-many-params.stderr
@@ -1,8 +1,7 @@
 error: Maximum supported number of params is 16
   --> $DIR/too-many-params.rs:5:2
    |
-5  |       /// Has too many params
-   |  _____^
+5  | /     /// Has too many params
 6  | |     #[rpc(name = "tooManyParams")]
 7  | |     fn to_many_params(
 8  | |         &self,

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -8,13 +8,13 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "server"]
 license = "MIT"
 name = "jsonrpc-http-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.0.0"
+version = "17.1.0"
 
 [dependencies]
 futures = "0.3"
 hyper = "0.13"
-jsonrpc-core = { version = "17.0", path = "../core" }
-jsonrpc-server-utils = { version = "17.0", path = "../server-utils" }
+jsonrpc-core = { version = "17.1", path = "../core" }
+jsonrpc-server-utils = { version = "17.1", path = "../server-utils" }
 log = "0.4"
 net2 = "0.2"
 parking_lot = "0.11.0"

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -7,14 +7,14 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-ipc-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.0.1"
+version = "17.1.0"
 
 [dependencies]
 futures = "0.3"
 log = "0.4"
 tower-service = "0.3"
-jsonrpc-core = { version = "17.0", path = "../core" }
-jsonrpc-server-utils = { version = "17.0", path = "../server-utils", default-features = false }
+jsonrpc-core = { version = "17.1", path = "../core" }
+jsonrpc-server-utils = { version = "17.1", path = "../server-utils", default-features = false }
 parity-tokio-ipc = "0.8"
 parking_lot = "0.11.0"
 

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -8,11 +8,11 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "macros"]
 license = "MIT"
 name = "jsonrpc-pubsub"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.0.0"
+version = "17.1.0"
 
 [dependencies]
 futures = { version = "0.3", features = ["thread-pool"] }
-jsonrpc-core = { version = "17.0", path = "../core" }
+jsonrpc-core = { version = "17.1", path = "../core" }
 lazy_static = "1.4"
 log = "0.4"
 parking_lot = "0.11.0"
@@ -20,7 +20,7 @@ rand = "0.7"
 serde = "1.0"
 
 [dev-dependencies]
-jsonrpc-tcp-server = { version = "17.0", path = "../tcp" }
+jsonrpc-tcp-server = { version = "17.1", path = "../tcp" }
 serde_json = "1.0"
 
 [badges]

--- a/pubsub/more-examples/Cargo.toml
+++ b/pubsub/more-examples/Cargo.toml
@@ -3,12 +3,12 @@ name = "jsonrpc-pubsub-examples"
 description = "Examples of Publish-Subscribe extension for jsonrpc."
 homepage = "https://github.com/paritytech/jsonrpc"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.0.0"
+version = "17.1.0"
 authors = ["tomusdrw <tomasz@parity.io>"]
 license = "MIT"
 
 [dependencies]
-jsonrpc-core = { version = "17.0", path = "../../core" }
-jsonrpc-pubsub = { version = "17.0", path = "../" }
-jsonrpc-ws-server = { version = "17.0", path = "../../ws" }
-jsonrpc-ipc-server = { version = "17.0", path = "../../ipc" }
+jsonrpc-core = { version = "17.1", path = "../../core" }
+jsonrpc-pubsub = { version = "17.1", path = "../" }
+jsonrpc-ws-server = { version = "17.1", path = "../../ws" }
+jsonrpc-ipc-server = { version = "17.1", path = "../../ipc" }

--- a/server-utils/Cargo.toml
+++ b/server-utils/Cargo.toml
@@ -8,13 +8,13 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
 name = "jsonrpc-server-utils"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.0.0"
+version = "17.1.0"
 
 [dependencies]
 bytes = "0.5"
 futures = "0.3"
 globset = "0.4"
-jsonrpc-core = { version = "17.0", path = "../core" }
+jsonrpc-core = { version = "17.1", path = "../core" }
 lazy_static = "1.1.0"
 log = "0.4"
 tokio = { version = "0.2", features = ["rt-threaded", "io-driver", "io-util", "time", "tcp"] }

--- a/stdio/Cargo.toml
+++ b/stdio/Cargo.toml
@@ -7,11 +7,11 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-stdio-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.0.0"
+version = "17.1.0"
 
 [dependencies]
 futures = "0.3"
-jsonrpc-core = { version = "17.0", path = "../core" }
+jsonrpc-core = { version = "17.1", path = "../core" }
 log = "0.4"
 tokio = { version = "0.2", features = ["io-std", "io-driver", "io-util"] }
 tokio-util = { version = "0.3", features = ["codec"] }

--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -7,11 +7,11 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-tcp-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.0.0"
+version = "17.1.0"
 
 [dependencies]
-jsonrpc-core = { version = "17.0", path = "../core" }
-jsonrpc-server-utils = { version = "17.0", path = "../server-utils" }
+jsonrpc-core = { version = "17.1", path = "../core" }
+jsonrpc-server-utils = { version = "17.1", path = "../server-utils" }
 log = "0.4"
 parking_lot = "0.11.0"
 tower-service = "0.3"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsonrpc-test"
 description = "Simple test framework for JSON-RPC."
-version = "17.0.0"
+version = "17.1.0"
 authors = ["Tomasz Drwięga <tomasz@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/jsonrpc"
@@ -10,9 +10,9 @@ documentation = "https://docs.rs/jsonrpc-test/"
 edition = "2018"
 
 [dependencies]
-jsonrpc-core = { version = "17.0", path = "../core" }
-jsonrpc-core-client = { version = "17.0", path = "../core-client" }
-jsonrpc-pubsub = { version = "17.0", path = "../pubsub" }
+jsonrpc-core = { version = "17.1", path = "../core" }
+jsonrpc-core-client = { version = "17.1", path = "../core-client" }
+jsonrpc-pubsub = { version = "17.1", path = "../pubsub" }
 log = "0.4"
 serde = "1.0"
 serde_json = "1.0"
@@ -21,5 +21,5 @@ serde_json = "1.0"
 arbitrary_precision = ["jsonrpc-core-client/arbitrary_precision", "serde_json/arbitrary_precision", "jsonrpc-core/arbitrary_precision"]
 
 [dev-dependencies]
-jsonrpc-derive = { version = "17.0", path = "../derive" }
+jsonrpc-derive = { version = "17.1", path = "../derive" }
 

--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -7,12 +7,12 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-ws-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.0.0"
+version = "17.1.0"
 
 [dependencies]
 futures = "0.3"
-jsonrpc-core = { version = "17.0", path = "../core" }
-jsonrpc-server-utils = { version = "17.0", path = "../server-utils" }
+jsonrpc-core = { version = "17.1", path = "../core" }
+jsonrpc-server-utils = { version = "17.1", path = "../server-utils" }
 log = "0.4"
 parking_lot = "0.11.0"
 slab = "0.4"


### PR DESCRIPTION
Because of #609 

cc @niklasad1 please let me know if that's good for you to bump to `17.1`, alternatively we can just release bugfix updates for `core-transport` (#620) and `pubsub` (#619) and leave `core` for later.