### PR TITLE
Do not pull in url-1.0 unless websocket is enabled

### DIFF
--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -48,7 +48,7 @@ hyper-tls = { version = "0.5", optional = true }
 jsonrpc-server-utils = { version = "18.0.0", path = "../../server-utils", optional = true }
 parity-tokio-ipc = { version = "0.9", optional = true }
 tokio = { version = "1", optional = true }
-websocket = { version = "0.24", optional = true }
+websocket = { version = "0.26", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.1"

--- a/core-client/transports/Cargo.toml
+++ b/core-client/transports/Cargo.toml
@@ -42,7 +42,6 @@ jsonrpc-pubsub = { version = "18.0.0", path = "../../pubsub" }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-url = "1.7"
 
 hyper = { version = "0.14", features = ["client", "http1", "tcp"], optional = true }
 hyper-tls = { version = "0.5", optional = true }

--- a/core-client/transports/src/transports/ws.rs
+++ b/core-client/transports/src/transports/ws.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use crate::{RpcChannel, RpcError};
-use websocket::{ClientBuilder, OwnedMessage};
+use websocket::{url, ClientBuilder, OwnedMessage};
 
 /// Connect to a JSON-RPC websocket server.
 ///


### PR DESCRIPTION
This takes advantage of rust-websocket re-exporting the `url` crate, making this easy.