### PR TITLE
Remove returns strings

### DIFF
--- a/core-client/transports/src/lib.rs
+++ b/core-client/transports/src/lib.rs
@@ -289,7 +289,8 @@ impl TypedClient {
 
 			log::debug!("response: {:?}", value);
 
-			serde_json::from_value::<R>(value).map_err(|error| RpcError::ParseError(type_name::<R>().into(), Box::new(error)))
+			serde_json::from_value::<R>(value)
+				.map_err(|error| RpcError::ParseError(type_name::<R>().into(), Box::new(error)))
 		}
 	}
 
@@ -452,8 +453,7 @@ mod tests {
 		let received = Arc::new(std::sync::Mutex::new(vec![]));
 		let r2 = received.clone();
 		let fut = async move {
-			let mut stream =
-				client.subscribe::<_, (u32,)>("subscribe_hello", (), "hello", "unsubscribe_hello")?;
+			let mut stream = client.subscribe::<_, (u32,)>("subscribe_hello", (), "hello", "unsubscribe_hello")?;
 			let result = stream.next().await;
 			r2.lock().unwrap().push(result.expect("Expected at least one item."));
 			tx.send(()).unwrap();

--- a/core-client/transports/src/lib.rs
+++ b/core-client/transports/src/lib.rs
@@ -12,6 +12,7 @@ use jsonrpc_core::{Error, Params};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::Value;
+use std::any::type_name;
 use std::marker::PhantomData;
 use std::pin::Pin;
 
@@ -269,10 +270,8 @@ impl TypedClient {
 	pub fn call_method<T: Serialize, R: DeserializeOwned>(
 		&self,
 		method: &str,
-		returns: &str,
 		args: T,
 	) -> impl Future<Output = RpcResult<R>> {
-		let returns = returns.to_owned();
 		let args =
 			serde_json::to_value(args).expect("Only types with infallible serialisation can be used for JSON-RPC");
 		let params = match args {
@@ -290,7 +289,7 @@ impl TypedClient {
 
 			log::debug!("response: {:?}", value);
 
-			serde_json::from_value::<R>(value).map_err(|error| RpcError::ParseError(returns, Box::new(error)))
+			serde_json::from_value::<R>(value).map_err(|error| RpcError::ParseError(type_name::<R>().into(), Box::new(error)))
 		}
 	}
 
@@ -318,7 +317,6 @@ impl TypedClient {
 		subscribe_params: T,
 		topic: &str,
 		unsubscribe: &str,
-		returns: &'static str,
 	) -> RpcResult<TypedSubscriptionStream<R>> {
 		let args = serde_json::to_value(subscribe_params)
 			.expect("Only types with infallible serialisation can be used for JSON-RPC");
@@ -335,7 +333,7 @@ impl TypedClient {
 
 		self.0
 			.subscribe(subscribe, params, topic, unsubscribe)
-			.map(move |stream| TypedSubscriptionStream::new(stream, returns))
+			.map(move |stream| TypedSubscriptionStream::new(stream, type_name::<R>()))
 	}
 }
 
@@ -361,7 +359,7 @@ mod tests {
 
 	impl AddClient {
 		fn add(&self, a: u64, b: u64) -> impl Future<Output = RpcResult<u64>> {
-			self.0.call_method("add", "u64", (a, b))
+			self.0.call_method("add", (a, b))
 		}
 
 		fn completed(&self, success: bool) -> RpcResult<()> {
@@ -455,7 +453,7 @@ mod tests {
 		let r2 = received.clone();
 		let fut = async move {
 			let mut stream =
-				client.subscribe::<_, (u32,)>("subscribe_hello", (), "hello", "unsubscribe_hello", "u32")?;
+				client.subscribe::<_, (u32,)>("subscribe_hello", (), "hello", "unsubscribe_hello")?;
 			let result = stream.next().await;
 			r2.lock().unwrap().push(result.expect("Expected at least one item."));
 			tx.send(()).unwrap();

--- a/core-client/transports/src/transports/http.rs
+++ b/core-client/transports/src/transports/http.rs
@@ -164,10 +164,10 @@ mod tests {
 
 	impl TestClient {
 		fn hello(&self, msg: &'static str) -> impl Future<Output = RpcResult<String>> {
-			self.0.call_method("hello", "String", (msg,))
+			self.0.call_method("hello", (msg,))
 		}
 		fn fail(&self) -> impl Future<Output = RpcResult<()>> {
-			self.0.call_method("fail", "()", ())
+			self.0.call_method("fail", ())
 		}
 		fn notify(&self, value: u64) -> RpcResult<()> {
 			self.0.notify("notify", (value,))

--- a/derive/src/to_client.rs
+++ b/derive/src/to_client.rs
@@ -106,7 +106,6 @@ fn generate_client_methods(methods: &[MethodRegistration], options: &DeriveOptio
 					AttributeKind::Rpc { returns, .. } => compute_returns(&method.trait_item, returns)?,
 					AttributeKind::PubSub { .. } => continue,
 				};
-				let returns_str = quote!(#returns).to_string();
 
 				let args_serialized = match method
 					.attr
@@ -134,7 +133,7 @@ fn generate_client_methods(methods: &[MethodRegistration], options: &DeriveOptio
 					#(#attrs)*
 					pub fn #name(&self, #args) -> impl Future<Output = RpcResult<#returns>> {
 						let args = #args_serialized;
-						self.inner.call_method(#rpc_name, #returns_str, args)
+						self.inner.call_method(#rpc_name, args)
 					}
 				};
 				client_methods.push(client_method);
@@ -149,7 +148,6 @@ fn generate_client_methods(methods: &[MethodRegistration], options: &DeriveOptio
 					let name = &subscribe.trait_item.sig.ident;
 					let mut args = compute_args(&subscribe.trait_item).into_iter();
 					let returns = compute_subscription_type(&args.next().unwrap());
-					let returns_str = quote!(#returns).to_string();
 					let args = args.collect();
 					let arg_names = compute_arg_identifiers(&args)?;
 					let subscribe = subscribe.name();
@@ -158,7 +156,7 @@ fn generate_client_methods(methods: &[MethodRegistration], options: &DeriveOptio
 						#(#attrs)*
 						pub fn #name(&self, #args) -> RpcResult<TypedSubscriptionStream<#returns>> {
 							let args_tuple = (#(#arg_names,)*);
-							self.inner.subscribe(#subscribe, args_tuple, #subscription, #unsubscribe, #returns_str)
+							self.inner.subscribe(#subscribe, args_tuple, #subscription, #unsubscribe)
 						}
 					);
 					client_methods.push(client_method);


### PR DESCRIPTION
Removes parameters that are not necessary.
Disadvantages:

- The `type_name` method does not currently have stable `const`.
- The value returned by `type_name` is not necessarily the shortest string, for example `type_name::<Option<String>>()` may return `Option<String>` or `std::option::Option<std::string::String>`.
- Also the returned value will vary with different versions of the compiler.

Advantages:

- Reduces unnecessary parameter input, which when calling a method will make the caller believe that the `return` value specified within the parameter has some relationship to the output `return` value, when in fact the `return` value entered within the parameter is only useful as a diagnostic for error output. The documentation of `type_name` within std, on the other hand, is meant to be used for code diagnostic purposes.
- The interface to call would be more clean.