### PR TITLE
Update README.md to match example in main repo (and not be broken)

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -9,25 +9,25 @@ Rust http server using JSON-RPC 2.0.
 
 ```
 [dependencies]
-jsonrpc-http-server = "15.0"
+jsonrpc-http-server = "18.0"
 ```
 
 `main.rs`
 
 ```rust
-use jsonrpc_http_server::*;
-use jsonrpc_http_server::jsonrpc_core::*;
+use jsonrpc_http_server::jsonrpc_core::{IoHandler, Value, Params};
+use jsonrpc_http_server::ServerBuilder;
 
 fn main() {
 	let mut io = IoHandler::default();
-	io.add_method("say_hello", |_| {
-		Ok(Value::String("hello".into()))
+	io.add_method("say_hello", |_params: Params| async {
+		Ok(Value::String("hello".to_owned()))
 	});
 
 	let server = ServerBuilder::new(io)
-		.cors(DomainsValidation::AllowOnly(vec![AccessControlAllowOrigin::Null]))
+		.threads(3)
 		.start_http(&"127.0.0.1:3030".parse().unwrap())
-		.expect("Unable to start RPC server");
+		.unwrap();
 
 	server.wait();
 }


### PR DESCRIPTION
Resolves #596

This grabs the example server implementation from [the root README](https://github.com/paritytech/jsonrpc#basic-usage-with-http-transport), as the given example ([rendered in docs.rs](https://paritytech.github.io/jsonrpc/jsonrpc_http_server/index.html)) currently fails with the following:

```
error[E0277]: `Result<jsonrpc_http_server::jsonrpc_core::Value, _>` is not a future
 --> src/main.rs:6:5
  |
6 |     io.add_method("say_hello", |_| {
  |        ^^^^^^^^^^ `Result<jsonrpc_http_server::jsonrpc_core::Value, _>` is not a future
  |
  = help: the trait `std::future::Future` is not implemented for `Result<jsonrpc_http_server::jsonrpc_core::Value, _>`
  = note: required because of the requirements on the impl of `RpcMethodSimple` for `[closure@src/main.rs:6:29: 8:3]`
```