### PR TITLE
Fix core examples so they don't panic

### DIFF
--- a/core/examples/async.rs
+++ b/core/examples/async.rs
@@ -9,7 +9,7 @@ fn main() {
 		});
 
 		let request = r#"{"jsonrpc": "2.0", "method": "say_hello", "params": [42, 23], "id": 1}"#;
-		let response = r#"{"jsonrpc":"2.0","result":"hello","id":1}"#;
+		let response = r#"{"jsonrpc":"2.0","result":"Hello World!","id":1}"#;
 
 		assert_eq!(io.handle_request(request).await, Some(response.to_owned()));
 	});

--- a/core/examples/basic.rs
+++ b/core/examples/basic.rs
@@ -6,7 +6,7 @@ fn main() {
 	io.add_sync_method("say_hello", |_: Params| Ok(Value::String("Hello World!".to_owned())));
 
 	let request = r#"{"jsonrpc": "2.0", "method": "say_hello", "params": [42, 23], "id": 1}"#;
-	let response = r#"{"jsonrpc":"2.0","result":"hello","id":1}"#;
+	let response = r#"{"jsonrpc":"2.0","result":"Hello World!","id":1}"#;
 
 	assert_eq!(io.handle_request_sync(request), Some(response.to_owned()));
 }


### PR DESCRIPTION
The `basic` and `async` examples did not correctly encode the expected response. Now they do!