### PR TITLE
Add clippy to CI and fix several clippy warnings

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,6 +47,7 @@ checkstyle-linux-stable:
   script:
     - rustup component add rustfmt
     - cargo fmt --all -- --check
+    - cargo clippy
   allow_failure:                   true
 
 # test rust stable

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ checkstyle-linux-stable:
   <<:                              *only
   <<:                              *docker-env
   script:
-    - rustup component add rustfmt
+    - rustup component add rustfmt clippy
     - cargo fmt --all -- --check
     - cargo clippy
   allow_failure:                   true

--- a/core-client/transports/src/lib.rs
+++ b/core-client/transports/src/lib.rs
@@ -178,7 +178,7 @@ impl<T: DeserializeOwned + Unpin + 'static> Stream for TypedSubscriptionStream<T
 					.map_err(|error| RpcError::ParseError(self.returns.into(), Box::new(error))),
 			),
 			None => None,
-			Some(Err(err)) => Some(Err(err.into())),
+			Some(Err(err)) => Some(Err(err)),
 		}
 		.into()
 	}

--- a/core-client/transports/src/transports/duplex.rs
+++ b/core-client/transports/src/transports/duplex.rs
@@ -281,7 +281,7 @@ where
 			}
 			match self.outgoing.pop_front() {
 				Some(request) => {
-					if let Err(_) = self.sink.as_mut().start_send(request) {
+					if self.sink.as_mut().start_send(request).is_err() {
 						// the channel is disconnected.
 						return err().into();
 					}

--- a/core-client/transports/src/transports/mod.rs
+++ b/core-client/transports/src/transports/mod.rs
@@ -151,7 +151,7 @@ impl From<ClientResponse> for Result<Value, Error> {
 						(Some(_), _, Some(error)) => {
 							let error = serde_json::from_value::<Error>(error.to_owned())
 								.ok()
-								.unwrap_or_else(|| Error::parse_error());
+								.unwrap_or_else(Error::parse_error);
 							Err(error)
 						}
 						_ => Ok(n.params.into()),

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -207,10 +207,7 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 		use self::future::Either::{Left, Right};
 		fn as_string(response: Option<Response>) -> Option<String> {
 			let res = response.map(write_response);
-			debug!(target: "rpc", "Response: {}.", match res {
-				Some(ref res) => res,
-				None => "None",
-			});
+			debug!(target: "rpc", "Response: {}.", res.as_ref().unwrap_or(&"None".to_string()));
 			res
 		}
 

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -8,7 +8,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use futures_util::{self, future, FutureExt};
-use serde_json;
 
 use crate::calls::{
 	Metadata, RemoteProcedure, RpcMethod, RpcMethodSimple, RpcMethodSync, RpcNotification, RpcNotificationSimple,
@@ -237,7 +236,7 @@ impl<T: Metadata, S: Middleware<T>> MetaIoHandler<T, S> {
 		}
 
 		fn outputs_as_batch(outs: Vec<Option<Output>>) -> Option<Response> {
-			let outs: Vec<_> = outs.into_iter().filter_map(|v| v).collect();
+			let outs: Vec<_> = outs.into_iter().flatten().collect();
 			if outs.is_empty() {
 				None
 			} else {

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -59,10 +59,10 @@ impl Default for Compatibility {
 
 impl Compatibility {
 	fn is_version_valid(self, version: Option<Version>) -> bool {
-		match (self, version) {
-			(Compatibility::V1, None) | (Compatibility::V2, Some(Version::V2)) | (Compatibility::Both, _) => true,
-			_ => false,
-		}
+		matches!(
+			(self, version),
+			(Compatibility::V1, None) | (Compatibility::V2, Some(Version::V2)) | (Compatibility::Both, _)
+		)
 	}
 
 	fn default_version(self) -> Option<Version> {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,19 +3,17 @@
 //! Right now it supports only server side handling requests.
 //!
 //! ```rust
-//! use jsonrpc_core::*;
+//! use jsonrpc_core::IoHandler;
+//! use jsonrpc_core::Value;
+//! let mut io = IoHandler::new();
+//! io.add_sync_method("say_hello", |_| {
+//!     Ok(Value::String("Hello World!".into()))
+//! });
 //!
-//! fn main() {
-//! 	let mut io = IoHandler::new();
-//! 	io.add_sync_method("say_hello", |_| {
-//!			Ok(Value::String("Hello World!".into()))
-//! 	});
+//! let request = r#"{"jsonrpc": "2.0", "method": "say_hello", "params": [42, 23], "id": 1}"#;
+//! let response = r#"{"jsonrpc":"2.0","result":"Hello World!","id":1}"#;
 //!
-//! 	let request = r#"{"jsonrpc": "2.0", "method": "say_hello", "params": [42, 23], "id": 1}"#;
-//! 	let response = r#"{"jsonrpc":"2.0","result":"Hello World!","id":1}"#;
-//!
-//! 	assert_eq!(io.handle_request_sync(request), Some(response.to_string()));
-//! }
+//! assert_eq!(io.handle_request_sync(request), Some(response.to_string()));
 //! ```
 
 #![deny(missing_docs)]

--- a/core/src/types/params.rs
+++ b/core/src/types/params.rs
@@ -1,7 +1,6 @@
 //! jsonrpc params field
 
 use serde::de::DeserializeOwned;
-use serde_json;
 use serde_json::value::from_value;
 
 use super::{Error, Value};

--- a/core/src/types/response.rs
+++ b/core/src/types/response.rs
@@ -43,8 +43,8 @@ impl Output {
 	/// Creates new output given `Result`, `Id` and `Version`.
 	pub fn from(result: CoreResult<Value>, id: Id, jsonrpc: Option<Version>) -> Self {
 		match result {
-			Ok(result) => Output::Success(Success { id, jsonrpc, result }),
-			Err(error) => Output::Failure(Failure { id, jsonrpc, error }),
+			Ok(result) => Output::Success(Success { jsonrpc, result, id }),
+			Err(error) => Output::Failure(Failure { jsonrpc, error, id }),
 		}
 	}
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -5,42 +5,41 @@
 //! Example
 //!
 //! ```
-//! use jsonrpc_derive::rpc;
 //! use jsonrpc_core::{IoHandler, Result, BoxFuture};
 //! use jsonrpc_core::futures::future;
 //!
 //! #[rpc(server)]
 //! pub trait Rpc {
-//! 	#[rpc(name = "protocolVersion")]
-//! 	fn protocol_version(&self) -> Result<String>;
+//!     #[rpc(name = "protocolVersion")]
+//!     fn protocol_version(&self) -> Result<String>;
 //!
-//! 	#[rpc(name = "add")]
-//! 	fn add(&self, a: u64, b: u64) -> Result<u64>;
+//!     #[rpc(name = "add")]
+//!     fn add(&self, a: u64, b: u64) -> Result<u64>;
 //!
-//! 	#[rpc(name = "callAsync")]
-//! 	fn call(&self, a: u64) -> BoxFuture<Result<String>>;
+//!     #[rpc(name = "callAsync")]
+//!     fn call(&self, a: u64) -> BoxFuture<Result<String>>;
 //! }
 //!
 //! struct RpcImpl;
 //! impl Rpc for RpcImpl {
-//! 	fn protocol_version(&self) -> Result<String> {
-//! 		Ok("version1".into())
-//! 	}
+//!     fn protocol_version(&self) -> Result<String> {
+//!         Ok("version1".into())
+//!     }
 //!
-//! 	fn add(&self, a: u64, b: u64) -> Result<u64> {
-//! 		Ok(a + b)
-//! 	}
+//!     fn add(&self, a: u64, b: u64) -> Result<u64> {
+//!         Ok(a + b)
+//!     }
 //!
-//! 	fn call(&self, _: u64) -> BoxFuture<Result<String>> {
-//! 		Box::pin(future::ready(Ok("OK".to_owned()).into()))
-//! 	}
+//!     fn call(&self, _: u64) -> BoxFuture<Result<String>> {
+//!         Box::pin(future::ready(Ok("OK".to_owned()).into()))
+//!     }
 //! }
 //!
 //! fn main() {
-//!	  let mut io = IoHandler::new();
-//!	  let rpc = RpcImpl;
+//!   let mut io = IoHandler::new();
+//!   let rpc = RpcImpl;
 //!
-//!	  io.extend_with(rpc.to_delegate());
+//!   io.extend_with(rpc.to_delegate());
 //! }
 //! ```
 //!
@@ -51,7 +50,6 @@
 //! have a matching unique subscription name.
 //!
 //! ```
-//! use std::thread;
 //! use std::sync::{atomic, Arc, RwLock};
 //! use std::collections::HashMap;
 //!
@@ -61,80 +59,80 @@
 //!
 //! #[rpc]
 //! pub trait Rpc {
-//!		type Metadata;
+//!    type Metadata;
 //!
-//!		/// Hello subscription
-//!		#[pubsub(
-//! 		subscription = "hello",
-//! 		subscribe,
-//! 		name = "hello_subscribe",
-//! 		alias("hello_sub")
-//! 	)]
-//!		fn subscribe(&self, _: Self::Metadata, _: Subscriber<String>, param: u64);
+//!    /// Hello subscription
+//!    #[pubsub(
+//!        subscription = "hello",
+//!        subscribe,
+//!        name = "hello_subscribe",
+//!        alias("hello_sub")
+//!     )]
+//!     fn subscribe(&self, _: Self::Metadata, _: Subscriber<String>, param: u64);
 //!
-//!		/// Unsubscribe from hello subscription.
-//!		#[pubsub(
-//! 		subscription = "hello",
-//! 		unsubscribe,
-//! 		name = "hello_unsubscribe"
-//! 	)]
-//!		fn unsubscribe(&self, _: Option<Self::Metadata>, _: SubscriptionId) -> Result<bool>;
+//!     /// Unsubscribe from hello subscription.
+//!     #[pubsub(
+//!         subscription = "hello",
+//!         unsubscribe,
+//!         name = "hello_unsubscribe"
+//!     )]
+//!     fn unsubscribe(&self, _: Option<Self::Metadata>, _: SubscriptionId) -> Result<bool>;
 //! }
 //!
 //!
 //! #[derive(Default)]
 //! struct RpcImpl {
-//! 	uid: atomic::AtomicUsize,
-//! 	active: Arc<RwLock<HashMap<SubscriptionId, Sink<String>>>>,
+//!     uid: atomic::AtomicUsize,
+//!     active: Arc<RwLock<HashMap<SubscriptionId, Sink<String>>>>,
 //! }
 //! impl Rpc for RpcImpl {
-//! 	type Metadata = Arc<Session>;
+//!     type Metadata = Arc<Session>;
 //!
-//! 	fn subscribe(&self, _meta: Self::Metadata, subscriber: Subscriber<String>, param: u64) {
-//! 		if param != 10 {
-//! 			subscriber.reject(Error {
-//! 				code: ErrorCode::InvalidParams,
-//! 				message: "Rejecting subscription - invalid parameters provided.".into(),
-//! 				data: None,
-//! 			}).unwrap();
-//! 			return;
-//! 		}
+//!     fn subscribe(&self, _meta: Self::Metadata, subscriber: Subscriber<String>, param: u64) {
+//!         if param != 10 {
+//!             subscriber.reject(Error {
+//!                  code: ErrorCode::InvalidParams,
+//!                  message: "Rejecting subscription - invalid parameters provided.".into(),
+//!                  data: None,
+//!             }).unwrap();
+//!             return;
+//!         }
 //!
-//! 		let id = self.uid.fetch_add(1, atomic::Ordering::SeqCst);
-//! 		let sub_id = SubscriptionId::Number(id as u64);
-//! 		let sink = subscriber.assign_id(sub_id.clone()).unwrap();
-//! 		self.active.write().unwrap().insert(sub_id, sink);
-//! 	}
+//!         let id = self.uid.fetch_add(1, atomic::Ordering::SeqCst);
+//!         let sub_id = SubscriptionId::Number(id as u64);
+//!         let sink = subscriber.assign_id(sub_id.clone()).unwrap();
+//!         self.active.write().unwrap().insert(sub_id, sink);
+//!     }
 //!
-//! 	fn unsubscribe(&self, _meta: Option<Self::Metadata>, id: SubscriptionId) -> Result<bool> {
-//! 		let removed = self.active.write().unwrap().remove(&id);
-//! 		if removed.is_some() {
-//! 			Ok(true)
-//! 		} else {
-//! 			Err(Error {
-//! 				code: ErrorCode::InvalidParams,
-//! 				message: "Invalid subscription.".into(),
-//! 				data: None,
-//! 			})
-//! 		}
-//! 	}
+//!     fn unsubscribe(&self, _meta: Option<Self::Metadata>, id: SubscriptionId) -> Result<bool> {
+//!          let removed = self.active.write().unwrap().remove(&id);
+//!          if removed.is_some() {
+//!              Ok(true)
+//!          } else {
+//!              Err(Error {
+//!                  code: ErrorCode::InvalidParams,
+//!                  message: "Invalid subscription.".into(),
+//!                  data: None,
+//!          })
+//!         }
+//!     }
 //! }
 //!
 //! fn main() {
-//!	  let mut io = jsonrpc_core::MetaIoHandler::default();
-//!	  io.extend_with(RpcImpl::default().to_delegate());
+//!   let mut io = jsonrpc_core::MetaIoHandler::default();
+//!   io.extend_with(RpcImpl::default().to_delegate());
 //!
-//!	  let server_builder = jsonrpc_tcp_server::ServerBuilder::with_meta_extractor(
-//!		io,
-//!		|request: &jsonrpc_tcp_server::RequestContext| Arc::new(Session::new(request.sender.clone()))
-//!	  );
-//!	  let server = server_builder
-//!		.start(&"127.0.0.1:3030".parse().unwrap())
-//!		.expect("Unable to start TCP server");
+//!   let server_builder = jsonrpc_tcp_server::ServerBuilder::with_meta_extractor(
+//!     io,
+//!     |request: &jsonrpc_tcp_server::RequestContext| Arc::new(Session::new(request.sender.clone()))
+//!   );
+//!   let server = server_builder
+//!     .start(&"127.0.0.1:3030".parse().unwrap())
+//!     .expect("Unable to start TCP server");
 //!
 //!   // The server spawns a separate thread. Dropping the `server` handle causes it to close.
 //!   // Uncomment the line below to keep the server running in your example.
-//!	  // server.wait();
+//!   // server.wait();
 //! }
 //! ```
 //!
@@ -149,47 +147,47 @@
 //! /// Rpc trait
 //! #[rpc]
 //! pub trait Rpc {
-//! 	/// Returns a protocol version
-//! 	#[rpc(name = "protocolVersion")]
-//! 	fn protocol_version(&self) -> Result<String>;
+//!     /// Returns a protocol version
+//!     #[rpc(name = "protocolVersion")]
+//!     fn protocol_version(&self) -> Result<String>;
 //!
-//! 	/// Adds two numbers and returns a result
-//! 	#[rpc(name = "add", alias("callAsyncMetaAlias"))]
-//! 	fn add(&self, a: u64, b: u64) -> Result<u64>;
+//!     /// Adds two numbers and returns a result
+//!     #[rpc(name = "add", alias("callAsyncMetaAlias"))]
+//!     fn add(&self, a: u64, b: u64) -> Result<u64>;
 //!
-//! 	/// Performs asynchronous operation
-//! 	#[rpc(name = "callAsync")]
-//! 	fn call(&self, a: u64) -> BoxFuture<Result<String>>;
+//!     /// Performs asynchronous operation
+//!     #[rpc(name = "callAsync")]
+//!     fn call(&self, a: u64) -> BoxFuture<Result<String>>;
 //! }
 //!
 //! struct RpcImpl;
 //!
 //! impl Rpc for RpcImpl {
-//! 	fn protocol_version(&self) -> Result<String> {
-//! 		Ok("version1".into())
-//! 	}
+//!    fn protocol_version(&self) -> Result<String> {
+//!         Ok("version1".into())
+//!    }
 //!
-//! 	fn add(&self, a: u64, b: u64) -> Result<u64> {
-//! 		Ok(a + b)
-//! 	}
+//!    fn add(&self, a: u64, b: u64) -> Result<u64> {
+//!         Ok(a + b)
+//!    }
 //!
-//! 	fn call(&self, _: u64) -> BoxFuture<Result<String>> {
-//! 		Box::pin(future::ready(Ok("OK".to_owned())))
-//! 	}
+//!    fn call(&self, _: u64) -> BoxFuture<Result<String>> {
+//!         Box::pin(future::ready(Ok("OK".to_owned())))
+//!    }
 //! }
 //!
 //! fn main() {
-//! 	let exec = futures::executor::ThreadPool::new().unwrap();
-//! 	exec.spawn_ok(run())
+//!     let exec = futures::executor::ThreadPool::new().unwrap();
+//!     exec.spawn_ok(run())
 //! }
 //! async fn run() {
-//! 	let mut io = IoHandler::new();
-//! 	io.extend_with(RpcImpl.to_delegate());
+//!    let mut io = IoHandler::new();
+//!    io.extend_with(RpcImpl.to_delegate());
 //!
-//! 	let (client, server) = local::connect::<RpcClient, _, _>(io);
-//! 	let res = client.add(5, 6).await.unwrap();
-//! 	println!("5 + 6 = {}", res);
-//! 	server.await.unwrap()
+//!    let (client, server) = local::connect::<RpcClient, _, _>(io);
+//!    let res = client.add(5, 6).await.unwrap();
+//!    println!("5 + 6 = {}", res);
+//!    server.await.unwrap()
 //! }
 //!
 //! ```

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -7,6 +7,7 @@
 //! ```
 //! use jsonrpc_core::{IoHandler, Result, BoxFuture};
 //! use jsonrpc_core::futures::future;
+//! use jsonrpc_derive::rpc;
 //!
 //! #[rpc(server)]
 //! pub trait Rpc {

--- a/derive/src/rpc_attr.rs
+++ b/derive/src/rpc_attr.rs
@@ -71,7 +71,7 @@ impl RpcMethodAttribute {
 	fn parse_meta(attr: &syn::Attribute, output: &syn::ReturnType) -> Option<Result<RpcMethodAttribute>> {
 		match attr.parse_meta().and_then(validate_attribute_meta) {
 			Ok(ref meta) => {
-				let attr_kind = match path_to_str(meta.path()).as_ref().map(String::as_str) {
+				let attr_kind = match path_to_str(meta.path()).as_deref() {
 					Some(RPC_ATTR_NAME) => Some(Self::parse_rpc(meta, output)),
 					Some(PUB_SUB_ATTR_NAME) => Some(Self::parse_pubsub(meta)),
 					_ => None,
@@ -89,9 +89,7 @@ impl RpcMethodAttribute {
 										// "`raw_params` will be deprecated in a future release. Use `params = \"raw\" instead`"
 										Ok(Some(ParamStyle::Raw))
 									}
-									false => {
-										get_meta_list(meta).map_or(Ok(None), |ml| get_params_style(ml).map(|s| Some(s)))
-									}
+									false => get_meta_list(meta).map_or(Ok(None), |ml| get_params_style(ml).map(Some)),
 								}?;
 								Ok(RpcMethodAttribute {
 									attr: attr.clone(),
@@ -110,13 +108,10 @@ impl RpcMethodAttribute {
 
 	fn parse_rpc(meta: &syn::Meta, output: &syn::ReturnType) -> Result<AttributeKind> {
 		let has_metadata = get_meta_list(meta).map_or(false, |ml| has_meta_word(METADATA_META_WORD, ml));
-		let returns = get_meta_list(meta).map_or(None, |ml| get_name_value(RETURNS_META_WORD, ml));
+		let returns = get_meta_list(meta).and_then(|ml| get_name_value(RETURNS_META_WORD, ml));
 		let is_notification = match output {
 			syn::ReturnType::Default => true,
-			syn::ReturnType::Type(_, ret) => match **ret {
-				syn::Type::Tuple(ref tup) if tup.elems.empty_or_trailing() => true,
-				_ => false,
-			},
+			syn::ReturnType::Type(_, ret) => matches!(**ret, syn::Type::Tuple(ref tup) if tup.elems.empty_or_trailing()),
 		};
 
 		if is_notification && returns.is_some() {
@@ -188,7 +183,7 @@ fn validate_attribute_meta(meta: syn::Meta) -> Result<syn::Meta> {
 	visit::visit_meta(&mut visitor, &meta);
 
 	let ident = path_to_str(meta.path());
-	match ident.as_ref().map(String::as_str) {
+	match ident.as_deref() {
 		Some(RPC_ATTR_NAME) => {
 			validate_idents(&meta, &visitor.meta_words, &[METADATA_META_WORD, RAW_PARAMS_META_WORD])?;
 			validate_idents(

--- a/derive/src/rpc_attr.rs
+++ b/derive/src/rpc_attr.rs
@@ -111,7 +111,9 @@ impl RpcMethodAttribute {
 		let returns = get_meta_list(meta).and_then(|ml| get_name_value(RETURNS_META_WORD, ml));
 		let is_notification = match output {
 			syn::ReturnType::Default => true,
-			syn::ReturnType::Type(_, ret) => matches!(**ret, syn::Type::Tuple(ref tup) if tup.elems.empty_or_trailing()),
+			syn::ReturnType::Type(_, ret) => {
+				matches!(**ret, syn::Type::Tuple(ref tup) if tup.elems.empty_or_trailing())
+			}
 		};
 
 		if is_notification && returns.is_some() {

--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -45,10 +45,9 @@ impl<'a> Fold for RpcTrait {
 		fold::fold_trait_item_method(self, foldable_method)
 	}
 
-	fn fold_trait_item_type(&mut self, ty: syn::TraitItemType) -> syn::TraitItemType {
+	fn fold_trait_item_type(&mut self, mut ty: syn::TraitItemType) -> syn::TraitItemType {
 		if ty.ident == METADATA_TYPE {
 			self.has_metadata = true;
-			let mut ty = ty;
 			if self.has_pubsub_methods {
 				ty.bounds.push(parse_quote!(_jsonrpc_pubsub::PubSubMetadata))
 			} else {

--- a/derive/src/rpc_trait.rs
+++ b/derive/src/rpc_trait.rs
@@ -48,7 +48,7 @@ impl<'a> Fold for RpcTrait {
 	fn fold_trait_item_type(&mut self, ty: syn::TraitItemType) -> syn::TraitItemType {
 		if ty.ident == METADATA_TYPE {
 			self.has_metadata = true;
-			let mut ty = ty.clone();
+			let mut ty = ty;
 			if self.has_pubsub_methods {
 				ty.bounds.push(parse_quote!(_jsonrpc_pubsub::PubSubMetadata))
 			} else {
@@ -146,7 +146,7 @@ fn compute_method_registrations(item_trait: &syn::ItemTrait) -> Result<(Vec<Meth
 								format!(
 									"Inconsistent signature for 'Subscriber' argument: {}, previously defined: {}",
 									next_method_arg.clone().into_token_stream(),
-									subscriber_arg.clone().into_token_stream()
+									subscriber_arg.into_token_stream()
 								),
 							));
 						}

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -108,7 +108,7 @@ fn generate_client_methods(methods: &[MethodRegistration], options: &DeriveOptio
 				};
 				let returns_str = quote!(#returns).to_string();
 
-				let args_serialized = match method.attr.params_style.clone().unwrap_or(options.params_style.clone()) {
+				let args_serialized = match method.attr.params_style.clone().unwrap_or_else(|| options.params_style.clone()) {
 					ParamStyle::Named => {
 						quote! {  // use object style serialization with field names taken from the function param names
 							serde_json::json!({
@@ -212,9 +212,8 @@ fn compute_args(method: &syn::TraitItemMethod) -> Punctuated<syn::FnArg, syn::to
 			}) => segments,
 			_ => continue,
 		};
-		let ident = match &segments[0] {
-			syn::PathSegment { ident, .. } => ident,
-		};
+		let syn::PathSegment { ident, .. } = &segments[0];
+		let ident = ident;
 		if *ident == "Self" {
 			continue;
 		}

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -215,7 +215,7 @@ fn compute_args(method: &syn::TraitItemMethod) -> Punctuated<syn::FnArg, syn::to
 		let ident = match &segments[0] {
 			syn::PathSegment { ident, .. } => ident,
 		};
-		if ident.to_string() == "Self" {
+		if *ident == "Self" {
 			continue;
 		}
 		args.push(arg.to_owned());

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -188,7 +188,7 @@ fn get_doc_comments(attrs: &[syn::Attribute]) -> Vec<syn::Attribute> {
 				..
 			} => match &segments[0] {
 				syn::PathSegment { ident, .. } => {
-					if ident.to_string() == "doc" {
+					if *ident == "doc" {
 						doc_comments.push(attr.to_owned());
 					}
 				}

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -108,7 +108,12 @@ fn generate_client_methods(methods: &[MethodRegistration], options: &DeriveOptio
 				};
 				let returns_str = quote!(#returns).to_string();
 
-				let args_serialized = match method.attr.params_style.clone().unwrap_or_else(|| options.params_style.clone()) {
+				let args_serialized = match method
+					.attr
+					.params_style
+					.clone()
+					.unwrap_or_else(|| options.params_style.clone())
+				{
 					ParamStyle::Named => {
 						quote! {  // use object style serialization with field names taken from the function param names
 							serde_json::json!({

--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -154,7 +154,7 @@ pub fn generate_trait_item_method(
 	};
 
 	let predicates = generate_where_clause_serialization_predicates(&trait_item, false);
-	let mut method = method.clone();
+	let mut method = method;
 	method.sig.generics.make_where_clause().predicates.extend(predicates);
 	Ok(method)
 }
@@ -244,11 +244,10 @@ impl RpcMethod {
 				quote! { let params: _jsonrpc_core::Result<_> = Ok((params,)); }
 			} else if self.attr.params_style == Some(ParamStyle::Positional) {
 				quote! { let params = params.parse::<(#(#param_types, )*)>(); }
-			} else
-			/* if self.attr.params_style == Some(ParamStyle::Named) */
-			{
+			} else {
 				unimplemented!("Server side named parameters are not implemented");
 			}
+			/* if self.attr.params_style == Some(ParamStyle::Named) */
 		};
 
 		let method_ident = self.ident();
@@ -324,10 +323,10 @@ impl RpcMethod {
 
 		let mut special_args = Vec::new();
 		if let Some(meta) = meta_arg {
-			special_args.push((ident(METADATA_CLOSURE_ARG), meta.clone()));
+			special_args.push((ident(METADATA_CLOSURE_ARG), meta));
 		}
 		if let Some(subscriber) = subscriber_arg {
-			special_args.push((ident(SUBSCRIBER_CLOSURE_ARG), subscriber.clone()));
+			special_args.push((ident(SUBSCRIBER_CLOSURE_ARG), subscriber));
 		}
 		special_args
 	}

--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -245,9 +245,9 @@ impl RpcMethod {
 			} else if self.attr.params_style == Some(ParamStyle::Positional) {
 				quote! { let params = params.parse::<(#(#param_types, )*)>(); }
 			} else {
+				/* if self.attr.params_style == Some(ParamStyle::Named) */
 				unimplemented!("Server side named parameters are not implemented");
 			}
-			/* if self.attr.params_style == Some(ParamStyle::Named) */
 		};
 
 		let method_ident = self.ident();

--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -220,7 +220,7 @@ impl RpcMethod {
 
 		// special args are those which are not passed directly via rpc params: metadata, subscriber
 		let special_args = Self::special_args(&param_types);
-		param_types.retain(|ty| special_args.iter().find(|(_, sty)| sty == ty).is_none());
+		param_types.retain(|ty| !special_args.iter().any(|(_, sty)| sty == ty));
 		if param_types.len() > TUPLE_FIELD_NAMES.len() {
 			return Err(syn::Error::new_spanned(
 				&self.trait_item,

--- a/derive/src/to_delegate.rs
+++ b/derive/src/to_delegate.rs
@@ -236,6 +236,7 @@ impl RpcMethod {
 		let parse_params = {
 			// last arguments that are `Option`-s are optional 'trailing' arguments
 			let trailing_args_num = param_types.iter().rev().take_while(|t| is_option_type(t)).count();
+
 			if trailing_args_num != 0 {
 				self.params_with_trailing(trailing_args_num, param_types, tuple_fields)
 			} else if param_types.is_empty() {
@@ -245,7 +246,6 @@ impl RpcMethod {
 			} else if self.attr.params_style == Some(ParamStyle::Positional) {
 				quote! { let params = params.parse::<(#(#param_types, )*)>(); }
 			} else {
-				/* if self.attr.params_style == Some(ParamStyle::Named) */
 				unimplemented!("Server side named parameters are not implemented");
 			}
 		};

--- a/derive/tests/client.rs
+++ b/derive/tests/client.rs
@@ -38,7 +38,7 @@ mod client_server {
 			.add(3, 4)
 			.map_ok(move |res| client.notify(res).map(move |_| res))
 			.map(|res| {
-				assert_matches!(res, Ok(Ok(7)));
+				self::assert_matches!(res, Ok(Ok(7)));
 			});
 		let exec = futures::executor::ThreadPool::builder().pool_size(1).create().unwrap();
 		exec.spawn_ok(async move {
@@ -82,7 +82,7 @@ mod named_params {
 			.call_with_named(3, String::from("test string"), json!({"key": ["value"]}))
 			.map_ok(move |res| client.notify(res.clone()).map(move |_| res))
 			.map(move |res| {
-				assert_matches!(res, Ok(Ok(x)) if x == expected);
+				self::assert_matches!(res, Ok(Ok(x)) if x == expected);
 			});
 		let exec = futures::executor::ThreadPool::builder().pool_size(1).create().unwrap();
 		exec.spawn_ok(async move { futures::join!(fut, rpc_client).1.unwrap() });
@@ -120,7 +120,7 @@ mod raw_params {
 			.call_raw_single_param(expected.clone())
 			.map_ok(move |res| client.notify(res.clone()).map(move |_| res))
 			.map(move |res| {
-				assert_matches!(res, Ok(Ok(x)) if x == expected);
+				self::assert_matches!(res, Ok(Ok(x)) if x == expected);
 			});
 		let exec = futures::executor::ThreadPool::builder().pool_size(1).create().unwrap();
 		exec.spawn_ok(async move { futures::join!(fut, rpc_client).1.unwrap() });

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -11,10 +11,10 @@
 //! 	});
 //!
 //! 	let _server = ServerBuilder::new(io)
-//!		.start_http(&"127.0.0.1:3030".parse().unwrap())
-//!		.expect("Unable to start RPC server");
+//!     .start_http(&"127.0.0.1:3030".parse().unwrap())
+//!     .expect("Unable to start RPC server");
 //!
-//!	_server.wait();
+//! _server.wait();
 //! }
 //! ```
 

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -5,12 +5,12 @@
 //! use jsonrpc_http_server::*;
 //!
 //! fn main() {
-//! 	let mut io = IoHandler::new();
-//! 	io.add_sync_method("say_hello", |_: Params| {
-//! 		Ok(Value::String("hello".to_string()))
-//! 	});
+//!     let mut io = IoHandler::new();
+//!     io.add_sync_method("say_hello", |_: Params| {
+//!         Ok(Value::String("hello".to_string()))
+//!     });
 //!
-//! 	let _server = ServerBuilder::new(io)
+//!     let _server = ServerBuilder::new(io)
 //!     .start_http(&"127.0.0.1:3030".parse().unwrap())
 //!     .expect("Unable to start RPC server");
 //!
@@ -21,7 +21,6 @@
 #![deny(missing_docs)]
 
 use jsonrpc_server_utils as server_utils;
-use net2;
 
 pub use hyper;
 pub use jsonrpc_core;
@@ -678,10 +677,11 @@ impl CloseHandle {
 	}
 }
 
+type Executors = Arc<Mutex<Option<Vec<(Executor, oneshot::Sender<()>)>>>>;
 /// jsonrpc http server instance
 pub struct Server {
 	address: SocketAddr,
-	executors: Arc<Mutex<Option<Vec<(Executor, oneshot::Sender<()>)>>>>,
+	executors: Executors,
 	done: Option<Vec<oneshot::Receiver<()>>>,
 }
 

--- a/http/src/utils.rs
+++ b/http/src/utils.rs
@@ -59,12 +59,7 @@ pub fn cors_allow_headers(
 /// `false` indicates `Connection: close`.
 pub fn keep_alive(request: &hyper::Request<hyper::Body>, keep_alive: bool) -> bool {
 	read_header(request, "connection")
-		.map(|val| match (keep_alive, val) {
-			// indicate that connection should be closed
-			(false, _) | (_, "close") => false,
-			// don't include any headers otherwise
-			_ => true,
-		})
+		.map(|val| !matches!((keep_alive, val), (false, _) | (_, "close")))
 		// if the client header is not present, close connection if we don't keep_alive
 		.unwrap_or(keep_alive)
 }

--- a/ipc/src/server.rs
+++ b/ipc/src/server.rs
@@ -210,7 +210,7 @@ where
 					})
 					.try_buffer_unordered(client_buffer_size)
 					// Filter out previously ignored service errors as `None`s
-					.try_filter_map(|x| futures::future::ok(x))
+					.try_filter_map(futures::future::ok)
 					// we use `select_with_weak` here, instead of `select`, to close the stream
 					// as soon as the ipc pipe is closed
 					.select_with_weak(receiver.map(Ok));

--- a/pubsub/src/oneshot.rs
+++ b/pubsub/src/oneshot.rs
@@ -52,7 +52,7 @@ impl<T> Sender<T> {
 	pub fn send_and_wait(self, t: T) -> impl Future<Output = Result<(), ()>> {
 		let Self { sender, receipt } = self;
 
-		if let Err(_) = sender.send(t) {
+		if sender.send(t).is_err() {
 			return future::Either::Left(future::ready(Err(())));
 		}
 

--- a/pubsub/src/typed.rs
+++ b/pubsub/src/typed.rs
@@ -5,7 +5,6 @@ use std::pin::Pin;
 
 use crate::subscription;
 use crate::types::{SinkResult, SubscriptionId, TransportError};
-use serde;
 
 use crate::core::futures::task::{Context, Poll};
 use crate::core::futures::{self, channel};

--- a/server-utils/src/cors.rs
+++ b/server-utils/src/cors.rs
@@ -1,7 +1,5 @@
 //! CORS handling utility functions
-use unicase;
-
-pub use self::unicase::Ascii;
+pub use unicase::Ascii;
 use crate::hosts::{Host, Port};
 use crate::matcher::{Matcher, Pattern};
 use std::collections::HashSet;

--- a/server-utils/src/cors.rs
+++ b/server-utils/src/cors.rs
@@ -1,9 +1,9 @@
 //! CORS handling utility functions
-pub use unicase::Ascii;
 use crate::hosts::{Host, Port};
 use crate::matcher::{Matcher, Pattern};
 use std::collections::HashSet;
 use std::{fmt, ops};
+pub use unicase::Ascii;
 
 /// Origin Protocol
 #[derive(Clone, Hash, Debug, PartialEq, Eq)]

--- a/server-utils/src/stream_codec.rs
+++ b/server-utils/src/stream_codec.rs
@@ -41,10 +41,7 @@ impl StreamCodec {
 }
 
 fn is_whitespace(byte: u8) -> bool {
-	match byte {
-		0x0D | 0x0A | 0x20 | 0x09 => true,
-		_ => false,
-	}
+	matches!(byte, 0x0D | 0x0A | 0x20 | 0x09)
 }
 
 impl tokio_util::codec::Decoder for StreamCodec {

--- a/stdio/src/lib.rs
+++ b/stdio/src/lib.rs
@@ -7,12 +7,12 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//! 	let mut io = IoHandler::default();
-//! 	io.add_sync_method("say_hello", |_params| {
-//! 		Ok(Value::String("hello".to_owned()))
-//! 	});
+//!     let mut io = IoHandler::default();
+//!     io.add_sync_method("say_hello", |_params| {
+//!         Ok(Value::String("hello".to_owned()))
+//!     });
 //!
-//! 	let server = ServerBuilder::new(io).build();
+//!     let server = ServerBuilder::new(io).build();
 //!     server.await;
 //! }
 //! ```

--- a/stdio/src/lib.rs
+++ b/stdio/src/lib.rs
@@ -13,7 +13,7 @@
 //! 	});
 //!
 //! 	let server = ServerBuilder::new(io).build();
-//!		server.await;
+//!     server.await;
 //! }
 //! ```
 

--- a/tcp/src/lib.rs
+++ b/tcp/src/lib.rs
@@ -5,11 +5,11 @@
 //! use jsonrpc_tcp_server::ServerBuilder;
 //!
 //! fn main() {
-//! 	let mut io = IoHandler::default();
-//! 	io.add_sync_method("say_hello", |_params| {
-//! 		Ok(Value::String("hello".to_string()))
-//! 	});
-//! 	let server = ServerBuilder::new(io)
+//!     let mut io = IoHandler::default();
+//!     io.add_sync_method("say_hello", |_params| {
+//!         Ok(Value::String("hello".to_string()))
+//!     });
+//!     let server = ServerBuilder::new(io)
 //!         .start(&"0.0.0.0:0".parse().unwrap())
 //!         .expect("Server must start with no issues.");
 //!

--- a/tcp/src/lib.rs
+++ b/tcp/src/lib.rs
@@ -10,10 +10,10 @@
 //! 		Ok(Value::String("hello".to_string()))
 //! 	});
 //! 	let server = ServerBuilder::new(io)
-//!			.start(&"0.0.0.0:0".parse().unwrap())
-//!			.expect("Server must start with no issues.");
+//!         .start(&"0.0.0.0:0".parse().unwrap())
+//!         .expect("Server must start with no issues.");
 //!
-//!		server.wait();
+//!     server.wait();
 //! }
 //! ```
 

--- a/tcp/src/server.rs
+++ b/tcp/src/server.rs
@@ -141,7 +141,7 @@ where
 
 					let mut peer_message_queue = {
 						let mut channels = channels.lock();
-						channels.insert(peer_addr, sender.clone());
+						channels.insert(peer_addr, sender);
 
 						PeerMessageQueue::new(responses, receiver, peer_addr)
 					};
@@ -164,7 +164,7 @@ where
 			match start.await {
 				Ok(server) => {
 					tx.send(Ok(())).expect("Rx is blocking parent thread.");
-					let server = server.buffer_unordered(1024).for_each(|_| async { () });
+					let server = server.buffer_unordered(1024).for_each(|_| async { });
 
 					future::select(Box::pin(server), stop_rx).await;
 				}

--- a/tcp/src/server.rs
+++ b/tcp/src/server.rs
@@ -164,7 +164,7 @@ where
 			match start.await {
 				Ok(server) => {
 					tx.send(Ok(())).expect("Rx is blocking parent thread.");
-					let server = server.buffer_unordered(1024).for_each(|_| async { });
+					let server = server.buffer_unordered(1024).for_each(|_| async {});
 
 					future::select(Box::pin(server), stop_rx).await;
 				}

--- a/tcp/src/service.rs
+++ b/tcp/src/service.rs
@@ -16,8 +16,8 @@ pub struct Service<M: Metadata = (), S: Middleware<M> = middleware::Noop> {
 impl<M: Metadata, S: Middleware<M>> Service<M, S> {
 	pub fn new(peer_addr: SocketAddr, handler: Arc<MetaIoHandler<M, S>>, meta: M) -> Self {
 		Service {
-			peer_addr,
 			handler,
+			peer_addr,
 			meta,
 		}
 	}

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -8,16 +8,16 @@
 //!
 //! #[rpc]
 //! pub trait Test {
-//!     #[rpc(name = "rpc_some_method")]
-//!     fn some_method(&self, a: u64) -> Result<u64>;
+//!    #[rpc(name = "rpc_some_method")]
+//!    fn some_method(&self, a: u64) -> Result<u64>;
 //! }
 //!
 //!
 //! struct Dummy;
 //! impl Test for Dummy {
-//!     fn some_method(&self, x: u64) -> Result<u64> {
-//!         Ok(x * 2)
-//!     }
+//!    fn some_method(&self, x: u64) -> Result<u64> {
+//!        Ok(x * 2)
+//!    }
 //! }
 //!
 //! fn main() {
@@ -31,7 +31,7 @@
 //!   let rpc = {
 //!     let mut io = IoHandler::new();
 //!     io.add_sync_method("rpc_test_method", |_| {
-//!         Err(Error::internal_error())
+//!        Err(Error::internal_error())
 //!     });
 //!     test::Rpc::from(io)
 //!   };

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -46,8 +46,6 @@
 #![deny(missing_docs)]
 
 extern crate jsonrpc_core as rpc;
-use serde;
-use serde_json;
 
 /// Test RPC options.
 #[derive(Default, Debug)]


### PR DESCRIPTION
This PR add running clippy right after rustfmt during the CI.
It also fixes many warnings (many being due to mix of spaces and tabs in the doc examples).