### PR TITLE
Limit the maximum WebSocket fragments capacity

### DIFF
--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -16,7 +16,7 @@ jsonrpc-server-utils = { version = "18.0.0", path = "../server-utils" }
 log = "0.4"
 parking_lot = "0.11.0"
 slab = "0.4"
-parity-ws = "0.11"
+parity-ws = "0.11.1"
 
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/ws/src/server.rs
+++ b/ws/src/server.rs
@@ -70,6 +70,7 @@ impl Server {
 			config.max_connections = max_connections;
 			// don't accept super large requests
 			config.max_fragment_size = max_payload_bytes;
+			config.max_total_fragments_size = max_payload_bytes;
 			config.in_buffer_capacity_hard_limit = max_in_buffer_capacity;
 			config.out_buffer_capacity_hard_limit = max_out_buffer_capacity;
 			// don't grow non-final fragments (to prevent DOS)

--- a/ws/src/server.rs
+++ b/ws/src/server.rs
@@ -75,6 +75,10 @@ impl Server {
 			// don't grow non-final fragments (to prevent DOS)
 			config.fragments_grow = false;
 			config.fragments_capacity = cmp::max(1, max_payload_bytes / config.fragment_size);
+			if config.fragments_capacity > 4096 {
+				config.fragments_capacity = 4096;
+				config.fragments_grow = true;
+			}
 			// accept only handshakes beginning with GET
 			config.method_strict = true;
 			// require masking


### PR DESCRIPTION
Fixes https://github.com/paritytech/jsonrpc/issues/643

If `max_payload_bytes` is very big this also sets the `fragments_capacity` to a very big number, and the `parity-ws` crates uses `fragments_capacity` to preallocate a `VecDeque` on each connection, which then fails.

So here we add a reasonable-ish limit so that the `fragments_capacity` isn't *too big*. Considering the `config.fragment_size`'s default value is 64k we'd need a `max_payload_bytes` of 256MB to reach it, which should be plenty. (Most likely no one should set it this high anyway due to the possibility of leaving the server open to a denial of service attack.)