### PR TITLE
move to rust 2021, macro tweak to compile

### DIFF
--- a/core-client/Cargo.toml
+++ b/core-client/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
+name = "jsonrpc-core-client"
+version = "18.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Transport agnostic JSON-RPC 2.0 client implementation."
 documentation = "https://docs.rs/jsonrpc-core-client/"
-edition = "2018"
 homepage = "https://github.com/paritytech/jsonrpc"
 keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
-name = "jsonrpc-core-client"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "18.0.0"
+edition = "2021"
+rust-version = "1.56.1"
 
 categories = [
 	"asynchronous",

--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
+name = "jsonrpc-client-transports"
+version = "18.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Transport agnostic JSON-RPC 2.0 client implementation."
 documentation = "https://docs.rs/jsonrpc-client-transports/"
-edition = "2018"
 homepage = "https://github.com/paritytech/jsonrpc"
 keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
-name = "jsonrpc-client-transports"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "18.0.0"
+edition = "2021"
+rust-version = "1.56.1"
 
 categories = [
 	"asynchronous",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
+name = "jsonrpc-core"
+version = "18.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Transport agnostic rust implementation of JSON-RPC 2.0 Specification."
 documentation = "https://docs.rs/jsonrpc-core/"
-edition = "2018"
 homepage = "https://github.com/paritytech/jsonrpc"
 keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
-name = "jsonrpc-core"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "18.0.0"
+edition = "2021"
+rust-version = "1.56.1"
 
 categories = [
 	"asynchronous",

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
+name = "jsonrpc-derive"
+version = "18.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 documentation = "https://docs.rs/jsonrpc-derive/"
 description = "High level, typed wrapper for `jsonrpc-core`"
-edition = "2018"
 homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
-name = "jsonrpc-derive"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "18.0.0"
+edition = "2021"
+rust-version = "1.56.1"
 
 [lib]
 proc-macro = true

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -58,12 +58,12 @@ pub fn generate_client_module(
 
 			/// The Client.
 			#[derive(Clone)]
-			pub struct Client#generics {
+			pub struct Client #generics {
 				inner: TypedClient,
 				#(#markers_decl),*
 			}
 
-			impl#generics Client#generics
+			impl #generics Client #generics
 			where
 				#(#where_clause),*
 			{
@@ -78,7 +78,7 @@ pub fn generate_client_module(
 				#(#client_methods)*
 			}
 
-			impl#generics From<RpcChannel> for Client#generics
+			impl #generics From<RpcChannel> for Client #generics
 			where
 				#(#where_clause2),*
 			{

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
+name = "jsonrpc-http-server"
+version = "18.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Rust http server using JSONRPC 2.0."
 documentation = "https://docs.rs/jsonrpc-http-server/"
-edition = "2018"
 homepage = "https://github.com/paritytech/jsonrpc"
 keywords = ["jsonrpc", "json-rpc", "json", "rpc", "server"]
 license = "MIT"
-name = "jsonrpc-http-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "18.0.0"
+edition = "2021"
+rust-version = "1.56.1"
 
 [dependencies]
 futures = "0.3"

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
+name = "jsonrpc-ipc-server"
+version = "18.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "IPC server for JSON-RPC"
 documentation = "https://docs.rs/jsonrpc-ipc-server/"
-edition = "2018"
 homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
-name = "jsonrpc-ipc-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "18.0.0"
+edition = "2021"
+rust-version = "1.56.1"
 
 [dependencies]
 futures = "0.3"

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
+name = "jsonrpc-pubsub"
+version = "18.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Publish-Subscribe extension for jsonrpc."
 documentation = "https://docs.rs/jsonrpc-pubsub/"
-edition = "2018"
 homepage = "https://github.com/paritytech/jsonrpc"
 keywords = ["jsonrpc", "json-rpc", "json", "rpc", "macros"]
 license = "MIT"
-name = "jsonrpc-pubsub"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "18.0.0"
+edition = "2021"
+rust-version = "1.56.1"
 
 [dependencies]
 futures = { version = "0.3", features = ["thread-pool"] }

--- a/server-utils/Cargo.toml
+++ b/server-utils/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
+name = "jsonrpc-server-utils"
+version = "18.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Server utils for jsonrpc-core crate."
 documentation = "https://docs.rs/jsonrpc-server-utils/"
-edition = "2018"
 homepage = "https://github.com/paritytech/jsonrpc"
 keywords = ["jsonrpc", "json-rpc", "json", "rpc", "serde"]
 license = "MIT"
-name = "jsonrpc-server-utils"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "18.0.0"
+edition = "2021"
+rust-version = "1.56.1"
 
 [dependencies]
 bytes = "1.0"

--- a/stdio/Cargo.toml
+++ b/stdio/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
+name = "jsonrpc-stdio-server"
+version = "18.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "STDIN/STDOUT server for JSON-RPC"
 documentation = "https://docs.rs/jsonrpc-stdio-server/"
-edition = "2018"
 homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
-name = "jsonrpc-stdio-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "18.0.0"
+edition = "2021"
+rust-version = "1.56.1"
 
 [dependencies]
 futures = "0.3"

--- a/tcp/Cargo.toml
+++ b/tcp/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
+name = "jsonrpc-tcp-server"
+version = "18.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "TCP/IP server for JSON-RPC"
 documentation = "https://docs.rs/jsonrpc-tcp-server/"
-edition = "2018"
 homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
-name = "jsonrpc-tcp-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "18.0.0"
+edition = "2021"
+rust-version = "1.56.1"
 
 [dependencies]
 jsonrpc-core = { version = "18.0.0", path = "../core" }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "jsonrpc-test"
-description = "Simple test framework for JSON-RPC."
 version = "18.0.0"
+description = "Simple test framework for JSON-RPC."
+documentation = "https://docs.rs/jsonrpc-test/"
 authors = ["Tomasz Drwięga <tomasz@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/jsonrpc"
 repository = "https://github.com/paritytech/jsonrpc"
-documentation = "https://docs.rs/jsonrpc-test/"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56.1"
 
 [dependencies]
 jsonrpc-core = { version = "18.0.0", path = "../core" }

--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
+name = "jsonrpc-ws-server"
+version = "18.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "WebSockets server for JSON-RPC"
 documentation = "https://docs.rs/jsonrpc-ws-server/"
-edition = "2018"
 homepage = "https://github.com/paritytech/jsonrpc"
 license = "MIT"
-name = "jsonrpc-ws-server"
 repository = "https://github.com/paritytech/jsonrpc"
-version = "18.0.0"
+edition = "2021"
+rust-version = "1.56.1"
 
 [dependencies]
 futures = "0.3"


### PR DESCRIPTION
Confirmed to build **and pass tests** locally on Ubuntu 20.04.3 LTS:
```
rustc 1.56.1 (59eed8a2a 2021-11-01)
rustc 1.58.0-nightly (e90c5fbbc 2021-11-12)
```