### PR TITLE
add nonstrict feature to jsonrpc-core

### DIFF
--- a/core-client/transports/src/transports/http.rs
+++ b/core-client/transports/src/transports/http.rs
@@ -249,10 +249,7 @@ mod tests {
 		if let Err(RpcError::JsonRpcError(err)) = res {
 			assert_eq!(
 				err,
-				Error::new_with_message(
-					ErrorCode::ServerError(-34),
-					"Server error"
-				)
+				Error::new_with_message(ErrorCode::ServerError(-34), "Server error")
 			)
 		} else {
 			panic!("Expected JsonRpcError. Received {:?}", res)

--- a/core-client/transports/src/transports/http.rs
+++ b/core-client/transports/src/transports/http.rs
@@ -249,11 +249,10 @@ mod tests {
 		if let Err(RpcError::JsonRpcError(err)) = res {
 			assert_eq!(
 				err,
-				Error {
-					code: ErrorCode::ServerError(-34),
-					message: "Server error".into(),
-					data: None
-				}
+				Error::new_with_message(
+					ErrorCode::ServerError(-34),
+					"Server error"
+				)
 			)
 		} else {
 			panic!("Expected JsonRpcError. Received {:?}", res)

--- a/core-client/transports/src/transports/mod.rs
+++ b/core-client/transports/src/transports/mod.rs
@@ -166,7 +166,7 @@ impl From<ClientResponse> for Result<Value, Error> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use jsonrpc_core::{Failure, Notification, Output, Params, Success, Value, Version};
+	use jsonrpc_core::{Notification, Output, Params, Value, Version};
 
 	#[test]
 	fn notification_deserialize() {
@@ -190,11 +190,7 @@ mod tests {
 		let deserialized: ClientResponse = jsonrpc_core::serde_from_str(dsr).unwrap();
 		assert_eq!(
 			deserialized,
-			ClientResponse::Output(Output::Success(Success {
-				jsonrpc: Some(Version::V2),
-				id: Id::Num(1),
-				result: 1.into(),
-			}))
+			ClientResponse::Output(Output::success(Value::from(1), Id::Num(1), Some(Version::V2)))
 		);
 	}
 
@@ -205,11 +201,7 @@ mod tests {
 		let deserialized: ClientResponse = jsonrpc_core::serde_from_str(dfo).unwrap();
 		assert_eq!(
 			deserialized,
-			ClientResponse::Output(Output::Failure(Failure {
-				jsonrpc: Some(Version::V2),
-				error: Error::parse_error(),
-				id: Id::Num(1)
-			}))
+			ClientResponse::Output(Output::failure(Error::parse_error(), Id::Num(1), Some(Version::V2)))
 		);
 	}
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,6 +33,7 @@ serde_derive = "1.0"
 [features]
 default = ["futures-executor", "futures"]
 arbitrary_precision = ["serde_json/arbitrary_precision"]
+nonstrict = []
 
 [badges]
 travis-ci = { repository = "paritytech/jsonrpc", branch = "master"}

--- a/core/src/types/response.rs
+++ b/core/src/types/response.rs
@@ -318,17 +318,23 @@ fn handle_incorrect_responses() {
 	);
 
 	#[cfg(feature = "nonstrict")]
-	assert_eq!(deserialized.unwrap(), Response::Single(Output::Failure(Failure {
-		error: Error {
-			code: ErrorCode::ServerError(-32000),
-			message: "VM Exception while processing transaction: revert".to_string(),
-			data: Some(serde_json::from_str("{}").unwrap()),
-			other: HashMap::new(),
-		},
-		jsonrpc: Some(Version::V2),
-		id: Id::Num(2),
-		other: serde_json::from_str("{\"result\": \"0x62d3776be72cc7fa62cad6fe8ed873d9bc7ca2ee576e400d987419a3f21079d5\"}").unwrap(),
-	})));
+	assert_eq!(
+		deserialized.unwrap(),
+		Response::Single(Output::Failure(Failure {
+			error: Error {
+				code: ErrorCode::ServerError(-32000),
+				message: "VM Exception while processing transaction: revert".to_string(),
+				data: Some(serde_json::from_str("{}").unwrap()),
+				other: HashMap::new(),
+			},
+			jsonrpc: Some(Version::V2),
+			id: Id::Num(2),
+			other: serde_json::from_str(
+				"{\"result\": \"0x62d3776be72cc7fa62cad6fe8ed873d9bc7ca2ee576e400d987419a3f21079d5\"}"
+			)
+			.unwrap(),
+		}))
+	);
 }
 
 #[test]

--- a/core/src/types/response.rs
+++ b/core/src/types/response.rs
@@ -323,6 +323,7 @@ fn handle_incorrect_responses() {
 			code: ErrorCode::ServerError(-32000),
 			message: "VM Exception while processing transaction: revert".to_string(),
 			data: Some(serde_json::from_str("{}").unwrap()),
+			other: HashMap::new(),
 		},
 		jsonrpc: Some(Version::V2),
 		id: Id::Num(2),

--- a/derive/examples/pubsub-macros.rs
+++ b/derive/examples/pubsub-macros.rs
@@ -33,7 +33,7 @@ impl Rpc for RpcImpl {
 			subscriber
 				.reject(Error::new_with_message(
 					ErrorCode::InvalidParams,
-					"Rejecting subscription - invalid parameters provided."
+					"Rejecting subscription - invalid parameters provided.",
 				))
 				.unwrap();
 			return;
@@ -52,7 +52,7 @@ impl Rpc for RpcImpl {
 		} else {
 			Err(Error::new_with_message(
 				ErrorCode::InvalidParams,
-				"Invalid subscription."
+				"Invalid subscription.",
 			))
 		}
 	}

--- a/derive/examples/pubsub-macros.rs
+++ b/derive/examples/pubsub-macros.rs
@@ -31,11 +31,10 @@ impl Rpc for RpcImpl {
 	fn subscribe(&self, _meta: Self::Metadata, subscriber: typed::Subscriber<String>, param: u64) {
 		if param != 10 {
 			subscriber
-				.reject(Error {
-					code: ErrorCode::InvalidParams,
-					message: "Rejecting subscription - invalid parameters provided.".into(),
-					data: None,
-				})
+				.reject(Error::new_with_message(
+					ErrorCode::InvalidParams,
+					"Rejecting subscription - invalid parameters provided."
+				))
 				.unwrap();
 			return;
 		}
@@ -51,11 +50,10 @@ impl Rpc for RpcImpl {
 		if removed.is_some() {
 			Ok(true)
 		} else {
-			Err(Error {
-				code: ErrorCode::InvalidParams,
-				message: "Invalid subscription.".into(),
-				data: None,
-			})
+			Err(Error::new_with_message(
+				ErrorCode::InvalidParams,
+				"Invalid subscription."
+			))
 		}
 	}
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -91,11 +91,10 @@
 //!
 //!     fn subscribe(&self, _meta: Self::Metadata, subscriber: Subscriber<String>, param: u64) {
 //!         if param != 10 {
-//!             subscriber.reject(Error {
-//!                  code: ErrorCode::InvalidParams,
-//!                  message: "Rejecting subscription - invalid parameters provided.".into(),
-//!                  data: None,
-//!             }).unwrap();
+//!             subscriber.reject(Error::new_with_message(
+//!                  ErrorCode::InvalidParams,
+//!                  "Rejecting subscription - invalid parameters provided.",
+//!             )).unwrap();
 //!             return;
 //!         }
 //!
@@ -106,15 +105,14 @@
 //!     }
 //!
 //!     fn unsubscribe(&self, _meta: Option<Self::Metadata>, id: SubscriptionId) -> Result<bool> {
-//!          let removed = self.active.write().unwrap().remove(&id);
-//!          if removed.is_some() {
-//!              Ok(true)
-//!          } else {
-//!              Err(Error {
-//!                  code: ErrorCode::InvalidParams,
-//!                  message: "Invalid subscription.".into(),
-//!                  data: None,
-//!          })
+//!         let removed = self.active.write().unwrap().remove(&id);
+//!         if removed.is_some() {
+//!             Ok(true)
+//!         } else {
+//!             Err(Error::new_with_message(
+//!                 ErrorCode::InvalidParams,
+//!                 "Invalid subscription.",
+//!             ))
 //!         }
 //!     }
 //! }

--- a/pubsub/examples/pubsub.rs
+++ b/pubsub/examples/pubsub.rs
@@ -23,11 +23,10 @@ fn main() {
 		("subscribe_hello", move |params: Params, _, subscriber: Subscriber| {
 			if params != Params::None {
 				subscriber
-					.reject(Error {
-						code: ErrorCode::ParseError,
-						message: "Invalid parameters. Subscription rejected.".into(),
-						data: None,
-					})
+					.reject(Error::new_with_message(
+						ErrorCode::ParseError,
+						"Invalid parameters. Subscription rejected.",
+					))
 					.unwrap();
 				return;
 			}

--- a/pubsub/examples/pubsub_simple.rs
+++ b/pubsub/examples/pubsub_simple.rs
@@ -23,11 +23,10 @@ fn main() {
 		("subscribe_hello", |params: Params, _, subscriber: Subscriber| {
 			if params != Params::None {
 				subscriber
-					.reject(Error {
-						code: ErrorCode::ParseError,
-						message: "Invalid parameters. Subscription rejected.".into(),
-						data: None,
-					})
+					.reject(Error::new_with_message(
+						ErrorCode::ParseError,
+						"Invalid parameters. Subscription rejected.",
+					))
 					.unwrap();
 				return;
 			}

--- a/pubsub/more-examples/examples/pubsub_ipc.rs
+++ b/pubsub/more-examples/examples/pubsub_ipc.rs
@@ -25,11 +25,10 @@ fn main() {
 		("subscribe_hello", |params: Params, _, subscriber: Subscriber| {
 			if params != Params::None {
 				subscriber
-					.reject(Error {
-						code: ErrorCode::ParseError,
-						message: "Invalid parameters. Subscription rejected.".into(),
-						data: None,
-					})
+					.reject(Error::new_with_message(
+						ErrorCode::ParseError,
+						"Invalid parameters. Subscription rejected.",
+					))
 					.unwrap();
 				return;
 			}

--- a/pubsub/more-examples/examples/pubsub_ws.rs
+++ b/pubsub/more-examples/examples/pubsub_ws.rs
@@ -43,7 +43,7 @@ fn main() {
 				subscriber
 					.reject(Error::new_with_message(
 						ErrorCode::ParseError,
-						"Invalid parameters. Subscription rejected."
+						"Invalid parameters. Subscription rejected.",
 					))
 					.unwrap();
 				return;

--- a/pubsub/more-examples/examples/pubsub_ws.rs
+++ b/pubsub/more-examples/examples/pubsub_ws.rs
@@ -41,11 +41,10 @@ fn main() {
 		("subscribe_hello", |params: Params, _, subscriber: Subscriber| {
 			if params != Params::None {
 				subscriber
-					.reject(Error {
-						code: ErrorCode::ParseError,
-						message: "Invalid parameters. Subscription rejected.".into(),
-						data: None,
-					})
+					.reject(Error::new_with_message(
+						ErrorCode::ParseError,
+						"Invalid parameters. Subscription rejected."
+					))
 					.unwrap();
 				return;
 			}

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -253,10 +253,7 @@ where
 }
 
 fn subscription_rejected() -> core::Error {
-	core::Error::new_with_message(
-		core::ErrorCode::ServerError(-32091),
-		"Subscription rejected",
-	)
+	core::Error::new_with_message(core::ErrorCode::ServerError(-32091), "Subscription rejected")
 }
 
 fn subscriptions_unavailable() -> core::Error {
@@ -496,10 +493,7 @@ mod tests {
 			transport,
 			sender: tx,
 		};
-		let error = core::Error::new_with_message(
-			core::ErrorCode::InvalidRequest,
-			"Cannot start subscription now.",
-		);
+		let error = core::Error::new_with_message(core::ErrorCode::InvalidRequest, "Cannot start subscription now.");
 
 		// when
 		let reject = subscriber.reject_async(error.clone());

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -253,19 +253,17 @@ where
 }
 
 fn subscription_rejected() -> core::Error {
-	core::Error {
-		code: core::ErrorCode::ServerError(-32091),
-		message: "Subscription rejected".into(),
-		data: None,
-	}
+	core::Error::new_with_message(
+		core::ErrorCode::ServerError(-32091),
+		"Subscription rejected",
+	)
 }
 
 fn subscriptions_unavailable() -> core::Error {
-	core::Error {
-		code: core::ErrorCode::ServerError(-32090),
-		message: "Subscriptions are not available on this transport.".into(),
-		data: None,
-	}
+	core::Error::new_with_message(
+		core::ErrorCode::ServerError(-32090),
+		"Subscriptions are not available on this transport.",
+	)
 }
 
 /// Subscribe RPC implementation.
@@ -498,11 +496,10 @@ mod tests {
 			transport,
 			sender: tx,
 		};
-		let error = core::Error {
-			code: core::ErrorCode::InvalidRequest,
-			message: "Cannot start subscription now.".into(),
-			data: None,
-		};
+		let error = core::Error::new_with_message(
+			core::ErrorCode::InvalidRequest,
+			"Cannot start subscription now.",
+		);
 
 		// when
 		let reject = subscriber.reject_async(error.clone());
@@ -591,11 +588,10 @@ mod tests {
 		// then
 		assert_eq!(
 			futures::executor::block_on(result),
-			Err(core::Error {
-				code: core::ErrorCode::InvalidParams,
-				message: "Invalid subscription id.".into(),
-				data: None,
-			})
+			Err(core::Error::new_with_message(
+				core::ErrorCode::InvalidParams,
+				"Invalid subscription id.",
+			))
 		);
 	}
 }


### PR DESCRIPTION
With nonstrict, we do not deny any unknown field, instead we collect them into `other` field.
This maybe fixes #595 