### PR TITLE
Implement named params for pubsub subscribe client

### DIFF
--- a/core-client/transports/src/lib.rs
+++ b/core-client/transports/src/lib.rs
@@ -301,9 +301,10 @@ impl TypedClient {
 		let params = match args {
 			Value::Array(vec) => Params::Array(vec),
 			Value::Null => Params::None,
+			Value::Object(map) => Params::Map(map),
 			_ => {
 				return Err(RpcError::Client(
-					"RPC params should serialize to a JSON array, or null".into(),
+					"RPC params should serialize to a JSON array, JSON object or null".into(),
 				))
 			}
 		};
@@ -326,9 +327,10 @@ impl TypedClient {
 		let params = match args {
 			Value::Array(vec) => Params::Array(vec),
 			Value::Null => Params::None,
+			Value::Object(map) => Params::Map(map),
 			_ => {
 				return Err(RpcError::Client(
-					"RPC params should serialize to a JSON array, or null".into(),
+					"RPC params should serialize to a JSON array, JSON object or null".into(),
 				))
 			}
 		};

--- a/derive/src/rpc_attr.rs
+++ b/derive/src/rpc_attr.rs
@@ -201,7 +201,11 @@ fn validate_attribute_meta(meta: syn::Meta) -> Result<syn::Meta> {
 				&visitor.meta_words,
 				&[SUBSCRIBE_META_WORD, UNSUBSCRIBE_META_WORD, RAW_PARAMS_META_WORD],
 			)?;
-			validate_idents(&meta, &visitor.name_value_names, &[SUBSCRIPTION_NAME_KEY, RPC_NAME_KEY])?;
+			validate_idents(
+				&meta,
+				&visitor.name_value_names,
+				&[SUBSCRIPTION_NAME_KEY, RPC_NAME_KEY, PARAMS_STYLE_KEY],
+			)?;
 			validate_idents(&meta, &visitor.meta_list_names, &[ALIASES_KEY])
 		}
 		_ => Ok(meta), // ignore other attributes - compiler will catch unknown ones


### PR DESCRIPTION
The library currently supports the `params = "named"` derive attribute for rpc methods. But it doesn't support it for `pubsub` subscribe methods.
This PR adds `params` to the allowed attributes for `pubsub` and adds the params generation code to send out named and raw params, in the same way as it was already implemented for normal rpc methods.

The following code will work with this PR:
```rust
#[rpc(client)]
pub trait Rpc {
    #[pubsub(
        subscription = "receive",
        subscribe,
        name = "subscribeReceive",
        params = "named"
    )]
    fn subscribe_receive(&self, _: Self::Metadata, _: Subscriber<Value>, some_param: Option<String>);

    /// Unsubscribe from hello subscription.
    #[pubsub(subscription = "receive", unsubscribe, name = "unsubscribeReceive")]
    fn unsubscribe_receive(&self, _: Option<Self::Metadata>, _: SubscriptionId) -> Result<bool>;
}
```
and will send out this JSON-RPC message: 
```json
{"jsonrpc":"2.0","method":"subscribeReceive","params":{"some_param":"value"},"id":0}
```