### PR TITLE
Address compilation warnings.

### DIFF
--- a/ipc/src/select_with_weak.rs
+++ b/ipc/src/select_with_weak.rs
@@ -60,7 +60,7 @@ where
 	type Item = S1::Item;
 
 	fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-		let mut this = Pin::into_inner(self);
+		let this = Pin::into_inner(self);
 		let mut checked_strong = false;
 		loop {
 			if this.use_strong {

--- a/server-utils/src/reactor.rs
+++ b/server-utils/src/reactor.rs
@@ -75,7 +75,7 @@ impl Executor {
 /// A handle to running event loop. Dropping the handle will cause event loop to finish.
 #[derive(Debug)]
 pub struct RpcEventLoop {
-	executor: TaskExecutor,
+	_executor: TaskExecutor,
 	close: Option<futures::channel::oneshot::Sender<()>>,
 	runtime: Option<runtime::Runtime>,
 }
@@ -112,7 +112,7 @@ impl RpcEventLoop {
 		});
 
 		Ok(RpcEventLoop {
-			executor,
+			_executor: executor,
 			close: Some(stop),
 			runtime: Some(runtime),
 		})


### PR DESCRIPTION
The compilation of `jsonrpc` leads to some compilation warnings, something that is not welcome.
That PR addresses it. There are other possibilities of improvement:
* Addressing `warning: the following packages contain code that will be rejected by a future version of Rust: traitobject v0.1.0`.
* Doing clippy on the code.

