### PR TITLE
Omit params field from requests instead of sending null value

### DIFF
--- a/core/src/types/params.rs
+++ b/core/src/types/params.rs
@@ -39,7 +39,6 @@ impl Params {
 
 	/// Check for None
 	pub fn is_none(&self) -> bool {
-		log::debug!("is_none called on {:?}", self);
 		matches!(*self, Params::None)
 	}
 }

--- a/core/src/types/params.rs
+++ b/core/src/types/params.rs
@@ -36,6 +36,12 @@ impl Params {
 			p => Err(Error::invalid_params_with_details("No parameters were expected", p)),
 		}
 	}
+
+	/// Check for None
+	pub fn is_none(&self) -> bool {
+		log::debug!("is_none called on {:?}", self);
+		matches!(*self, Params::None)
+	}
 }
 
 impl From<Params> for Value {

--- a/core/src/types/request.rs
+++ b/core/src/types/request.rs
@@ -12,7 +12,7 @@ pub struct MethodCall {
 	pub method: String,
 	/// A Structured value that holds the parameter values to be used
 	/// during the invocation of the method. This member MAY be omitted.
-	#[serde(default = "default_params")]
+	#[serde(default = "default_params", skip_serializing_if = "Params::is_none")]
 	pub params: Params,
 	/// An identifier established by the Client that MUST contain a String,
 	/// Number, or NULL value if included. If it is not included it is assumed


### PR DESCRIPTION
Based on the [specification](https://www.jsonrpc.org/specification#parameter_structures), the request's params must be an array or an object if it exists, so sending a null value is not valid. Actually, it causes errors for KODI JSONRPC server, that's why I tried to find a way to fix it.

The solution is very simple, just I haven't updated the comments for the params field.