### PR TITLE
Fine-tune the Ordering for the atomic usages

### DIFF
--- a/ws/src/metadata.rs
+++ b/ws/src/metadata.rs
@@ -26,7 +26,7 @@ impl Sender {
 	}
 
 	fn check_active(&self) -> error::Result<()> {
-		if self.active.load(atomic::Ordering::SeqCst) {
+		if self.active.load(atomic::Ordering::Relaxed) {
 			Ok(())
 		} else {
 			Err(error::Error::ConnectionClosed)


### PR DESCRIPTION
`SeqCst` is overly restrictive. I believe that the ordering can be appropriately modified.
I think that `active` is merely signal for multithreading purposes and do not synchronize with other locals. Therefore, using `Relaxed` ordering should suffice.
https://github.com/paritytech/jsonrpc/blob/dc9550b4b0d8bf409d025eba7e9b229b67af9401/ws/src/metadata.rs#L29
https://github.com/paritytech/jsonrpc/blob/dc9550b4b0d8bf409d025eba7e9b229b67af9401/ws/src/session.rs#L166
https://github.com/paritytech/jsonrpc/blob/dc9550b4b0d8bf409d025eba7e9b229b67af9401/ws/src/session.rs#L277-L291
