### PR TITLE
feat(Metadata): Add request resource (path) to context so it can be used in Metadata

### DIFF
--- a/ws/src/metadata.rs
+++ b/ws/src/metadata.rs
@@ -70,6 +70,8 @@ pub struct RequestContext {
 	pub session_id: session::SessionId,
 	/// Request Origin
 	pub origin: Option<Origin>,
+	/// Requested resource
+	pub resource: Option<String>,
 	/// Requested protocols
 	pub protocols: Vec<String>,
 	/// Direct channel to send messages to a client.

--- a/ws/src/session.rs
+++ b/ws/src/session.rs
@@ -235,7 +235,7 @@ where
 				return Ok(response);
 			}
 		}
-
+		self.context.resource = Some(String::from(req.resource()));
 		self.context.origin = origin
 			.and_then(|origin| ::std::str::from_utf8(origin).ok())
 			.map(Into::into);
@@ -351,6 +351,7 @@ where
 			context: metadata::RequestContext {
 				session_id: self.session_id,
 				origin: None,
+				resource: None,
 				protocols: Vec::new(),
 				out: metadata::Sender::new(sender, active),
 				executor: self.executor.clone(),


### PR DESCRIPTION
I would like my clients to pass a query parameter "token" in the websocket connect url as an identifier of the client, then use this token in my io middleware and in my rpc methods to tailor the response based on client.
I could not find anyway to link the context to a request to get this information. I tried session_id, but could not find a way to map that to request as well.
Please let me know if there is already an existing way to get the uri/resource/query parameters in the metadata extractor.