### PR TITLE
Bump versions to v18

### DIFF
--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
 name = "jsonrpc-core-client"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.1.0"
+version = "18.0.0"
 
 categories = [
 	"asynchronous",
@@ -26,7 +26,7 @@ ipc = ["jsonrpc-client-transports/ipc"]
 arbitrary_precision = ["jsonrpc-client-transports/arbitrary_precision"]
 
 [dependencies]
-jsonrpc-client-transports = { version = "17.1", path = "./transports", default-features = false }
+jsonrpc-client-transports = { version = "18.0.0", path = "./transports", default-features = false }
 futures = { version = "0.3", features = [ "compat" ] }
 
 [badges]

--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
 name = "jsonrpc-client-transports"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.1.0"
+version = "18.0.0"
 
 categories = [
 	"asynchronous",
@@ -37,8 +37,8 @@ arbitrary_precision = ["serde_json/arbitrary_precision", "jsonrpc-core/arbitrary
 [dependencies]
 derive_more = "0.99"
 futures = "0.3"
-jsonrpc-core = { version = "17.1", path = "../../core" }
-jsonrpc-pubsub = { version = "17.1", path = "../../pubsub" }
+jsonrpc-core = { version = "18.0.0", path = "../../core" }
+jsonrpc-pubsub = { version = "18.0.0", path = "../../pubsub" }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -46,15 +46,15 @@ url = "1.7"
 
 hyper = { version = "0.14", features = ["client", "http1"], optional = true }
 hyper-tls = { version = "0.5", optional = true }
-jsonrpc-server-utils = { version = "17.1", path = "../../server-utils", optional = true }
+jsonrpc-server-utils = { version = "18.0.0", path = "../../server-utils", optional = true }
 parity-tokio-ipc = { version = "0.9", optional = true }
 tokio = { version = "1", optional = true }
 websocket = { version = "0.24", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.1"
-jsonrpc-http-server = { version = "17.1", path = "../../http" }
-jsonrpc-ipc-server = { version = "17.1", path = "../../ipc" }
+jsonrpc-http-server = { version = "18.0.0", path = "../../http" }
+jsonrpc-ipc-server = { version = "18.0.0", path = "../../ipc" }
 lazy_static = "1.0"
 env_logger = "0.7"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
 name = "jsonrpc-core"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.1.0"
+version = "18.0.0"
 
 categories = [
 	"asynchronous",

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-derive"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.1.0"
+version = "18.0.0"
 
 [lib]
 proc-macro = true
@@ -20,10 +20,10 @@ proc-macro-crate = "0.1.4"
 
 [dev-dependencies]
 assert_matches = "1.3"
-jsonrpc-core = { version = "17.1", path = "../core" }
-jsonrpc-core-client = { version = "17.1", path = "../core-client" }
-jsonrpc-pubsub = { version = "17.1", path = "../pubsub" }
-jsonrpc-tcp-server = { version = "17.1", path = "../tcp" }
+jsonrpc-core = { version = "18.0.0", path = "../core" }
+jsonrpc-core-client = { version = "18.0.0", path = "../core-client" }
+jsonrpc-pubsub = { version = "18.0.0", path = "../pubsub" }
+jsonrpc-tcp-server = { version = "18.0.0", path = "../tcp" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 trybuild = "1.0"

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -8,13 +8,13 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "server"]
 license = "MIT"
 name = "jsonrpc-http-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.1.0"
+version = "18.0.0"
 
 [dependencies]
 futures = "0.3"
 hyper = { version = "0.14", features = ["http1", "tcp", "server",  "stream"] }
-jsonrpc-core = { version = "17.1", path = "../core" }
-jsonrpc-server-utils = { version = "17.1", path = "../server-utils" }
+jsonrpc-core = { version = "18.0.0", path = "../core" }
+jsonrpc-server-utils = { version = "18.0.0", path = "../server-utils" }
 log = "0.4"
 net2 = "0.2"
 parking_lot = "0.11.0"

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -7,14 +7,14 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-ipc-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.1.0"
+version = "18.0.0"
 
 [dependencies]
 futures = "0.3"
 log = "0.4"
 tower-service = "0.3"
-jsonrpc-core = { version = "17.1", path = "../core" }
-jsonrpc-server-utils = { version = "17.1", path = "../server-utils", default-features = false }
+jsonrpc-core = { version = "18.0.0", path = "../core" }
+jsonrpc-server-utils = { version = "18.0.0", path = "../server-utils", default-features = false }
 parity-tokio-ipc = "0.9"
 parking_lot = "0.11.0"
 

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -8,11 +8,11 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "macros"]
 license = "MIT"
 name = "jsonrpc-pubsub"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.1.0"
+version = "18.0.0"
 
 [dependencies]
 futures = { version = "0.3", features = ["thread-pool"] }
-jsonrpc-core = { version = "17.1", path = "../core" }
+jsonrpc-core = { version = "18.0.0", path = "../core" }
 lazy_static = "1.4"
 log = "0.4"
 parking_lot = "0.11.0"
@@ -20,7 +20,7 @@ rand = "0.7"
 serde = "1.0"
 
 [dev-dependencies]
-jsonrpc-tcp-server = { version = "17.1", path = "../tcp" }
+jsonrpc-tcp-server = { version = "18.0.0", path = "../tcp" }
 serde_json = "1.0"
 
 [badges]

--- a/pubsub/more-examples/Cargo.toml
+++ b/pubsub/more-examples/Cargo.toml
@@ -3,12 +3,12 @@ name = "jsonrpc-pubsub-examples"
 description = "Examples of Publish-Subscribe extension for jsonrpc."
 homepage = "https://github.com/paritytech/jsonrpc"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.1.0"
+version = "18.0.0"
 authors = ["tomusdrw <tomasz@parity.io>"]
 license = "MIT"
 
 [dependencies]
-jsonrpc-core = { version = "17.1", path = "../../core" }
-jsonrpc-pubsub = { version = "17.1", path = "../" }
-jsonrpc-ws-server = { version = "17.1", path = "../../ws" }
-jsonrpc-ipc-server = { version = "17.1", path = "../../ipc" }
+jsonrpc-core = { version = "18.0.0", path = "../../core" }
+jsonrpc-pubsub = { version = "18.0.0", path = "../" }
+jsonrpc-ws-server = { version = "18.0.0", path = "../../ws" }
+jsonrpc-ipc-server = { version = "18.0.0", path = "../../ipc" }

--- a/server-utils/Cargo.toml
+++ b/server-utils/Cargo.toml
@@ -8,13 +8,13 @@ keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
 name = "jsonrpc-server-utils"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.1.0"
+version = "18.0.0"
 
 [dependencies]
 bytes = "1.0"
 futures = "0.3"
 globset = "0.4"
-jsonrpc-core = { version = "17.1", path = "../core" }
+jsonrpc-core = { version = "18.0.0", path = "../core" }
 lazy_static = "1.1.0"
 log = "0.4"
 tokio = { version = "1", features = ["rt-multi-thread", "io-util", "time", "net"] }

--- a/stdio/Cargo.toml
+++ b/stdio/Cargo.toml
@@ -7,11 +7,11 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-stdio-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.1.0"
+version = "18.0.0"
 
 [dependencies]
 futures = "0.3"
-jsonrpc-core = { version = "17.1", path = "../core" }
+jsonrpc-core = { version = "18.0.0", path = "../core" }
 log = "0.4"
 tokio = { version = "1", features = ["io-std", "io-util"] }
 tokio-util = { version = "0.6", features = ["codec"] }

--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -7,11 +7,11 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-tcp-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.1.0"
+version = "18.0.0"
 
 [dependencies]
-jsonrpc-core = { version = "17.1", path = "../core" }
-jsonrpc-server-utils = { version = "17.1", path = "../server-utils" }
+jsonrpc-core = { version = "18.0.0", path = "../core" }
+jsonrpc-server-utils = { version = "18.0.0", path = "../server-utils" }
 log = "0.4"
 parking_lot = "0.11.0"
 tower-service = "0.3"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsonrpc-test"
 description = "Simple test framework for JSON-RPC."
-version = "17.1.0"
+version = "18.0.0"
 authors = ["Tomasz Drwięga <tomasz@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/jsonrpc"
@@ -10,9 +10,9 @@ documentation = "https://docs.rs/jsonrpc-test/"
 edition = "2018"
 
 [dependencies]
-jsonrpc-core = { version = "17.1", path = "../core" }
-jsonrpc-core-client = { version = "17.1", path = "../core-client" }
-jsonrpc-pubsub = { version = "17.1", path = "../pubsub" }
+jsonrpc-core = { version = "18.0.0", path = "../core" }
+jsonrpc-core-client = { version = "18.0.0", path = "../core-client" }
+jsonrpc-pubsub = { version = "18.0.0", path = "../pubsub" }
 log = "0.4"
 serde = "1.0"
 serde_json = "1.0"
@@ -21,5 +21,5 @@ serde_json = "1.0"
 arbitrary_precision = ["jsonrpc-core-client/arbitrary_precision", "serde_json/arbitrary_precision", "jsonrpc-core/arbitrary_precision"]
 
 [dev-dependencies]
-jsonrpc-derive = { version = "17.1", path = "../derive" }
+jsonrpc-derive = { version = "18.0.0", path = "../derive" }
 

--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -7,12 +7,12 @@ homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
 name = "jsonrpc-ws-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "17.1.0"
+version = "18.0.0"
 
 [dependencies]
 futures = "0.3"
-jsonrpc-core = { version = "17.1", path = "../core" }
-jsonrpc-server-utils = { version = "17.1", path = "../server-utils" }
+jsonrpc-core = { version = "18.0.0", path = "../core" }
+jsonrpc-server-utils = { version = "18.0.0", path = "../server-utils" }
 log = "0.4"
 parking_lot = "0.11.0"
 slab = "0.4"


### PR DESCRIPTION
As per https://github.com/paritytech/jsonrpc/pull/628#issuecomment-875886874.

Done via `cargo unleash version bump-breaking`.